### PR TITLE
Issue #570.  Removed the return types for events controller attend an…

### DIFF
--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -1839,9 +1839,6 @@ class EventsController extends Controller
 
     /**
      * Mark user as attending the event.
-     *
-     * @return Response
-     *
      * @throws \Throwable
      */
     public function attend(int $id, Request $request)
@@ -1889,7 +1886,7 @@ class EventsController extends Controller
      *
      * @throws \Throwable
      */
-    public function unattend(int $id, Request $request): RedirectResponse
+    public function unattend(int $id, Request $request)
     {
         // check if there is a logged in user
         if (!$this->user) {


### PR DESCRIPTION
…d unattend, as we cannot yet use mixed type in php 7.4.