### PR TITLE
Limit depth of API resource relationships

### DIFF
--- a/app/Http/Controllers/Api/EntitiesController.php
+++ b/app/Http/Controllers/Api/EntitiesController.php
@@ -640,7 +640,7 @@ class EntitiesController extends Controller
         // add to activity log
         Activity::log($entity, $this->user, 2);
 
-        return response()->json($entity);
+        return response()->json(new EntityResource($entity));
     }
 
     /**

--- a/app/Http/Controllers/Api/SeriesController.php
+++ b/app/Http/Controllers/Api/SeriesController.php
@@ -730,7 +730,7 @@ class SeriesController extends Controller
         // flash('Success', 'Your event template has been updated');
 
         //return redirect('series');
-        return response()->json($series);
+        return response()->json(new SeriesResource($series));
     }
 
     protected function unauthorized(SeriesRequest $request): RedirectResponse | Response

--- a/app/Http/Resources/EntityCollection.php
+++ b/app/Http/Resources/EntityCollection.php
@@ -3,7 +3,8 @@
 namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\ResourceCollection;
-use \Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use App\Http\Resources\EntityResource;
 
 /**
  * @mixin \Illuminate\Contracts\Pagination\LengthAwarePaginator
@@ -20,7 +21,7 @@ class EntityCollection extends ResourceCollection
     {
         return [
             'current_page' => $this->currentPage(),
-            'data' => $this->collection->toArray(),
+            'data' => EntityResource::collection($this->collection)->resolve(),
             'first_page_url' => $this->url(1),
             'from' => $this->firstItem(),
             'last_page' => $this->lastPage(),

--- a/app/Http/Resources/EntityResource.php
+++ b/app/Http/Resources/EntityResource.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 use App\Models\Entity;
+use App\Http\Resources\MinimalResource;
 
 /**
  * @mixin \App\Models\Entity
@@ -19,27 +20,35 @@ class EntityResource extends JsonResource
     public function toArray($request)
     {
         return [
-        'id' => $this->id,
-        'name' => $this->name,
-        'slug' => $this->slug,
-        'short' => $this->short,
-        'description' => $this->description,
-        'entity_status' => $this->entityStatus,
-        'entity_type' => $this->entityType,
-        'facebook_username' => $this->facebook_username,
-        'twitter_username' => $this->twitter_username,
-        'started_at' => $this->started_at,
-        'links' => $this->links,
-        'tags' => $this->tags,
-        'roles' => $this->roles,
-        'created_by' => $this->created_by,
-        'updated_by' => $this->updated_by,
-        'created_at' => $this->created_at,
-        'updated_at' => $this->updated_at,
-        'primary_photo' => $this->getPrimaryPhotoPath(),
-        'primary_photo_thumbnail' => $this->getPrimaryPhotoThumbnailPath(),
-        'primary_location' => $this->getPrimaryLocation(),
-        'photos' => $this->photos->map(function ($photo) {
+            'id' => $this->id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'short' => $this->short,
+            'description' => $this->description,
+            'entity_status' => $this->entityStatus ? new MinimalResource($this->entityStatus) : null,
+            'entity_type' => $this->entityType ? new MinimalResource($this->entityType) : null,
+            'facebook_username' => $this->facebook_username,
+            'twitter_username' => $this->twitter_username,
+            'started_at' => $this->started_at,
+            'links' => $this->links->map(function ($link) {
+                return [
+                    'id' => $link->id,
+                    'text' => $link->text,
+                    'url' => $link->url,
+                    'title' => $link->title,
+                    'is_primary' => $link->is_primary,
+                ];
+            })->toArray(),
+            'tags' => MinimalResource::collection($this->tags)->resolve(),
+            'roles' => MinimalResource::collection($this->roles)->resolve(),
+            'created_by' => $this->created_by,
+            'updated_by' => $this->updated_by,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+            'primary_photo' => $this->getPrimaryPhotoPath(),
+            'primary_photo_thumbnail' => $this->getPrimaryPhotoThumbnailPath(),
+            'primary_location' => $this->getPrimaryLocation(),
+            'photos' => $this->photos->map(function ($photo) {
                 return [
                     'id' => $photo->id,
                     'path' => $photo->getPath(),

--- a/app/Http/Resources/SeriesCollection.php
+++ b/app/Http/Resources/SeriesCollection.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\ResourceCollection;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use App\Http\Resources\SeriesResource;
 
 /**
  * @mixin \Illuminate\Contracts\Pagination\LengthAwarePaginator
@@ -20,7 +21,7 @@ class SeriesCollection extends ResourceCollection
     {
         return [
             'current_page' => $this->currentPage(),
-            'data' => $this->collection->toArray(),
+            'data' => SeriesResource::collection($this->collection)->resolve(),
             'first_page_url' => $this->url(1),
             'from' => $this->firstItem(),
             'last_page' => $this->lastPage(),

--- a/app/Http/Resources/SeriesResource.php
+++ b/app/Http/Resources/SeriesResource.php
@@ -31,7 +31,7 @@ class SeriesResource extends JsonResource
             'occurrence_type' => $this->occurrenceType ? new MinimalResource($this->occurrenceType) : null,
             'occurrence_week' => $this->occurrenceWeek ? new MinimalResource($this->occurrenceWeek) : null,
             'occurrence_day' => $this->occurrenceDay ? new MinimalResource($this->occurrenceDay) : null,
-            'occurrence_repeat' => $this->occurrenceRepeat ? new MinimalResource($this->occurrenceRepeat) : null,
+            'occurrence_repeat' => $this->occurrenceRepeat,
             'is_benefit' => $this->is_benefit,
             'promoter' => $this->promoter ? new MinimalResource($this->promoter) : null,
             'venue' => $this->venue ? new MinimalResource($this->venue) : null,

--- a/app/Http/Resources/SeriesResource.php
+++ b/app/Http/Resources/SeriesResource.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 use App\Models\Series;
+use App\Http\Resources\MinimalResource;
 
 /**
  * @mixin \App\Models\Series
@@ -23,17 +24,17 @@ class SeriesResource extends JsonResource
             'name' => $this->name,
             'slug' => $this->slug,
             'short' => $this->short,
-            'visibility' => $this->visibility,
+            'visibility' => $this->visibility ? new MinimalResource($this->visibility) : null,
             'description' => $this->description,
-            'event_status' => $this->eventStatus,
-            'event_type' => $this->eventType,
-            'occurrence_type' => $this->occurrenceType,
-            'occurrence_week' => $this->occurrenceWeek,
-            'occurrence_day' => $this->occurrenceDay,
-            'occurrence_repeat' => $this->occurrenceRepeat,
+            'event_status' => $this->eventStatus ? new MinimalResource($this->eventStatus) : null,
+            'event_type' => $this->eventType ? new MinimalResource($this->eventType) : null,
+            'occurrence_type' => $this->occurrenceType ? new MinimalResource($this->occurrenceType) : null,
+            'occurrence_week' => $this->occurrenceWeek ? new MinimalResource($this->occurrenceWeek) : null,
+            'occurrence_day' => $this->occurrenceDay ? new MinimalResource($this->occurrenceDay) : null,
+            'occurrence_repeat' => $this->occurrenceRepeat ? new MinimalResource($this->occurrenceRepeat) : null,
             'is_benefit' => $this->is_benefit,
-            'promoter' => $this->promoter,
-            'venue' => $this->venue,
+            'promoter' => $this->promoter ? new MinimalResource($this->promoter) : null,
+            'venue' => $this->venue ? new MinimalResource($this->venue) : null,
             'attending' => $this->attending,
             'like' => $this->like,
             'presale_price' => $this->presale_price,
@@ -45,8 +46,8 @@ class SeriesResource extends JsonResource
             'min_age' => $this->min_age,
             'primary_link' => $this->primary_link,
             'ticket_link' => $this->ticket_link,
-            'tags' => $this->tags,
-            'entities' => $this->entities,
+            'tags' => MinimalResource::collection($this->tags)->resolve(),
+            'entities' => MinimalResource::collection($this->entities)->resolve(),
             'created_by' => $this->created_by,
             'updated_by' => $this->updated_by,
             'created_at' => $this->created_at,


### PR DESCRIPTION
## Summary
- trim relationship data in `EntityResource` and `SeriesResource`
- use resource classes in collection responses
- return resources from entity and series updates

## Testing
- `composer phpstan` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a4b5fecd0832283547db4541f2518