### PR TITLE
Add API endpoint for all event photos

### DIFF
--- a/app/Http/Controllers/Api/EventsController.php
+++ b/app/Http/Controllers/Api/EventsController.php
@@ -1310,4 +1310,37 @@ class EventsController extends Controller
 
         return response()->json($photos);
     }
+
+    public function allPhotos(?Event $event): JsonResponse
+    {
+        if (!$event) {
+            abort(404);
+        }
+
+        $photos = [];
+
+        $photoList = $event->photos()->get();
+        foreach ($photoList as $photo) {
+            $photos[$photo->id] = [
+                'id' => $photo->id,
+                'name' => $photo->name,
+                'photo' => Storage::disk('external')->url($photo->getStoragePath()),
+                'thumbnail' => Storage::disk('external')->url($photo->getStorageThumbnail()),
+            ];
+        }
+
+        $entities = $event->entities()->with('photos')->get();
+        foreach ($entities as $entity) {
+            foreach ($entity->photos as $photo) {
+                $photos[$photo->id] = [
+                    'id' => $photo->id,
+                    'name' => $photo->name,
+                    'photo' => Storage::disk('external')->url($photo->getStoragePath()),
+                    'thumbnail' => Storage::disk('external')->url($photo->getStorageThumbnail()),
+                ];
+            }
+        }
+
+        return response()->json(array_values($photos));
+    }
 }

--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -2575,6 +2575,28 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Photos"
+  /api/events/{slug}/all-photos:
+    get:
+      parameters:
+        - name: slug
+          description: The unique identifier of the entity
+          in: path
+          required: true
+          schema:
+            type: string
+            readOnly: true
+            example: "strobe"
+      tags:
+        - events
+      summary: Get All Related Events Photos
+      operationId: getAllEventPhotosBySlug
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Photos"
   /api/entities:
     post:
       tags:

--- a/routes/api.php
+++ b/routes/api.php
@@ -66,6 +66,7 @@ Route::middleware('auth.either')->name('api.')->group(function () {
     Route::get('events/rpp-reset', ['as' => 'events.rppReset', 'uses' => 'Api\EventsController@rppReset']);
     
     Route::get('events/{event}/photos', ['as' => 'events.photos', 'uses' => 'Api\EventsController@photos']);
+    Route::get('events/{event}/all-photos', ['as' => 'events.allPhotos', 'uses' => 'Api\EventsController@allPhotos']);
     Route::get('events/{event}/embeds', ['as' => 'events.embeds', 'uses' => 'Api\EventsController@embeds']);
     Route::get('events/{event}/minimal-embeds', ['as' => 'events.minimalEmbeds', 'uses' => 'Api\EventsController@minimalEmbeds']);
     

--- a/routes/api.php
+++ b/routes/api.php
@@ -70,7 +70,7 @@ Route::middleware('auth.either')->name('api.')->group(function () {
     Route::get('events/{event}/embeds', ['as' => 'events.embeds', 'uses' => 'Api\EventsController@embeds']);
     Route::get('events/{event}/minimal-embeds', ['as' => 'events.minimalEmbeds', 'uses' => 'Api\EventsController@minimalEmbeds']);
     
-    Route::resource('events', 'Api\EventsController');;
+    Route::resource('events', 'Api\EventsController');
 
     Route::get('entities/{entity}/photos', ['as' => 'entities.photos', 'uses' => 'Api\EntitiesController@photos']);
     Route::get('entities/{entity}/embeds', ['as' => 'entities.embeds', 'uses' => 'Api\EntitiesController@embeds']);


### PR DESCRIPTION
## Summary
- add `allPhotos` API method in `EventsController`
- expose new route `events/{event}/all-photos`

## Testing
- `composer run-script phpstan` *(fails: command not found)*
- `composer run-script tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68544a996d008322beaf4d2bf803b669