### PR TITLE
Limit data depth for event API

### DIFF
--- a/app/Http/Controllers/Api/EventsController.php
+++ b/app/Http/Controllers/Api/EventsController.php
@@ -152,7 +152,16 @@ class EventsController extends Controller
         // get the events
         // @phpstan-ignore-next-line
         $events = $query->visible($this->user)
-            ->with('visibility', 'venue')
+            ->with([
+                'visibility',
+                'venue',
+                'eventStatus',
+                'eventType',
+                'promoter',
+                'series',
+                'tags',
+                'entities',
+            ])
             ->paginate($listResultSet->getLimit());
     
         return response()->json(new EventCollection($events));
@@ -215,7 +224,16 @@ class EventsController extends Controller
             })
             ->orderBy('start_at', 'ASC')
             ->orderBy('name', 'ASC')
-            ->with('visibility', 'venue')
+            ->with([
+                'visibility',
+                'venue',
+                'eventStatus',
+                'eventType',
+                'promoter',
+                'series',
+                'tags',
+                'entities',
+            ])
             ->paginate($listResultSet->getLimit());
         
 

--- a/app/Http/Resources/EventCollection.php
+++ b/app/Http/Resources/EventCollection.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\ResourceCollection;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use App\Http\Resources\EventResource;
 
 /**
  * @mixin \Illuminate\Contracts\Pagination\LengthAwarePaginator
@@ -20,7 +21,7 @@ class EventCollection extends ResourceCollection
     {
         return [
             'current_page' => $this->currentPage(),
-            'data' => $this->collection->toArray(),
+            'data' => EventResource::collection($this->collection)->resolve(),
             'first_page_url' => $this->url(1),
             'from' => $this->firstItem(),
             'last_page' => $this->lastPage(),

--- a/app/Http/Resources/EventResource.php
+++ b/app/Http/Resources/EventResource.php
@@ -5,6 +5,9 @@ namespace App\Http\Resources;
 use Illuminate\Http\Resources\Json\JsonResource;
 use App\Models\Event;
 
+// Resource for minimal relationship data
+use App\Http\Resources\MinimalResource;
+
 /**
  * @mixin \App\Models\Event
  */
@@ -24,13 +27,13 @@ class EventResource extends JsonResource
             'name' => $this->name,
             'slug' => $this->slug,
             'short' => $this->short,
-            'visibility' => $this->visibility,
+            'visibility' => new MinimalResource($this->visibility),
             'description' => $this->description,
-            'event_status' => $this->eventStatus,
-            'event_type' => $this->eventType,
+            'event_status' => new MinimalResource($this->eventStatus),
+            'event_type' => new MinimalResource($this->eventType),
             'is_benefit' => $this->is_benefit,
-            'promoter' => $this->promoter,
-            'venue' => $this->venue,
+            'promoter' => $this->promoter ? new MinimalResource($this->promoter) : null,
+            'venue' => $this->venue ? new MinimalResource($this->venue) : null,
             'attending' => $this->attending,
             'like' => $this->like,
             'presale_price' => $this->presale_price,
@@ -40,11 +43,11 @@ class EventResource extends JsonResource
             'start_at' => $this->start_at,
             'end_at' => $this->end_at,
             'min_age' => $this->min_age,
-            'series' => $this->series,
+            'series' => $this->series ? new MinimalResource($this->series) : null,
             'primary_link' => $this->primary_link,
             'ticket_link' => $this->ticket_link,
-            'tags' => $this->tags,
-            'entities' => EntityResource::collection($this->entities),
+            'tags' => MinimalResource::collection($this->whenLoaded('tags', $this->tags)),
+            'entities' => MinimalResource::collection($this->whenLoaded('entities', $this->entities)),
             'created_by' => $this->created_by,
             'updated_by' => $this->updated_by,
             'created_at' => $this->created_at,

--- a/app/Http/Resources/MinimalResource.php
+++ b/app/Http/Resources/MinimalResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Generic resource for returning minimal relationship data.
+ */
+class MinimalResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+        ];
+    }
+}

--- a/app/Http/Resources/MinimalResource.php
+++ b/app/Http/Resources/MinimalResource.php
@@ -13,13 +13,13 @@ class MinimalResource extends JsonResource
      * Transform the resource into an array.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return array
+     * @return array<string, mixed>
      */
     public function toArray($request)
     {
         return [
-            'id' => $this->id,
-            'name' => $this->name,
+            'id' => $this->resource->id,
+            'name' => $this->resource->name,
         ];
     }
 }

