### PR TITLE
Add visibility API endpoints

### DIFF
--- a/app/Filters/VisibilityFilters.php
+++ b/app/Filters/VisibilityFilters.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Filters;
+
+use Illuminate\Database\Eloquent\Builder;
+
+class VisibilityFilters extends QueryFilter
+{
+    public function name(?string $value = null): Builder
+    {
+        if (isset($value)) {
+            return $this->builder->where('name', 'like', '%'.$value.'%');
+        }
+
+        return $this->builder;
+    }
+}

--- a/app/Http/Controllers/Api/VisibilitiesController.php
+++ b/app/Http/Controllers/Api/VisibilitiesController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Filters\VisibilityFilters;
+use App\Http\Controllers\Controller;
+use App\Http\ResultBuilder\ListEntityResultBuilder;
+use App\Models\Visibility;
+use App\Services\SessionStore\ListParameterSessionStore;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class VisibilitiesController extends Controller
+{
+    protected VisibilityFilters $filter;
+
+    public function __construct(VisibilityFilters $filter)
+    {
+        $this->filter = $filter;
+        parent::__construct();
+    }
+
+    public function index(
+        Request $request,
+        ListParameterSessionStore $listParamSessionStore,
+        ListEntityResultBuilder $listEntityResultBuilder
+    ): JsonResponse {
+        $listParamSessionStore->setBaseIndex('internal_visibility');
+        $listParamSessionStore->setKeyPrefix('internal_visibility_index');
+
+        $baseQuery = Visibility::query()->select('visibilities.*');
+
+        $listEntityResultBuilder
+            ->setFilter($this->filter)
+            ->setQueryBuilder($baseQuery)
+            ->setDefaultSort(['visibilities.name' => 'asc']);
+
+        $listResultSet = $listEntityResultBuilder->listResultSetFactory();
+        $query = $listResultSet->getList();
+        $visibilities = $query->paginate($listResultSet->getLimit());
+
+        return response()->json($visibilities);
+    }
+
+    public function filter(
+        Request $request,
+        ListParameterSessionStore $listParamSessionStore,
+        ListEntityResultBuilder $listEntityResultBuilder
+    ): JsonResponse {
+        return $this->index($request, $listParamSessionStore, $listEntityResultBuilder);
+    }
+
+    public function show(Visibility $visibility): JsonResponse
+    {
+        return response()->json($visibility);
+    }
+}

--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -29,6 +29,7 @@ tags:
   - name: tags
   - name: threads
   - name: users
+  - name: visibilities
 components:
   responses:
     NotFound:
@@ -1926,6 +1927,15 @@ components:
           format: date-time
           description: Date and time that the visibility was last updated
           readOnly: true
+    Visibilities:
+      allOf: [$ref: "#/components/schemas/Pagination"]
+      type: object
+      properties:
+        data:
+          type: array
+          description: List of the current page of visibilities
+          items:
+            "$ref": "#/components/schemas/Visibility"
     Error:
       type: object
       required:
@@ -4387,3 +4397,74 @@ paths:
           description: Successful response
           content:
             application/json: {}
+  /api/visibilities:
+    get:
+      tags:
+        - visibilities
+      summary: Get Visibilities
+      operationId: getVisibilities
+      parameters:
+        - name: filters[name]
+          in: query
+          required: false
+          description: A filter query of the visibility name
+          schema:
+            type: string
+            example: Public
+        - name: limit
+          in: query
+          required: false
+          description: The limit on the number of results to return per page
+          schema:
+            type: integer
+            example: 25
+        - name: page
+          in: query
+          required: false
+          description: The page number to return
+          schema:
+            type: integer
+            example: 1
+        - name: sort
+          in: query
+          required: false
+          description: A column to be used to sort the query
+          schema:
+            type: string
+            example: name
+        - name: direction
+          in: query
+          required: false
+          description: A string indicating the sort direction of the query (asc or desc)
+          schema:
+            type: string
+            example: asc
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Visibilities"
+  /api/visibilities/{visibilityId}:
+    parameters:
+      - name: visibilityId
+        description: The unique identifier of the visibility
+        in: path
+        required: true
+        schema:
+          type: integer
+          readOnly: true
+          example: 1
+    get:
+      tags:
+        - visibilities
+      summary: Get Visibility
+      operationId: getVisibilityById
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Visibility"

--- a/public/postman/schemas/minimal-api.yml
+++ b/public/postman/schemas/minimal-api.yml
@@ -24,6 +24,7 @@ tags:
   - name: tags
   - name: threads
   - name: users
+  - name: visibilities
 components:
   responses:
     NotFound:
@@ -1475,6 +1476,15 @@ components:
           format: date-time
           description: Date and time that the visibility was last updated
           readOnly: true
