### PR TITLE
Add API endpoint for posting event photos

### DIFF
--- a/app/Http/Controllers/Api/EventsController.php
+++ b/app/Http/Controllers/Api/EventsController.php
@@ -1348,7 +1348,7 @@ class EventsController extends Controller
     /**
      * Add a photo to an event.
      */
-    public function addPhoto(int $id, Request $request, ImageHandler $imageHandler): void
+    public function addPhoto(int $id, Request $request, ImageHandler $imageHandler): JsonResponse
     {
         $this->validate($request, [
             'file' => 'required|mimes:jpg,jpeg,png,gif,webp',
@@ -1369,6 +1369,17 @@ class EventsController extends Controller
                     $this->notifyFollowing($event);
                 }
             }
+
+            $photoData = [
+                'id' => $photo->id,
+                'name' => $photo->name,
+                'photo' => Storage::disk('external')->url($photo->getStoragePath()),
+                'thumbnail' => Storage::disk('external')->url($photo->getStorageThumbnail()),
+            ];
+
+            return response()->json($photoData, 201);
         }
+
+        return response()->json([], 404);
     }
 }

--- a/app/Http/Controllers/Api/EventsController.php
+++ b/app/Http/Controllers/Api/EventsController.php
@@ -28,6 +28,7 @@ use App\Models\User;
 use App\Models\Visibility;
 use App\Notifications\EventPublished;
 use App\Services\Embeds\EmbedExtractor;
+use App\Services\ImageHandler;
 use App\Services\RssFeed;
 use App\Services\SessionStore\ListParameterSessionStore;
 use Carbon\Carbon;

--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -2597,6 +2597,35 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Photos"
+  /api/events/{id}/photos:
+    post:
+      parameters:
+        - name: id
+          description: The unique identifier of the event
+          in: path
+          required: true
+          schema:
+            type: integer
+            readOnly: true
+            example: 1
+      tags:
+        - events
+      summary: Add Event Photo
+      operationId: addEventPhotoById
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        "204":
+          description: Successful response
+          content:
+            application/json: {}
   /api/entities:
     post:
       tags:

--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -2199,10 +2199,12 @@ paths:
       summary: Delete Blog
       operationId: deleteBlogById
       responses:
-        "204":
+        "201":
           description: Successful response
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PhotoResponse"
   /api/events:
     post:
       tags:
@@ -2505,10 +2507,12 @@ paths:
       summary: Delete Event
       operationId: deleteEventById
       responses:
-        "204":
+        "201":
           description: Successful response
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PhotoResponse"
   /api/events/{slug}/embeds:
     get:
       parameters:
@@ -2622,10 +2626,12 @@ paths:
                   type: string
                   format: binary
       responses:
-        "204":
+        "201":
           description: Successful response
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PhotoResponse"
   /api/entities:
     post:
       tags:

--- a/routes/api.php
+++ b/routes/api.php
@@ -67,6 +67,7 @@ Route::middleware('auth.either')->name('api.')->group(function () {
     
     Route::get('events/{event}/photos', ['as' => 'events.photos', 'uses' => 'Api\EventsController@photos']);
     Route::get('events/{event}/all-photos', ['as' => 'events.allPhotos', 'uses' => 'Api\EventsController@allPhotos']);
+    Route::post('events/{id}/photos', 'Api\EventsController@addPhoto');
     Route::get('events/{event}/embeds', ['as' => 'events.embeds', 'uses' => 'Api\EventsController@embeds']);
     Route::get('events/{event}/minimal-embeds', ['as' => 'events.minimalEmbeds', 'uses' => 'Api\EventsController@minimalEmbeds']);
     


### PR DESCRIPTION
## Summary
- add route to POST `/api/events/{id}/photos`
- implement `addPhoto` method in API EventsController

## Testing
- `./vendor/bin/phpunit tests/Feature/ApiEventsTest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6854f74559c0832299d044446fc222b5