### PR TITLE
Issue #725.  Limit weekly email events to 14 days rather than 21 even…

### DIFF
--- a/app/Console/Commands/NotifyWeekly.php
+++ b/app/Console/Commands/NotifyWeekly.php
@@ -59,8 +59,8 @@ class NotifyWeekly extends Command
             $tagEvents = [];
             $attendingIdList = [];
 
-            // get the next x events they are attending
-            $attendingEvents = $user->getAttendingFuture()->take($show_count);
+            // get the events they are attending in the next two weeks
+            $attendingEvents = $user->getAttendingFuture()->where('start_at', '<=', Carbon::now()->addDays(14));
             foreach ($attendingEvents as $event) {
                 $attendingIdList[] = $event->id;
             }
@@ -123,10 +123,10 @@ class NotifyWeekly extends Command
                     ->send(new WeeklyUpdate($url, $site, $admin_email, $reply_email, $user, $attendingEvents, $seriesList, $interests));
 
                 // log that the weekly email was sent
-                Log::info('Weekly update email was sent to ' . $user->name . ' at ' . $user->email . '.');
+                Log::info('Weekly update email was sent to '.$user->name.' at '.$user->email.'.');
             } else {
                 // log that no email was sent
-                Log::info('No weekly update email was sent to ' . $user->name . ' at ' . $user->email . '.');
+                Log::info('No weekly update email was sent to '.$user->name.' at '.$user->email.'.');
             }
         }
     }

--- a/resources/views/emails/weekly-update-markdown.blade.php
+++ b/resources/views/emails/weekly-update-markdown.blade.php
@@ -19,7 +19,7 @@ This is your weekly update on upcoming events related to artists, venues, promot
 @endif
 
 @if (count($seriesList) > 0)
-Here are the event series you follow that happen today.
+Here are the event series you follow that are forthcoming.
 
 ### Summary of series:
 @foreach ($seriesList as $series)


### PR DESCRIPTION
…ts.  Changed the text in the series summary.