### PR TITLE
Add entity photo upload API

### DIFF
--- a/app/Http/Controllers/Api/EntitiesController.php
+++ b/app/Http/Controllers/Api/EntitiesController.php
@@ -661,7 +661,7 @@ class EntitiesController extends Controller
     /**
      * Add a photo to an entity.
      */
-    public function addPhoto(int $id, Request $request, ImageHandler $imageHandler): void
+    public function addPhoto(int $id, Request $request, ImageHandler $imageHandler): JsonResponse
     {
         $this->validate($request, [
             'file' => 'required|mimes:jpg,jpeg,png,gif,webp',
@@ -683,7 +683,18 @@ class EntitiesController extends Controller
 
             // attach to entity
             $entity->addPhoto($photo);
+
+            $photoData = [
+                'id' => $photo->id,
+                'name' => $photo->name,
+                'photo' => Storage::disk('external')->url($photo->getStoragePath()),
+                'thumbnail' => Storage::disk('external')->url($photo->getStorageThumbnail()),
+            ];
+
+            return response()->json($photoData, 201);
         }
+
+        return response()->json([], 404);
     }
 
     protected function makePhoto(UploadedFile $file): Photo

--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -2856,6 +2856,37 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Photos"
+  /api/entities/{id}/photos:
+    post:
+      parameters:
+        - name: id
+          description: The unique identifier of the entity
+          in: path
+          required: true
+          schema:
+            type: integer
+            readOnly: true
+            example: 1
+      tags:
+        - entities
+      summary: Add Entity Photo
+      operationId: addEntityPhotoById
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        "201":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PhotoResponse"
   /api/entity-statuses:
     get:
       tags:

--- a/routes/api.php
+++ b/routes/api.php
@@ -76,6 +76,7 @@ Route::middleware('auth.either')->name('api.')->group(function () {
     Route::get('entities/{entity}/photos', ['as' => 'entities.photos', 'uses' => 'Api\EntitiesController@photos']);
     Route::get('entities/{entity}/embeds', ['as' => 'entities.embeds', 'uses' => 'Api\EntitiesController@embeds']);
     Route::get('entities/{entity}/minimal-embeds', ['as' => 'entities.minimalEmbeds', 'uses' => 'Api\EntitiesController@minimalEmbeds']);
+    Route::post('entities/{id}/photos', 'Api\EntitiesController@addPhoto');
     Route::resource('entities', 'Api\EntitiesController');
 
     Route::match(['get', 'post'], 'entity-types/filter', ['as' => 'entityType.filter', 'uses' => 'Api\EntityTypesController@filter']);


### PR DESCRIPTION
## Summary
- add POST route for entity photo uploads
- return photo data on successful upload
- document new endpoint in Postman API definition

## Testing
- `composer run-script tests` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855d23f309c8322b12b5dc7b74c1c53