### PR TITLE
Add series photo upload endpoint

### DIFF
--- a/app/Http/Controllers/Api/SeriesController.php
+++ b/app/Http/Controllers/Api/SeriesController.php
@@ -730,11 +730,9 @@ class SeriesController extends Controller
             'file' => 'required|mimes:jpg,jpeg,png,gif,webp',
         ]);
 
-        $fileName = time().'_'.$request->file->getClientOriginalName();
-        $filePath = $request->file('file')->storePubliclyAs('photos', $fileName, 'external');
-
         // attach to series
         if ($series = Series::find($id)) {
+
             // make the photo object from the file in the request
             $photo = $imageHandler->makePhoto($request->file('file'));
 

--- a/app/Http/Controllers/Api/SeriesController.php
+++ b/app/Http/Controllers/Api/SeriesController.php
@@ -22,6 +22,7 @@ use App\Models\Tag;
 use App\Models\User;
 use App\Models\Visibility;
 use App\Services\ImageHandler;
+use Storage;
 use App\Services\RssFeed;
 use App\Services\SessionStore\ListParameterSessionStore;
 use App\Services\StringHelper;
@@ -723,7 +724,7 @@ class SeriesController extends Controller
     /**
      * Add a photo to a series.
      */
-    public function addPhoto(int $id, Request $request, ImageHandler $imageHandler): void
+    public function addPhoto(int $id, Request $request, ImageHandler $imageHandler): JsonResponse
     {
         $this->validate($request, [
             'file' => 'required|mimes:jpg,jpeg,png,gif,webp',
@@ -746,7 +747,18 @@ class SeriesController extends Controller
 
             // attach to series
             $series->addPhoto($photo);
+
+            $photoData = [
+                'id' => $photo->id,
+                'name' => $photo->name,
+                'photo' => Storage::disk('external')->url($photo->getStoragePath()),
+                'thumbnail' => Storage::disk('external')->url($photo->getStorageThumbnail()),
+            ];
+
+            return response()->json($photoData, 201);
         }
+
+        return response()->json([], 404);
     }
 
     protected function makePhoto(UploadedFile $file): ?Photo

--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -3851,6 +3851,37 @@ paths:
           description: Successful response
           content:
             application/json: {}
+  /api/series/{id}/photos:
+    post:
+      parameters:
+        - name: id
+          description: The unique identifier of the series
+          in: path
+          required: true
+          schema:
+            type: integer
+            readOnly: true
+            example: 1
+      tags:
+        - series
+      summary: Add Series Photo
+      operationId: addSeriesPhotoById
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        "201":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PhotoResponse"
   /api/tags:
     post:
       tags:

--- a/routes/api.php
+++ b/routes/api.php
@@ -111,6 +111,7 @@ Route::middleware('auth.either')->name('api.')->group(function () {
 
     Route::get('series/reset', ['as' => 'series.reset', 'uses' => 'Api\SeriesController@reset']);
     Route::get('series/rpp-reset', ['as' => 'series.rppReset', 'uses' => 'Api\SeriesController@rppReset']);
+    Route::post('series/{id}/photos', 'Api\SeriesController@addPhoto');
     Route::resource('series', 'Api\SeriesController');
 
     Route::match(['get', 'post'], 'tags/filter', ['as' => 'tags.filter', 'uses' => 'Api\TagsController@filter']);


### PR DESCRIPTION
## Summary
- allow uploading photos to a series via API
- document new API endpoint in Postman schema

## Testing
- `composer run-script tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855e0685fc88322b275552482ad9e64