+    Visibilities:
+      allOf: [$ref: "#/components/schemas/Pagination"]
+      type: object
+      properties:
+        data:
+          type: array
+          description: List of the current page of visibilities
+          items:
+            "$ref": "#/components/schemas/Visibility"
     Error:
       type: object
       required:
@@ -2244,6 +2254,61 @@ paths:
           description: Successful response
           content:
             application/json: {}
+  /api/visibilities:
+    get:
+      tags:
+        - visibilities
+      summary: Get Visibilities
+      operationId: getVisibilities
+      parameters:
+        - name: filters[name]
+          in: query
+          schema:
+            type: string
+          example: Public
+        - name: sort
+          in: query
+          required: false
+          description: A column to be used to sort the query
+          schema:
+            type: string
+            example: name
+        - name: direction
+          in: query
+          required: false
+          description: A string indicating the sort direction of the query (asc or desc)
+          schema:
+            type: string
+            example: asc
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Visibilities"
+  /api/visibilities/{visibilityId}:
+    get:
+      parameters:
+        - name: visibilityId
+          description: The unique identifier of the visibility
+          in: path
+          required: true
+          schema:
+            type: integer
+            readOnly: true
+            example: 1
+      tags:
+        - visibilities
+      summary: Get Visibility by ID
+      operationId: getVisibilityById
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Visibility"
   /api/docs:
     get:
       tags:

--- a/routes/api.php
+++ b/routes/api.php
@@ -137,6 +137,9 @@ Route::middleware('auth.either')->name('api.')->group(function () {
     Route::get('users/reset', ['as' => 'users.reset', 'uses' => 'Api\UsersController@reset']);
     Route::get('users/rpp-reset', ['as' => 'users.rppReset', 'uses' => 'Api\UsersController@rppReset']);
     Route::resource('users', 'Api\UsersController');
+
+    Route::match(['get', 'post'], 'visibilities/filter', ['as' => 'visibilities.filter', 'uses' => 'Api\VisibilitiesController@filter']);
+    Route::resource('visibilities', 'Api\VisibilitiesController')->only(['index', 'show']);
 });
 
 // routes protected by the shield middleware

--- a/tests/Feature/ApiVisibilitiesTest.php
+++ b/tests/Feature/ApiVisibilitiesTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Visibility;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ApiVisibilitiesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    public function testIndexEndpoint()
+    {
+        $user = User::factory()->create(['user_status_id' => 1]);
+        $this->actingAs($user);
+
+        Visibility::factory()->count(3)->create();
+
+        $response = $this->getJson('/api/visibilities');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'current_page',
+                'data',
+                'first_page_url',
+                'from',
+                'last_page',
+                'last_page_url',
+                'next_page_url',
+                'path',
+                'per_page',
+                'prev_page_url',
+                'to',
+                'total',
+            ]);
+    }
+
+    public function testShowEndpoint()
+    {
+        $user = User::factory()->create(['user_status_id' => 1]);
+        $this->actingAs($user);
+
+        $visibility = Visibility::factory()->create(['name' => 'Public']);
+
+        $response = $this->getJson('/api/visibilities/' . $visibility->id);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'id' => $visibility->id,
+                'name' => 'Public',
+            ]);
+    }
+
+    public function testFilterEndpoint()
+    {
+        $user = User::factory()->create(['user_status_id' => 1]);
+        $this->actingAs($user);
+
+        Visibility::factory()->create(['name' => 'Private']);
+        $target = Visibility::factory()->create(['name' => 'Public']);
+
+        $response = $this->getJson('/api/visibilities/filter?name=Public');
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['name' => 'Public'])
+            ->assertJsonMissing(['name' => 'Private']);
+    }
+}

--- a/tests/Feature/ApiVisibilitiesTest.php
+++ b/tests/Feature/ApiVisibilitiesTest.php
@@ -63,7 +63,7 @@ class ApiVisibilitiesTest extends TestCase
         Visibility::factory()->create(['name' => 'Private']);
         $target = Visibility::factory()->create(['name' => 'Public']);
 
-        $response = $this->getJson('/api/visibilities/filter?name=Public');
+        $response = $this->getJson('/api/visibilities?filters[name]=Public');
 
         $response->assertStatus(200)
             ->assertJsonFragment(['name' => 'Public'])


### PR DESCRIPTION
## Summary
- add `VisibilityFilters`
- add `VisibilitiesController` with index, filter, and show endpoints
- add API routes for visibilities
- test API endpoints for visibilities
- document visibility endpoints in OpenAPI spec

## Testing
- `composer test` *(fails: composer not found)*
- `./vendor/bin/phpunit tests/Feature/ApiVisibilitiesTest.php` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685b41e969bc8322ab32aa1c040abe1c