### PR TITLE
Fix duplicate routes and typos

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -47,7 +47,7 @@ Route::middleware('auth.basic')->name('api.')->group(function () {
 
 Route::middleware('auth.either')->name('api.')->group(function () {
 
-    Route::match(['get', 'post'], 'blogs/filter', ['as' => 'blogss.filter', 'uses' => 'Api\BlogsController@filter']);
+    Route::match(['get', 'post'], 'blogs/filter', ['as' => 'blogs.filter', 'uses' => 'Api\BlogsController@filter']);
     Route::get('blogs/reset', ['as' => 'blogs.reset', 'uses' => 'Api\BlogsController@reset']);
     Route::get('blogs/rpp-reset', ['as' => 'blogs.rppReset', 'uses' => 'Api\BlogsController@rppReset']);
     Route::resource('blogs', 'Api\BlogsController');
@@ -55,8 +55,6 @@ Route::middleware('auth.either')->name('api.')->group(function () {
     Route::get('events/{event}/photos', ['as' => 'events.photos', 'uses' => 'Api\EventsController@photos']);
     Route::get('events/{event}/embeds', ['as' => 'events.embeds', 'uses' => 'Api\EventsController@embeds']);
     Route::get('events/{event}/minimal-embeds', ['as' => 'events.minimalEmbeds', 'uses' => 'Api\EventsController@minimalEmbeds']);
-    Route::get('events/reset', ['as' => 'events.reset', 'uses' => 'Api\EventsController@reset']);
-
     Route::get('events/reset', ['as' => 'events.reset', 'uses' => 'Api\EventsController@reset']);
     Route::get('events/rpp-reset', ['as' => 'events.rppReset', 'uses' => 'Api\EventsController@rppReset']);
     Route::resource('events', 'Api\EventsController');

--- a/routes/web.php
+++ b/routes/web.php
@@ -93,8 +93,6 @@ Route::get('users/{id}/notify', [
     'as' => 'users.notify',
     'uses' => 'UsersController@notifyUser',
 ]);
-
-
 Route::match(['get', 'post'], 'activity/filter', ['as' => 'activities.filter', 'uses' => 'ActivityController@filter']);
 Route::get('activity', 'ActivityController@index')->name('activities.index');
 Route::get('activity/reset', ['as' => 'activities.reset', 'uses' => 'ActivityController@reset']);
@@ -121,11 +119,6 @@ Route::get('impersonate/{user}', function (User $user) {
 
 Route::post('users/{id}/photos', 'UsersController@addPhoto');
 Route::delete('users/{id}/photos/{photo_id}', 'UsersController@deletePhoto');
-
-Route::get('users/{id}/notify', [
-    'as' => 'users.notify',
-    'uses' => 'UsersController@notifyUser',
-]);
 
 Route::get('users/{id}/activate', [
     'as' => 'users.activate',


### PR DESCRIPTION
## Summary
- fix duplicate `users.notify` route in `routes/web.php`
- fix route typo and duplicate in `routes/api.php`
- ensure both routes files end with a newline

## Testing
- `composer run-script tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a23a3f8c8322b3397207286160a5