--- a/public/postman/schemas/action-api.yml
+++ b/public/postman/schemas/action-api.yml
@@ -1,0 +1,2443 @@
+openapi: 3.1.0
+info:
+  title: Arcane City
+  version: 1.0.0
+  description: REST API for working with Arcane City data
+  contact:
+    name: Geoff Maddock
+    email: geoff.maddock@gmail.com
+servers:
+  - url: https://arcane.city
+    description: Production
+tags:
+  - name: entities
+  - name: entity-types
+  - name: events
+  - name: event-types
+  - name: tags
+  - name: users
+components:
+  responses:
+    NotFound:
+      description: The specified resource was not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    Unauthorized:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    Unexpected:
+      description: Unexpected
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+  schemas:
+    Embeds:
+      allOf:
+        - $ref: "#/components/schemas/Pagination"
+      type: object
+      properties:
+        data:
+          type: array
+          description: List of the current page of event embeds
+          items:
+            $ref: "#/components/schemas/EmbedResponse"
+    EmbedResponse:
+      type: object
+      properties:
+        embed:
+          type: string
+          maxLength: 65535
+          description: Code that can be output to display embedded content, typically external content
+          example: https://bandcamp.com/brillobox
+    Photos:
+      allOf:
+        - $ref: "#/components/schemas/Pagination"
+      type: object
+      properties:
+        data:
+          type: array
+          description: List of the photo responses
+          items:
+            $ref: "#/components/schemas/PhotoResponse"
+    PhotoResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Unique ID of the photo
+        name:
+          type: string
+          maxLength: 255
+          description: The cannonical name of the photo
+          example: Brillobox
+        photo:
+          type: string
+          maxLength: 65535
+          description: A link to a photo image
+          example: https://some.url/imagelink.jpg
+        thumbnail:
+          type: string
+          maxLength: 65535
+          description: A link to a photo image thumbnail
+          example: https://some.url/tb-imagelink.jpg
+    EntityRequest:
+      type: object
+      required:
+        - name
+        - slug
+      properties:
+        name:
+          type: string
+          maxLength: 255
+          description: The cannonical name of the enitity
+          example: Brillobox
+        slug:
+          type: string
+          maxLength: 255
+          description: A unique identifier name for the entity in kebab-case
+          example: brillobox-bar
+        short:
+          type: string
+          maxLength: 255
+          description: A brief description of the enitity
+          example: A two level bar and venue
+        description:
+          type: string
+          maxLength: 65535
+          description: Full description of the entity
+          example: A two level bar and venue that specializes in indie music and vegetarian food
+        entity_type_id:
+          description: Relation to the entity type table that defines the type of an entity
+          type: integer
+          example: 1
+        entity_status_id:
+          description: The unique identifier of an entity type
+          type: integer
+          example: 1
+        started_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the entity started to exist
+        facebook_username:
+          type: string
+          maxLength: 64
+          description: The entity's username on facebook
+          example: johnsmith
+        twitter_username:
+          type: string
+          maxLength: 64
+          description: The entity's username on twitter
+          example: johnsmith
+    EntityResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Unique ID of the entity
+        name:
+          type: string
+          maxLength: 255
+          description: The cannonical name of the enitity
+          example: Brillobox
+        slug:
+          type: string
+          maxLength: 255
+          description: A unique identifier name for the entity in kebab-case
+          example: brillobox-bar
+        short:
+          type: string
+          maxLength: 255
+          description: A brief description of the enitity
+          example: A two level bar and venue
+        description:
+          type: string
+          maxLength: 65535
+          description: Full description of the entity
+          example: A two level bar and venue that specializes in indie music and vegetarian food
+        entity_type:
+          $ref: "#/components/schemas/EntityType"
+        entity_status:
+          $ref: "#/components/schemas/EntityStatus"
+        created_by:
+          $ref: "#/components/schemas/UserSimple"
+        updated_by:
+          $ref: "#/components/schemas/UserSimple"
+        created_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the entity was created
+        updated_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the entity was last updated
+        started_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the entity started to exist
+        facebook_username:
+          type: string
+          maxLength: 64
+          description: The entity's username on facebook
+          example: johnsmith
+        twitter_username:
+          type: string
+          maxLength: 64
+          description: The entity's username on twitter
+          example: johnsmith
+        links:
+          type: array
+          items:
+            $ref: "#/components/schemas/Link"
+        tags:
+          type: array
+          items:
+            $ref: "#/components/schemas/Tag"
+    Entities:
+      allOf:
+        - $ref: "#/components/schemas/Pagination"
+      type: object
+      properties:
+        data:
+          type: array
+          description: List of the current page of entities
+          items:
+            $ref: "#/components/schemas/EntityResponse"
+    EntityType:
+      type: object
+      required:
+        - name
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          example: 1
+        name:
+          type: string
+          maxLength: 255
+          description: A name of an entity type
+          example: Group
+        slug:
+          type: string
+          maxLength: 255
+          description: A unique identifier name for the entity type in kebab-case
+          example: group-slug
+        short:
+          type: string
+          example: A multi-member entity
+          description: A brief description of the entity type
+          maxLength: 255
+        created_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the entity type was created
+          readOnly: true
+        updated_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the entity type was last updated
+          readOnly: true
+    EntityTypes:
+      allOf:
+        - $ref: "#/components/schemas/Pagination"
+      type: object
+      properties:
+        data:
+          type: array
+          description: List of the current page of events
+          items:
+            $ref: "#/components/schemas/EntityType"
+    EntityStatus:
+      type: object
+      required:
+        - name
+      properties:
+        id:
+          description: The unique identifier of an entity type
+          type: integer
+          readOnly: true
+          example: 1
+        name:
+          type: string
+          maxLength: 255
+          description: A name of an entity status
+          example: Active
+        created_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the entity status was created
+          readOnly: true
+        updated_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the entity status was last updated
+          readOnly: true
+    EventRequest:
+      type: object
+      required:
+        - id
+        - name
+        - slug
+        - start_at
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          example: 1
+        name:
+          type: string
+          example: October's Lazercrunk at the Brillobox
+          description: The cannonical name of the event
+          maxLength: 255
+        slug:
+          type: string
+          maxLength: 255
+          description: A unique identifier name for the event in kebab-case
+          example: octobers-lazercrunk-at-the-brillobox
+        short:
+          type: string
+          example: a really fun dj night featuring performers from around the world
+          description: A brief description of the event
+          maxLength: 255
+        visibility_id:
+          type: integer
+          example: 1
+          description: Relation to the visibility table that defines the visibility of events
+        description:
+          type: string
+          description: Full description of the event
+          example: a really fun dj night featuring performers from around the world and locally playing new electronic music
+          maxLength: 65535
+        event_status_id:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the event type table that defines the status of the event
+        event_type_id:
+          type: integer
+          example: 1
+          description: Relation to the event type table that defines the type of event
+        promoter_id:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the entity table that defines the promoter of the event
+        venue_id:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the entity table that defines the venue for the event
+        is_benefit:
+          type: boolean
+          description: Flag indicating if the event is a benefit
+          example: true
+        attending:
+          description: The number of users who marked that they are attending the event
+          type: integer
+          example: 10
+        like:
+          description: The number of users who marked that they like the event
+          type: integer
+          example: 10
+        presale_price:
+          description: The price for a presale price for the event
+          type: number
+          example: 9.99
+        door_price:
+          description: The price of the show at the door
+          type: number
+          example: 19.99
+        soundcheck_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the event soundcheck is scheduled
+        door_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the event doors are scheduled to open
+        start_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the event starts
+        end_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the event starts
+        series_id:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the series table that defines the series for the event
+        min_age:
+          description: The minimum age requirement for the event in years
+          type: integer
+          example: 21
+        primary_link:
+          type: string
+          description: The primary URL related to this event
+          example: http://lazercrunk.com/october-2022
+          maxLength: 255
+        ticket_link:
+          type: string
+          description: The URL for buying a ticket to the event
+          example: http://lazercrunk.com/october-2022/tickets
+          maxLength: 255
+        created_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the event was created
+        updated_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time"
+          description: Date and time that the event was last updated
+        cancelled_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the event was cancelled
+        created_by:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the user table that defines the user who created the event
+        updated_by:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the user table that defines the user who last updated the event
+    Event:
+      type: object
+      required:
+        - id
+        - name
+        - slug
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          example: 1
+        name:
+          type: string
+          example: October's Lazercrunk at the Brillobox
+          description: The cannonical name of the event
+          maxLength: 255
+        slug:
+          type: string
+          maxLength: 255
+          description: A unique identifier name for the event in kebab-case
+          example: octobers-lazercrunk-at-the-brillobox
+        short:
+          type: string
+          example: a really fun dj night featuring performers from around the world
+          description: A brief description of the event
+          maxLength: 255
+        visibility_id:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the visibility table that defines the visibility of events
+        description:
+          type: string
+          description: Full description of the event
+          example: a really fun dj night featuring performers from around the world and locally playing new electronic music
+          maxLength: 65535
+        event_status_id:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the event type table that defines the status of the event
+        event_type_id:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the event type table that defines the type of event
+        promoter_id:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the entity table that defines the promoter of the event
+        venue_id:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the entity table that defines the venue for the event
+        is_benefit:
+          type: boolean
+          description: Flag indicating if the event is a benefit
+          example: true
+        attending:
+          description: The number of users who marked that they are attending the event
+          type: integer
+          example: 10
+        like:
+          description: The number of users who marked that they like the event
+          type: integer
+          example: 10
+        presale_price:
+          description: The price for a presale price for the event
+          type: number
+          example: 9.99
+        door_price:
+          description: The price of the show at the door
+          type: number
+          example: 19.99
+        soundcheck_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the event soundcheck is scheduled
+        door_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the event doors are scheduled to open
+        start_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the event starts
+        end_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the event starts
+        series_id:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the series table that defines the series for the event
+        min_age:
+          description: The minimum age requirement for the event in years
+          type: integer
+          example: 21
+        primary_link:
+          type: string
+          description: The primary URL related to this event
+          example: http://lazercrunk.com/october-2022
+          maxLength: 255
+        ticket_link:
+          type: string
+          description: The URL for buying a ticket to the event
+          example: http://lazercrunk.com/october-2022/tickets
+          maxLength: 255
+        created_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the event was created
+        updated_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the event was last updated
+        cancelled_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the event was cancelled
+        created_by:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the user table that defines the user who created the event
+        updated_by:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the user table that defines the user who last updated the event
+    EventResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          example: 1
+        name:
+          type: string
+          example: October's Lazercrunk at the Brillobox
+          description: The cannonical name of the event
+          maxLength: 255
+        slug:
+          type: string
+          maxLength: 255
+          description: A unique identifier name for the event in kebab-case
+          example: octobers-lazercrunk-at-the-brillobox
+        short:
+          type: string
+          example: a really fun dj night featuring performers from around the world
+          description: A brief description of the event
+          maxLength: 255
+        visibility:
+          $ref: "#/components/schemas/Visibility"
+        description:
+          type: string
+          description: Full description of the event
+          example: a really fun dj night featuring performers from around the world and locally playing new electronic music
+          maxLength: 65535
+        event_status:
+          $ref: "#/components/schemas/EventStatus"
+        event_type:
+          $ref: "#/components/schemas/EventType"
+        promoter:
+          $ref: "#/components/schemas/EntityResponse"
+        venue:
+          $ref: "#/components/schemas/EntityResponse"
+        is_benefit:
+          type: boolean
+          description: Flag indicating if the event is a benefit
+          example: true
+        attending:
+          description: The number of users who marked that they are attending the event
+          type: integer
+          example: 10
+        like:
+          description: The number of users who marked that they like the event
+          type: integer
+          example: 10
+        presale_price:
+          description: The price for a presale price for the event
+          type: number
+          example: 9.99
+        door_price:
+          description: The price of the show at the door
+          type: number
+          example: 19.99
+        soundcheck_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the event soundcheck is scheduled
+        door_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the event doors are scheduled to open
+        start_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the event starts
+        end_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the event starts
+        series:
+          $ref: "#/components/schemas/SeriesResponse"
+        min_age:
+          description: The minimum age requirement for the event in years
+          type: integer
+          example: 21
+        primary_link:
+          type: string
+          description: The primary URL related to this event
+          example: http://lazercrunk.com/october-2022
+          maxLength: 255
+        ticket_link:
+          type: string
+          description: The URL for buying a ticket to the event
+          example: http://lazercrunk.com/october-2022/tickets
+          maxLength: 255
+        created_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the event was created
+        updated_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the event was last updated
+        cancelled_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the event was cancelled
+        tags:
+          type: array
+          items:
+            $ref: "#/components/schemas/Tag"
+        created_by:
+          $ref: "#/components/schemas/UserSimple"
+        updated_by:
+          $ref: "#/components/schemas/UserSimple"
+    Events:
+      allOf:
+        - $ref: "#/components/schemas/Pagination"
+      type: object
+      properties:
+        data:
+          type: array
+          description: List of the current page of events
+          items:
+            $ref: "#/components/schemas/EventResponse"
+    EventStatus:
+      type: object
+      required:
+        - name
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          example: 1
+        name:
+          type: string
+          maxLength: 255
+          description: A name of an event status
+          example: Active
+        created_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the event status was created
+          readOnly: true
+        updated_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the event status was last updated
+          readOnly: true
+    EventType:
+      type: object
+      required:
+        - name
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          example: 1
+        name:
+          type: string
+          maxLength: 255
+          description: A name of an event type
+          example: Concert
+        created_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the event type  was created
+          readOnly: true
+        updated_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the event type was last updated
+          readOnly: true
+    EventTypes:
+      allOf:
+        - $ref: "#/components/schemas/Pagination"
+      type: object
+      properties:
+        data:
+          type: array
+          description: List of the current page of events
+          items:
+            $ref: "#/components/schemas/EventType"
+    Location:
+      type: object
+      required:
+        - name
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          example: 1
+        name:
+          type: string
+          maxLength: 255
+          description: The name of the location
+          example: Brillobox
+        slug:
+          type: string
+          maxLength: 255
+          description: A unique identifier name for the series in kebab-case
+          example: brillobox-bar
+        address_line_one:
+          type: string
+          maxLength: 255
+          description: First line of the address
+          example: 100 East Street
+        address_line_two:
+          type: string
+          maxLength: 255
+          description: Second line of the address
+          example: Suite 9000
+        neighborhood:
+          type: string
+          maxLength: 255
+          description: Neighborhood the location is in
+          example: Bloomfield
+        city:
+          type: string
+          maxLength: 255
+          description: City of the location
+          example: Pittsburgh
+        state:
+          type: string
+          maxLength: 5
+          description: State of the location
+          example: Pittsburgh
+        postal_code:
+          type: string
+          maxLength: 15
+          description: Postal code of the location
+          example: 15224
+        country:
+          type: string
+          maxLength: 64
+          description: Country of the location
+          example: USA
+        latitude:
+          type: number
+          description: Latitude of the location
+          example: 0
+        longitude:
+          type: number
+          description: longitude of the location
+          example: 0
+        visibility:
+          $ref: "#/components/schemas/Visibility"
+        map_url:
+          type: string
+          maxLength: 128
+          description: URL of the map location
+          example: USA
+        created_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the entity type was created
+          readOnly: true
+        updated_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the entity type was last updated
+          readOnly: true
+    LocationRequest:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          example: 1
+        name:
+          type: string
+          maxLength: 255
+          description: The name of the location
+          example: Brillobox
+        slug:
+          type: string
+          maxLength: 255
+          description: A unique identifier name for the series in kebab-case
+          example: brillobox-bar
+        address_line_one:
+          type: string
+          maxLength: 255
+          description: First line of the address
+          example: 100 East Street
+        address_line_two:
+          type: string
+          maxLength: 255
+          description: Second line of the address
+          example: Suite 9000
+        neighborhood:
+          type: string
+          maxLength: 255
+          description: Neighborhood the location is in
+          example: Bloomfield
+        city:
+          type: string
+          maxLength: 255
+          description: City of the location
+          example: Pittsburgh
+        state:
+          type: string
+          maxLength: 5
+          description: State of the location
+          example: Pittsburgh
+        postal_code:
+          type: string
+          maxLength: 15
+          description: Postal code of the location
+          example: 15224
+        country:
+          type: string
+          maxLength: 64
+          description: Country of the location
+          example: USA
+        latitude:
+          type: number
+          description: Latitude of the location
+          example: 0
+        longitude:
+          type: number
+          description: longitude of the location
+          example: 0
+        visibility_id:
+          type: integer
+          description: Type of visibility
+          example: 1
+        locatoin_type_id:
+          type: integer
+          description: Type of location
+          example: 1
+        map_url:
+          type: string
+          maxLength: 128
+          description: URL of the map location
+          example: USA
+        created_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the entity type was created
+          readOnly: true
+        updated_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the entity type was last updated
+          readOnly: true
+    Series:
+      type: object
+      required:
+        - id
+        - name
+        - slug
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          example: 1
+        name:
+          type: string
+          example: Lazercrunk, First Fridays of the Month
+          description: The cannonical name of the series
+          maxLength: 255
+        slug:
+          type: string
+          maxLength: 255
+          description: A unique identifier name for the series in kebab-case
+          example: lazercrunk-first-fridays-of-the-month
+        short:
+          type: string
+          example: a really fun monthly dj night featuring performers from around the world
+          description: A brief description of the series
+          maxLength: 255
+        visibility_id:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the visibility table that defines the visibility of series
+        description:
+          type: string
+          description: Full description of the series
+          example:
+            a really fun monthly dj night featuring performers from around the world and locally playing new electronic
+            music
+          maxLength: 65535
+        event_type_id:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the event type table that defines the type of series
+        occurrence_type_id:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the occurrence type table that defines the type of occurrence
+        occurrence_week_id:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the occurrence week table that defines the occurrence week of the month
+        occurrence_day_id:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the occurrence day table that defines the occurrence day of the week
+        hold_date:
+          type: boolean
+          description: Flag indicating that there is a request to hold this date open
+          example: true
+        promoter_id:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the entity table that defines the promoter for the series
+        venue_id:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the entity table that defines the venue for the series
+        is_benefit:
+          type: boolean
+          description: Flag indicating if the series is a benefit
+          example: true
+        attending:
+          description: The number of users who marked that they are attending the series
+          type: integer
+          example: 10
+        like:
+          description: The number of users who marked that they like the series
+          type: integer
+          example: 10
+        presale_price:
+          description: The price for a presale price for the series
+          type: number
+          example: 9.99
+        door_price:
+          description: The price of the show at the door
+          type: number
+          example: 19.99
+        soundcheck_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the series soundcheck is scheduled
+        door_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the series doors are scheduled to open
+        start_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the series starts
+        end_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the series ends
+        min_age:
+          description: The minimum age requirement for the series in years
+          type: integer
+          example: 21
+        primary_link:
+          type: string
+          description: The primary URL related to this series
+          example: http://lazercrunk.com/october-2022
+          maxLength: 255
+        ticket_link:
+          type: string
+          description: The URL for buying a ticket to the series
+          example: http://lazercrunk.com/october-2022/tickets
+          maxLength: 255
+        created_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the series was created
+        updated_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the series was last updated
+        cancelled_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the series was cancelled
+        created_by:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the user table that defines the user who created the series
+        updated_by:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the user table that defines the user who last updated the series
+    SeriesResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          example: 1
+        name:
+          type: string
+          example: Lazercrunk, First Fridays of the Month
+          description: The cannonical name of the series
+          maxLength: 255
+        slug:
+          type: string
+          maxLength: 255
+          description: A unique identifier name for the series in kebab-case
+          example: lazercrunk-first-fridays-of-the-month
+        short:
+          type: string
+          example: a really fun monthly dj night featuring performers from around the world
+          description: A brief description of the series
+          maxLength: 255
+        visibility:
+          $ref: "#/components/schemas/Visibility"
+        description:
+          type: string
+          description: Full description of the series
+          example:
+            a really fun monthly dj night featuring performers from around the world and locally playing new electronic
+            music
+          maxLength: 65535
+        event_type:
+          $ref: "#/components/schemas/EventType"
+        occurrence_type:
+          $ref: "#/components/schemas/OccurrenceType"
+        occurrence_week:
+          $ref: "#/components/schemas/OccurrenceWeek"
+        occurrence_day:
+          $ref: "#/components/schemas/OccurrenceDay"
+        hold_date:
+          type: boolean
+          description: Flag indicating that there is a request to hold this date open
+          example: true
+        promoter_id:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the entity table that defines the promoter of the series
+        venue_id:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the entity table that defines the venue for the series
+        is_benefit:
+          type: boolean
+          description: Flag indicating if the series is a benefit
+          example: true
+        attending:
+          description: The number of users who marked that they are attending the series
+          type: integer
+          example: 10
+        like:
+          description: The number of users who marked that they like the series
+          type: integer
+          example: 10
+        presale_price:
+          description: The price for a presale price for the series
+          type: number
+          example: 9.99
+        door_price:
+          description: The price of the show at the door
+          type: number
+          example: 19.99
+        soundcheck_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the series soundcheck is scheduled
+        door_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the series doors are scheduled to open
+        start_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the series starts
+        end_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the series starts
+        min_age:
+          description: The minimum age requirement for the series in years
+          type: integer
+          example: 21
+        primary_link:
+          type: string
+          description: The primary URL related to this series
+          example: http://lazercrunk.com/october-2022
+          maxLength: 255
+        ticket_link:
+          type: string
+          description: The URL for buying a ticket to the series
+          example: http://lazercrunk.com/october-2022/tickets
+          maxLength: 255
+        created_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the series was created
+        updated_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the series was last updated
+        cancelled_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the series was cancelled
+        created_by:
+          $ref: "#/components/schemas/UserSimple"
+        updated_by:
+          $ref: "#/components/schemas/UserSimple"
+    Seriess:
+      allOf:
+        - $ref: "#/components/schemas/Pagination"
+      type: object
+      properties:
+        data:
+          type: array
+          description: List of the current page of series
+          items:
+            $ref: "#/components/schemas/SeriesResponse"
+    Tag:
+      type: object
+      required:
+        - name
+        - tag_type_id
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          example: 1
+        name:
+          type: string
+          description: Name of the tag
+          example: post punk
+          maxLength: 255
+        slug:
+          type: string
+          maxLength: 255
+          description: A unique identifier name for the tag in kebab-case
+          example: post-punk
+        tag_type_id:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the tag type table that defines the type of tag
+        created_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the tag was created
+          readOnly: true
+        updated_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the tag was last updated
+          readOnly: true
+    Tags:
+      allOf:
+        - $ref: "#/components/schemas/Pagination"
+        - type: object
+          properties:
+            data:
+              type: array
+              items:
+                $ref: "#/components/schemas/Tag"
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          example: 1
+        name:
+          type: string
+          description: Name of the user
+          example: john.smith
+          maxLength: 255
+        password:
+          type: string
+          description: Encrypted password of the user
+          example: abcdefg
+          maxLength: 60
+        email:
+          type: string
+          description: Email address of the user
+          example: john.smith@gmail.com
+          maxLength: 255
+        user_status_id:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the user status table that defines the status of the user
+        remember_token:
+          type: string
+          description: Token used to remember the user's logged in status
+          example: ABCDEFGHI
+          maxLength: 100
+        email_verified_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the user's email was verified
+          readOnly: true
+        created_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the user was created
+          readOnly: true
+        updated_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the user was last updated
+          readOnly: true
+    UserSimple:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          example: 1
+        name:
+          type: string
+          description: Name of the user
+          example: john.smith
+          maxLength: 255
+        email:
+          type: string
+          description: Email address of the user
+          example: john.smith@gmail.com
+          maxLength: 255
+    UserResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          example: 1
+        name:
+          type: string
+          description: Name of the user
+          example: john.smith
+          maxLength: 255
+        password:
+          type: string
+          description: Encrypted password of the user
+          example: abcdefg
+          maxLength: 60
+        email:
+          type: string
+          description: Email address of the user
+          example: john.smith@gmail.com
+          maxLength: 255
+        user_status_id:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the user status table that defines the status of the user
+        remember_token:
+          type: string
+          description: Token used to remember the user's logged in status
+          example: ABCDEFGHI
+          maxLength: 100
+        email_verified_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the user's email was verified
+          readOnly: true
+        created_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the user was created
+          readOnly: true
+        updated_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the user was last updated
+          readOnly: true
+    UserRequest:
+      type: object
+      required:
+        - name
+        - email
+        - password
+      properties:
+        name:
+          type: string
+          description: Name of the user
+          example: john.smith
+          maxLength: 255
+        password:
+          type: string
+          description: Encrypted password of the user
+          example: abcdefg
+          maxLength: 60
+        email:
+          type: string
+          description: Email address of the user
+          example: john.smith@gmail.com
+          maxLength: 255
+        user_status_id:
+          type: integer
+          readOnly: true
+          example: 1
+          description: Relation to the user status table that defines the status of the user
+        remember_token:
+          type: string
+          description: Token used to remember the user's logged in status
+          example: ABCDEFGHI
+          maxLength: 100
+    Users:
+      allOf:
+        - $ref: "#/components/schemas/Pagination"
+        - type: object
+          properties:
+            data:
+              type: array
+              items:
+                $ref: "#/components/schemas/UserResponse"
+    UserTokenResponse:
+      type: object
+      properties:
+        token:
+          type: string
+          description: Valid user token
+          example: ABCDEF12345
+          maxLength: 255
+    Visibility:
+      type: object
+      required:
+        - name
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          example: 1
+        name:
+          type: string
+          example: Public
+        created_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the visibility was created
+          readOnly: true
+        updated_at:
+          type: string
+          example: 2018-03-20T09:12:28Z
+          format: date-time
+          description: Date and time that the visibility was last updated
+          readOnly: true
+    Error:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          description: A human readable error message
+          type: string
+    Pagination:
+      type: object
+      properties:
+        current_page:
+          description: The current page in the paginated list
+          type: integer
+        first_page_url:
+          description: URL for the first page
+          type: string
+          example: https://dev.arcane.city/api/resources?page=1
+        from:
+          description: First element in the current page
+          type: integer
+          example: 1
+        last_page:
+          description: Last page of results
+          type: integer
+          example: 1
+        last_page_url:
+          description: URL for the first page
+          type: string
+          example: https://dev.arcane.city/api/resources?page=100
+        links:
+          description: Array of links used to paginate the list of entities
+          type: array
+          items: {}
+        next_page_url:
+          description: URL for the next page
+          type: string
+          example: https://dev.arcane.city/api/resources?page=2
+        path:
+          description: Path for the primary route
+          type: string
+          example: https://dev.arcane.city/api/resources
+        per_page:
+          description: Number of results per page
+          type: integer
+          example: 25
+        prev_page_url:
+          description: URL for the previous page
+          type: string
+          example: https://dev.arcane.city/api/resources?page=0
+        to:
+          description: Last element in the current page
+          type: integer
+          example: 25
+        total:
+          description: Total number of results from the request
+          type: integer
+          example: 100
+        data:
+          description: List of the current page of the paginated entity
+          type: array
+          items: {}
+security:
+  - basicAuth: []
+paths:
+  /api/events:
+    post:
+      tags:
+        - events
+      summary: Create Event
+      operationId: getCreateEvent
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EventRequest"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventResponse"
+        "201":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventResponse"
+        "500":
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    get:
+      tags:
+        - events
+      summary: Get Events
+      operationId: getEvents
+      parameters:
+        - name: filters[name]
+          in: query
+          required: false
+          description: A filter query of the event name
+          schema:
+            type: string
+            example: Lazercrunk
+        - name: filters[venue]
+          in: query
+          required: false
+          description: A filter query of the venue name
+          schema:
+            type: string
+            example: Brillobox
+        - name: filters[promoter]
+          in: query
+          required: false
+          description: A filter query of the promoter name
+          schema:
+            type: string
+            example: Cutups
+        - name: filters[related]
+          in: query
+          required: false
+          description: A filter query of related entity name
+          schema:
+            type: string
+            example: 0h85
+        - name: filters[series]
+          in: query
+          required: false
+          description: A filter query of related series name
+          schema:
+            type: string
+            example: Lazercrunk
+        - name: filters[event_type]
+          in: query
+          required: false
+          description: A filter query of related event type name
+          schema:
+            type: string
+            example: Concert
+        - name: filters[start_at][start]
+          in: query
+          required: false
+          description: A filter query of the start time starting
+          schema:
+            type: string
+            example: 2022-01-01 1:00:00
+        - name: filters[start_at][end]
+          in: query
+          required: false
+          description: A filter query of the start time ending
+          schema:
+            type: string
+            example: 2022-02-01 2:00:00
+        - name: filters[end_at][start]
+          in: query
+          required: false
+          description: A filter query of the end time starting
+          schema:
+            type: string
+            example: 2022-02-01 1:00:00
+        - name: filters[end_at][end]
+          in: query
+          required: false
+          description: A filter query of the end time ending
+          schema:
+            type: string
+            example: 2022-01-01 2:00:00
+        - name: filters[ages]
+          in: query
+          required: false
+          description: A filter query of the end time ending
+          schema:
+            type: integer
+            example: 21
+        - name: filters[tag]
+          in: query
+          required: false
+          description: A filter query of the event tags
+          schema:
+            type: string
+            example: electronic
+        - name: limit
+          in: query
+          required: false
+          description: The limit on the number of results to return per page
+          schema:
+            type: integer
+            example: 25
+        - name: page
+          in: query
+          required: false
+          description: The page number to return
+          schema:
+            type: integer
+            example: 1
+        - name: sort
+          in: query
+          required: false
+          description: A column to be used to sort the query
+          schema:
+            type: string
+            example: name
+        - name: direction
+          in: query
+          required: false
+          description: A string indicating the sort direction of the query (asc or desc)
+          schema:
+            type: string
+            example: asc
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Events"
+  /api/events/{slug}:
+    get:
+      parameters:
+        - name: slug
+          description: The unique identifier of the entity
+          in: path
+          required: true
+          schema:
+            type: string
+            example: cutups-event
+      tags:
+        - events
+      summary: Get Event
+      operationId: getEventById
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventResponse"
+    put:
+      parameters:
+        - name: slug
+          description: A unique string identifier of the event
+          in: path
+          required: true
+          schema:
+            type: string
+            readOnly: true
+            example: cutups-event
+      tags:
+        - events
+      summary: Update Events
+      operationId: updateEventById
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EventRequest"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventResponse"
+  /api/events/{slug}/photos:
+    get:
+      parameters:
+        - name: slug
+          description: The unique identifier of the entity
+          in: path
+          required: true
+          schema:
+            type: string
+            readOnly: true
+            example: strobe
+      tags:
+        - events
+      summary: Get Events Photos
+      operationId: getEventPhotosBySlug
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Photos"
+  /api/events/{slug}/all-photos:
+    get:
+      parameters:
+        - name: slug
+          description: The unique identifier of the event
+          in: path
+          required: true
+          schema:
+            type: string
+            readOnly: true
+            example: strobe
+      tags:
+        - events
+      summary: Get All Related Events Photos
+      operationId: getAllEventPhotosBySlug
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Photos"
+  /api/events/{id}/photos:
+    post:
+      parameters:
+        - name: id
+          description: The unique identifier of the event
+          in: path
+          required: true
+          schema:
+            type: integer
+            readOnly: true
+            example: 1
+      tags:
+        - events
+      summary: Add Event Photo
+      operationId: addEventPhotoById
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        "201":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PhotoResponse"
+  /api/entities:
+    post:
+      tags:
+        - entities
+      summary: Create Entity
+      operationId: createEntity
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EntityRequest"
+      responses:
+        "201":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EntityResponse"
+    get:
+      tags:
+        - entities
+      summary: Get Entities
+      operationId: getEntities
+      parameters:
+        - name: filters[name]
+          in: query
+          required: false
+          description: A filter query of the entity name
+          schema:
+            type: string
+            example: cutups
+        - name: filters[role]
+          in: query
+          required: false
+          description: A filter query of the role name
+          schema:
+            type: string
+            example: dj
+        - name: filters[tag]
+          in: query
+          required: false
+          description: A filter query of related tag
+          schema:
+            type: string
+            example: jungle
+        - name: filters[entity_status]
+          in: query
+          required: false
+          description: A filter query of related entity status name
+          schema:
+            type: string
+            example: Active
+        - name: filters[entity_type]
+          in: query
+          required: false
+          description: A filter query of related entity type name
+          schema:
+            type: string
+            example: Individual
+        - name: limit
+          in: query
+          required: false
+          description: The limit on the number of results to return per page
+          schema:
+            type: integer
+            example: 25
+        - name: page
+          in: query
+          required: false
+          description: The page number to return
+          schema:
+            type: integer
+            example: 1
+        - name: sort
+          in: query
+          required: false
+          description: A column to be used to sort the query
+          schema:
+            type: string
+            example: name
+        - name: direction
+          in: query
+          required: false
+          description: A string indicating the sort direction of the query (asc or desc)
+          schema:
+            type: string
+            example: asc
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Entities"
+  /api/entities/{slug}:
+    get:
+      parameters:
+        - name: slug
+          description: The unique identifier of the entity
+          in: path
+          required: true
+          schema:
+            type: string
+          example: cutups
+      tags:
+        - entities
+      summary: Get Entity
+      operationId: getEntityBySlug
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EntityResponse"
+    put:
+      parameters:
+        - name: slug
+          description: The unique identifier of the entity
+          in: path
+          required: true
+          schema:
+            type: string
+            example: cutups
+      tags:
+        - entities
+      summary: Update Entity
+      operationId: updateEntityBySlug
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EntityRequest"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EntityResponse"
+  /api/entities/{slug}/photos:
+    get:
+      parameters:
+        - name: slug
+          description: The unique identifier of the entity
+          in: path
+          required: true
+          schema:
+            type: string
+            readOnly: true
+            example: strobe
+      tags:
+        - entities
+      summary: Get Entity Photos
+      operationId: getEntityPhotosBySlug
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Photos"
+  /api/entities/{id}/photos:
+    post:
+      parameters:
+        - name: id
+          description: The unique identifier of the entity
+          in: path
+          required: true
+          schema:
+            type: integer
+            readOnly: true
+            example: 1
+      tags:
+        - entities
+      summary: Add Entity Photo
+      operationId: addEntityPhotoById
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        "201":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PhotoResponse"
+  /api/entity-types:
+    get:
+      tags:
+        - entity-types
+      summary: Get Entity Types
+      operationId: updateEntityTypes
+      parameters:
+        - name: filters[name]
+          in: query
+          required: false
+          description: A filter query of the entity status name
+          schema:
+            type: string
+            example: Group
+        - name: limit
+          in: query
+          required: false
+          description: The limit on the number of results to return per page
+          schema:
+            type: integer
+            example: 25
+        - name: page
+          in: query
+          required: false
+          description: The page number to return
+          schema:
+            type: integer
+            example: 1
+        - name: sort
+          in: query
+          required: false
+          description: A column to be used to sort the query
+          schema:
+            type: string
+            example: name
+        - name: direction
+          in: query
+          required: false
+          description: A string indicating the sort direction of the query (asc or desc)
+          schema:
+            type: string
+            example: asc
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pagination"
+    post:
+      tags:
+        - entity-types
+      summary: Create entity type
+      operationId: createEntityType
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EntityType"
+      responses:
+        "201":
+          description: Successful response
+          content:
+            application/json: {}
+  /api/entity-types/{entityTypeId}:
+    parameters:
+      - name: entityTypeId
+        description: The unique identifier of the entity type
+        in: path
+        required: true
+        schema:
+          type: integer
+          readOnly: true
+          example: 1
+    get:
+      tags:
+        - entity-types
+      summary: Get EntityType
+      operationId: getEntityTypeById
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EntityType"
+    put:
+      tags:
+        - entity-types
+      summary: Update Entity Type
+      operationId: updateEntityTypeById
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EntityType"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EntityType"
+  /api/event-types:
+    get:
+      tags:
+        - event-types
+      summary: Get Event Types
+      operationId: updateEventTypes
+      parameters:
+        - name: filters[name]
+          in: query
+          required: false
+          description: A filter query of the event status name
+          schema:
+            type: string
+            example: Concert
+        - name: limit
+          in: query
+          required: false
+          description: The limit on the number of results to return per page
+          schema:
+            type: integer
+            example: 25
+        - name: page
+          in: query
+          required: false
+          description: The page number to return
+          schema:
+            type: integer
+            example: 1
+        - name: sort
+          in: query
+          required: false
+          description: A column to be used to sort the query
+          schema:
+            type: string
+            example: name
+        - name: direction
+          in: query
+          required: false
+          description: A string indicating the sort direction of the query (asc or desc)
+          schema:
+            type: string
+            example: asc
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventTypes"
+    post:
+      tags:
+        - event-types
+      summary: Create event type
+      operationId: createEventType
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EventType"
+      responses:
+        "201":
+          description: Successful response
+          content:
+            application/json: {}
+  /api/event-types/{eventTypeId}:
+    parameters:
+      - name: eventTypeId
+        description: The unique identifier of the event type
+        in: path
+        required: true
+        schema:
+          type: integer
+          readOnly: true
+          example: 1
+    get:
+      tags:
+        - event-types
+      summary: Get EventType
+      operationId: getEventTypeById
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventType"
+    put:
+      tags:
+        - event-types
+      summary: Update Event Type
+      operationId: updateEventTypeById
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EventType"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventType"
+  /api/tags:
+    post:
+      tags:
+        - tags
+      summary: Create Tag
+      operationId: createTag
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Tag"
+      responses:
+        "201":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Tag"
+    get:
+      tags:
+        - tags
+      summary: Get Tags
+      operationId: getTags
+      parameters:
+        - name: filters[name]
+          in: query
+          schema:
+            type: string
+            example: techno
+        - name: limit
+          in: query
+          required: false
+          description: The limit on the number of results to return per page
+          schema:
+            type: integer
+            example: 25
+        - name: page
+          in: query
+          required: false
+          description: The page number to return
+          schema:
+            type: integer
+            example: 1
+        - name: sort
+          in: query
+          required: false
+          description: A column to be used to sort the query
+          schema:
+            type: string
+            example: name
+        - name: direction
+          in: query
+          required: false
+          description: A string indicating the sort direction of the query (asc or desc)
+          schema:
+            type: string
+            example: asc
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Tags"
+  /api/tags/{tagId}:
+    parameters:
+      - name: tagId
+        description: The unique identifier of the tag
+        in: path
+        required: true
+        schema:
+          type: integer
+          readOnly: true
+          example: 1
+    get:
+      tags:
+        - tags
+      summary: Get one Tag
+      operationId: getTagById
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Tag"
+    put:
+      tags:
+        - tags
+      summary: Update Tag
+      operationId: updateTagById
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Tag"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json: {}
+  /api/tokens/create:
+    post:
+      tags:
+        - users
+      summary: Create User Bearer Token
+      operationId: createUserBearerToken
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserTokenResponse"
+  /api/tokens/validate:
+    get:
+      tags:
+        - users
+      summary: Validate User Token
+      operationId: validateUserToken
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: string
+                    description: Valid user token
+                    example: ABCDEF12345
+  /api/users:
+    post:
+      tags:
+        - users
+      summary: Create User
+      operationId: createUser
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UserRequest"
+      responses:
+        "201":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserResponse"
+    get:
+      tags:
+        - users
+      summary: Get Users
+      operationId: getUsers
+      parameters:
+        - name: filters[status]
+          in: query
+          required: false
+          description: A filter query of the user status
+          schema:
+            type: string
+            example: Active
+        - name: filters[name]
+          in: query
+          required: false
+          description: A filter query of the user name
+          schema:
+            type: string
+            example: Geoff
+        - name: filters[email]
+          in: query
+          required: false
+          description: A filter query of the user email
+          schema:
+            type: string
+            example: geoff.maddock@gmail.com
+        - name: limit
+          in: query
+          required: false
+          description: The limit on the number of results to return per page
+          schema:
+            type: integer
+            example: 25
+        - name: page
+          in: query
+          required: false
+          description: The page number to return
+          schema:
+            type: integer
+            example: 1
+        - name: sort
+          in: query
+          required: false
+          description: A column to be used to sort the query
+          schema:
+            type: string
+            example: name
+        - name: direction
+          in: query
+          required: false
+          description: A string indicating the sort direction of the query (asc or desc)
+          schema:
+            type: string
+            example: asc
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Users"
+  /api/users/{userId}:
+    parameters:
+      - name: userId
+        description: The unique identifier of the user
+        in: path
+        required: true
+        schema:
+          type: integer
+          readOnly: true
+          example: 1
+    get:
+      tags:
+        - users
+      summary: Get one User by id
+      operationId: getUserById
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserResponse"
+    put:
+      tags:
+        - users
+      summary: Update User
+      operationId: updateUserById
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/User"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserResponse"


### PR DESCRIPTION
## Summary
- add `MinimalResource` for trimming nested output
- use `MinimalResource` from `EventResource`
- update `EventCollection` to return each event as `EventResource`
- eager load required relations in `EventsController`

## Testing
- `composer run-script phpstan` *(fails: composer not found)*
- `composer run-script tests` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a44f366a08322a44ad5ae7ab67dc4