### PR TITLE
Fix naming in edit breadcrumbs

### DIFF
--- a/app/Http/Controllers/Api/LocationsController.php
+++ b/app/Http/Controllers/Api/LocationsController.php
@@ -14,6 +14,8 @@ use App\Http\Resources\LocationCollection;
 use App\Http\ResultBuilder\ListEntityResultBuilder;
 use App\Services\SessionStore\ListParameterSessionStore;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Js;
+use Nette\Utils\Json;
 
 class LocationsController extends Controller
 {
@@ -95,9 +97,9 @@ class LocationsController extends Controller
     /**
      * Display the specified resource.
      */
-    public function show(Entity $entity, Location $location): View
+    public function show(Location $location): JsonResponse
     {
-        return view('locations.show', compact('entity', 'location'));
+        return response()->json($location);
     }
 
     /**
@@ -112,7 +114,7 @@ class LocationsController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, Entity $entity, Location $location): RedirectResponse
+    public function update(Request $request, Location $location): JsonResponse
     {
         $input = $request->all();
         $input['is_primary'] = isset($input['is_primary']) ? 1 : 0;
@@ -121,7 +123,7 @@ class LocationsController extends Controller
 
         flash()->success('Success', 'Your location has been updated!');
 
-        return redirect()->route('entities.show', $entity->slug);
+        return response()->json($location);
     }
 
     /**
@@ -129,13 +131,13 @@ class LocationsController extends Controller
      *
      * @throws \Exception
      */
-    public function destroy(Entity $entity, Location $location): RedirectResponse
+    public function destroy(Location $location): JsonResponse
     {
         $location->delete();
 
         flash()->success('Success', 'Your location has been deleted!');
 
-        return redirect()->route('entities.show', $entity->slug);
+        return response()->json([], 204);
     }
 
     protected function getFormOptions(): array

--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -2222,11 +2222,11 @@ paths:
       summary: Get Locations
       operationId: getLocations
       parameters:
-        - name: title
+        - name: name
           in: query
           schema:
             type: string
-          example: Google
+          example: Brillobox
         - name: sort
           in: query
           required: false

--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -848,6 +848,91 @@ components:
           format: date-time
           description: Date and time that the entity type was last updated
           readOnly: true
+    LocationRequest:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          example: 1
+        name:
+          type: string
+          maxLength: 255
+          description: The name of the location
+          example: Brillobox
+        slug:
+          type: string
+          maxLength: 255
+          description: A unique identifier name for the series in kebab-case
+          example: brillobox-bar
+        address_line_one:
+          type: string
+          maxLength: 255
+          description: First line of the address
+          example: 100 East Street
+        address_line_two:
+          type: string
+          maxLength: 255
+          description: Second line of the address
+          example: Suite 9000
+        neighborhood:
+          type: string
+          maxLength: 255
+          description: Neighborhood the location is in
+          example: Bloomfield
+        city:
+          type: string
+          maxLength: 255
+          description: City of the location
+          example: Pittsburgh
+        state:
+          type: string
+          maxLength: 5
+          description: State of the location
+          example: Pittsburgh
+        postal_code:
+          type: string
+          maxLength: 15
+          description: Postal code of the location
+          example: 15224
+        country:
+          type: string
+          maxLength: 64
+          description: Country of the location
+          example: USA
+        latitude:
+          type: number
+          description: Latitude of the location
+          example: 0.00000000
+        longitude:
+          type: number
+          description: longitude of the location
+          example: 0.00000000
+        visibility_id:
+          type: integer
+          description: Type of visibility
+          example: 1
+        locatoin_type_id:
+          type: integer
+          description: Type of location
+          example: 1
+        map_url:
+          type: string
+          maxLength: 128
+          description: URL of the map location
+          example: USA
+        created_at:
+          type: string
+          example: "2018-03-20T09:12:28Z"
+          format: date-time
+          description: Date and time that the entity type was created
+          readOnly: true
+        updated_at:
+          type: string
+          example: "2018-03-20T09:12:28Z"
+          format: date-time
+          description: Date and time that the entity type was last updated
+          readOnly: true
     OccurrenceDay:
       type: object
       required:
@@ -2257,7 +2342,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Location"
+              $ref: "#/components/schemas/LocationRequest"
       responses:
         "201":
           description: Successful response
@@ -2294,7 +2379,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Location"
+              $ref: "#/components/schemas/LocationRequest"
       responses:
         "200":
           description: Successful response

--- a/resources/views/entities/crumbs.blade.php
+++ b/resources/views/entities/crumbs.blade.php
@@ -17,5 +17,5 @@
 	. {{ ucfirst($type) }}
 @endif
 @if (isset($slug))
-	. {{ Str::studly($slug) }}
+	. {{ $entity->name }}
 @endif 

--- a/resources/views/entities/crumbs.blade.php
+++ b/resources/views/entities/crumbs.blade.php
@@ -16,6 +16,6 @@
 @if (isset($type))
 	. {{ ucfirst($type) }}
 @endif
-@if (isset($slug))
+@if (isset($entity))
 	. {{ $entity->name }}
 @endif 

--- a/resources/views/entities/edit.blade.php
+++ b/resources/views/entities/edit.blade.php
@@ -10,7 +10,7 @@
 
 @section('content')
 
-<h1 class="display-crumbs text-primary">Entity . EDIT
+<h1 class="display-crumbs text-primary">Entity . Edit
 	@include('events.crumbs', ['slug' => $entity->name ?: $entity->id])
 </h1>
       <a href="{!! route('entities.show', ['entity' => $entity->slug]) !!}" class="btn btn-primary">Show Entity</a> <a href="{!! URL::route('entities.index') !!}" class="btn btn-info">Return to list</a>

--- a/resources/views/entities/show.blade.php
+++ b/resources/views/entities/show.blade.php
@@ -10,7 +10,7 @@
 
 @section('content')
 
-<h1 class="display-crumbs text-primary">Entity	@include('entities.crumbs', ['slug' => $entity->name], ['class' => 'item-title'])</h1>
+<h1 class="display-crumbs text-primary">Entity	@include('entities.crumbs', ['slug' => $entity->name, 'entity' => $entity], ['class' => 'item-title'])</h1>
 
 <div id="action-menu" class="mb-2">
 @if ($user && Auth::user()->id === ($entity->user ? $entity->user?->id : null))

--- a/resources/views/entities/title-crumbs.blade.php
+++ b/resources/views/entities/title-crumbs.blade.php
@@ -8,5 +8,5 @@
 • {{ ucfirst($type) }}
 @endif
 @if (isset($slug))
-• {{ strtoupper($slug) }}
+• {{ strtoupper($name) }}
 @endif 

--- a/resources/views/events/crumbs.blade.php
+++ b/resources/views/events/crumbs.blade.php
@@ -28,7 +28,7 @@
 @if (isset($type))
 . {{ ucfirst($type) }}
 @endif
-@if (isset($slug))
+@if (isset($event))
 . {{ $event->name }}
 @endif
 @if (isset($cdate))

--- a/resources/views/events/crumbs.blade.php
+++ b/resources/views/events/crumbs.blade.php
@@ -29,7 +29,7 @@
 . {{ ucfirst($type) }}
 @endif
 @if (isset($slug))
-. {{ ucfirst($slug) }}
+. {{ $event->name }}
 @endif
 @if (isset($cdate))
 . {{ $cdate->toDateString() }}

--- a/resources/views/events/edit.blade.php
+++ b/resources/views/events/edit.blade.php
@@ -13,7 +13,7 @@
 <script src="{{ asset('/js/facebook-sdk.js') }}"></script>
 <script async defer src="https://connect.facebook.net/en_US/sdk.js"></script>
 
-<h1 class="display-crumbs text-primary">Events. Edit	@include('events.crumbs', ['slug' => $event->slug ?: $event->id])</h1>
+<h1 class="display-crumbs text-primary">Events. Edit	@include('events.crumbs', ['slug' => $event->slug ?: $event->id, 'event' => $event])</h1>
 
 <div id="action-menu" class="mb-2">
 	@include('events.edit.actions', ['event' => $event, 'user' => $user])

--- a/resources/views/series/edit.blade.php
+++ b/resources/views/series/edit.blade.php
@@ -10,7 +10,7 @@
 
 @section('content')
 
-<h1 class="display-6 text-primary">Series . Edit . {{ $series->name }}</h1>
+<h1 class="display-crumbs text-primary">Series . Edit . {{ $series->name }}</h1>
 
 <div id="action-menu" class="mb-2">
     <a href="{!! route('series.show', ['series' => $series->id]) !!}" class="btn btn-primary">Show Series</a> <a href="{!! URL::route('series.index') !!}" class="btn btn-info">Return to list</a>

--- a/resources/views/series/show.blade.php
+++ b/resources/views/series/show.blade.php
@@ -9,7 +9,7 @@
 
 @section('content')
 
-<h1 class="display-6 text-primary">Series	@include('series.crumbs', ['slug' => $series->name])</h4>
+<h1 class="display-crumbs text-primary">Series	@include('series.crumbs', ['slug' => $series->name])</h4>
 
 <div id="action-menu" class="mb-2">	
 	@if ($user && (Auth::user()->id == $series?->user?->id || $user->id == Config::get('app.superuser')  ) )

--- a/resources/views/tags/list.blade.php
+++ b/resources/views/tags/list.blade.php
@@ -13,7 +13,7 @@
 				@endif
 
                     @if ($signedIn &&  Auth::user()->id == Config::get('app.superuser'))
-						<a href="{!! route('tags.edit', ['tag' => $tag->id]) !!}" title="Click to edit"><i class='bi bi-pencil-fill'></i></a>
+						<a href="{!! route('tags.edit', ['tag' => $tag->slug]) !!}" title="Click to edit"><i class='bi bi-pencil-fill'></i></a>
 						{!! link_form_bootstrap_icon('bi bi-trash-fill text-warning icon', $tag, 'DELETE', 'Delete the tag', NULL, 'delete') !!} 
                     @endif
 			@endif

--- a/routes/api.php
+++ b/routes/api.php
@@ -57,6 +57,11 @@ Route::middleware('auth.basic')->name('api.')->group(function () {
     Route::get('links/rpp-reset', ['as' => 'links.rppReset', 'uses' => 'Api\LinksController@rppReset']);
     Route::resource('links', 'Api\LinksController');
 
+    Route::match(['get', 'post'], 'locations/filter', ['as' => 'locations.filter', 'uses' => 'Api\LocationsController@filter']);
+    Route::get('locations/reset', ['as' => 'locations.reset', 'uses' => 'Api\LocationsController@reset']);
+    Route::get('locations/rpp-reset', ['as' => 'locations.rppReset', 'uses' => 'Api\LocationsController@rppReset']);
+    Route::resource('locations', 'Api\LocationsController');
+
     Route::match(['get', 'post'], 'users/filter', ['as' => 'users.filter', 'uses' => 'Api\UsersController@filter']);
     Route::get('users/reset', ['as' => 'users.reset', 'uses' => 'Api\UsersController@reset']);
     Route::get('users/rpp-reset', ['as' => 'users.rppReset', 'uses' => 'Api\UsersController@rppReset']);


### PR DESCRIPTION
This pull request fixes the naming in the edit breadcrumbs for the entities and events views. It updates the blade templates to use the correct variables for displaying the entity and event names.