### PR TITLE
Add /api/auth/me endpoint

### DIFF
--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -4299,6 +4299,19 @@ paths:
                     type: string
                     description: Valid user token
                     example: ABCDEF12345
+  /api/auth/me:
+    get:
+      tags:
+        - users
+      summary: Get Authenticated User
+      operationId: getAuthenticatedUser
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserResponse"
   /api/users:
     post:
       tags:

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 use Illuminate\Support\Facades\Route;
 use Illuminate\Http\Request;
+use App\Http\Resources\UserResource;
 
 Route::group(['middleware' => ['auth:sanctum']], function () {
     // validate the token
@@ -29,6 +30,10 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
 
 Route::middleware('auth:sanctum')->get('tokens/test', function (Request $request) {
     return ['data' => 'token test'];
+});
+
+Route::middleware('auth:sanctum')->get('auth/me', function (Request $request) {
+    return response()->json(new UserResource($request->user()));
 });
 
 


### PR DESCRIPTION
## Summary
- expose authenticated user info via a new API endpoint
- document the endpoint in the OpenAPI schema

## Testing
- `composer run-script phpstan` *(fails: composer not installed)*
- `composer run-script tests` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68654ee236e88322be011ab55e375d6f