### PR TITLE
Add menus API endpoints and documentation

### DIFF
--- a/app/Http/Controllers/Api/MenusController.php
+++ b/app/Http/Controllers/Api/MenusController.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Filters\MenuFilters;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\MenuRequest;
+use App\Http\Resources\MenuCollection;
+use App\Http\Resources\MenuResource;
+use App\Http\ResultBuilder\ListEntityResultBuilder;
+use App\Models\Menu;
+use App\Services\SessionStore\ListParameterSessionStore;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class MenusController extends Controller
+{
+    protected string $prefix;
+
+    protected int $defaultLimit;
+
+    protected string $defaultSort;
+
+    protected string $defaultSortDirection;
+
+    protected array $defaultSortCriteria;
+
+    protected int $limit;
+
+    protected string $sort;
+
+    protected string $sortDirection;
+
+    protected bool $hasFilter;
+
+    protected MenuFilters $filter;
+
+    public function __construct(MenuFilters $filter)
+    {
+        $this->filter = $filter;
+
+        $this->prefix = 'app.menus.';
+        $this->defaultLimit = 5;
+        $this->defaultSort = 'name';
+        $this->defaultSortDirection = 'asc';
+        $this->defaultSortCriteria = ['menus.name' => 'asc'];
+
+        $this->limit = $this->defaultLimit;
+        $this->sort = $this->defaultSort;
+        $this->sortDirection = $this->defaultSortDirection;
+
+        $this->hasFilter = false;
+
+        parent::__construct();
+    }
+
+    public function index(
+        Request $request,
+        ListParameterSessionStore $listParamSessionStore,
+        ListEntityResultBuilder $listEntityResultBuilder
+    ): JsonResponse {
+        $listParamSessionStore->setBaseIndex('internal_menu');
+        $listParamSessionStore->setKeyPrefix('internal_menu_index');
+        $listParamSessionStore->setIndexTab(action([MenusController::class, 'index']));
+
+        $baseQuery = Menu::query()->select('menus.*');
+
+        $listEntityResultBuilder
+            ->setFilter($this->filter)
+            ->setQueryBuilder($baseQuery)
+            ->setDefaultSort($this->defaultSortCriteria);
+
+        $listResultSet = $listEntityResultBuilder->listResultSetFactory();
+
+        $query = $listResultSet->getList();
+
+        $menus = $query->paginate($listResultSet->getLimit());
+
+        return response()->json(new MenuCollection($menus));
+    }
+
+    public function show(Menu $menu): JsonResponse
+    {
+        return response()->json(new MenuResource($menu));
+    }
+
+    public function store(MenuRequest $request, Menu $menu): JsonResponse
+    {
+        $menu = $menu->create($request->all());
+
+        return response()->json(new MenuResource($menu), 201);
+    }
+
+    public function update(Menu $menu, MenuRequest $request): JsonResponse
+    {
+        $menu->fill($request->all())->save();
+
+        return response()->json(new MenuResource($menu));
+    }
+
+    public function destroy(Menu $menu): JsonResponse
+    {
+        $menu->delete();
+
+        return response()->json([], 204);
+    }
+}

--- a/app/Http/Resources/MenuCollection.php
+++ b/app/Http/Resources/MenuCollection.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+/**
+ * @mixin \Illuminate\Contracts\Pagination\LengthAwarePaginator
+ */
+class MenuCollection extends ResourceCollection
+{
+    public function toArray($request)
+    {
+        return [
+            'current_page' => $this->currentPage(),
+            'data' => $this->collection->toArray(),
+            'first_page_url' => $this->url(1),
+            'from' => $this->firstItem(),
+            'last_page' => $this->lastPage(),
+            'last_page_url' => $this->url($this->lastPage()),
+            'next_page_url' => $this->nextPageUrl(),
+            'path' => $this->path(),
+            'per_page' => $this->perPage(),
+            'prev_page_url' => $this->previousPageUrl(),
+            'to' => $this->lastItem(),
+            'total' => $this->total(),
+        ];
+    }
+}

--- a/app/Http/Resources/MenuResource.php
+++ b/app/Http/Resources/MenuResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\Menu
+ */
+class MenuResource extends JsonResource
+{
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'body' => $this->body,
+            'menu_parent_id' => $this->menu_parent_id,
+            'visibility_id' => $this->visibility_id,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -23,6 +23,7 @@ tags:
   - name: event-types
   - name: forums
   - name: links
+  - name: menus
   - name: locations
   - name: posts
   - name: series
@@ -1049,6 +1050,59 @@ components:
             data:
               type: array
               items: { "$ref": "#/components/schemas/Link" }
+    Menu:
+      type: object
+      required:
+        - name
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          example: 1
+        name:
+          type: string
+          maxLength: 255
+          description: Name of the menu
+          example: Main
+        slug:
+          type: string
+          maxLength: 255
+          description: A unique identifier name for the menu in kebab-case
+          example: main-menu
+        menu_parent_id:
+          type: integer
+          nullable: true
+          example: 1
+          description: Parent menu id
+        body:
+          type: string
+          description: Body of the menu
+          example: Menu body
+        visibility_id:
+          type: integer
+          example: 1
+          description: Relation to the visibility table
+        created_at:
+          type: string
+          example: "2018-03-20T09:12:28Z"
+          format: date-time
+          description: Date and time that the menu was created
+          readOnly: true
+        updated_at:
+          type: string
+          example: "2018-03-20T09:12:28Z"
+          format: date-time
+          description: Date and time that the menu was last updated
+          readOnly: true
+    Menus:
+      allOf:
+        - $ref: "#/components/schemas/Pagination"
+        - type: object
+          properties:
+            data:
+              type: array
+              items: { "$ref": "#/components/schemas/Menu" }
+
     Location:
       type: object
       required:
@@ -3538,6 +3592,112 @@ paths:
         - links
       summary: Delete Link
       operationId: deleteLinkById
+      responses:
+        "204":
+          description: Successful response
+          content:
+              application/json: {}
+  /api/menus:
+    get:
+      tags:
+        - menus
+      summary: Get Menus
+      operationId: getMenus
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: The limit on the number of results to return per page
+          schema:
+            type: integer
+          example: 25
+        - name: page
+          in: query
+          required: false
+          description: The page number to return
+          schema:
+            type: integer
+            example: 1
+        - name: sort
+          in: query
+          required: false
+          description: A column to be used to sort the query
+          schema:
+            type: string
+            example: name
+        - name: direction
+          in: query
+          required: false
+          description: A string indicating the sort direction of the query (asc or desc)
+          schema:
+            type: string
+            example: asc
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Menus"
+    post:
+      tags:
+        - menus
+      summary: Create menu
+      operationId: createMenu
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Menu"
+      responses:
+        "201":
+          description: Successful response
+          content:
+            application/json: {}
+  /api/menus/{menuId}:
+    parameters:
+      - name: menuId
+        description: The unique identifier of the menu
+        in: path
+        required: true
+        schema:
+          type: integer
+          readOnly: true
+          example: 1
+    get:
+      tags:
+        - menus
+      summary: Get Menu
+      operationId: getMenuById
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Menu"
+    patch:
+      tags:
+        - menus
+      summary: Update menu
+      operationId: updateMenuById
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Menu"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Menu"
+    delete:
+      tags:
+        - menus
+      summary: Delete Menu
+      operationId: deleteMenuById
       responses:
         "204":
           description: Successful response

--- a/routes/api.php
+++ b/routes/api.php
@@ -108,6 +108,7 @@ Route::middleware('auth.either')->name('api.')->group(function () {
     Route::get('links/reset', ['as' => 'links.reset', 'uses' => 'Api\LinksController@reset']);
     Route::get('links/rpp-reset', ['as' => 'links.rppReset', 'uses' => 'Api\LinksController@rppReset']);
     Route::resource('links', 'Api\LinksController');
+    Route::resource('menus', 'Api\MenusController');
 
     Route::match(['get', 'post'], 'locations/filter', ['as' => 'locations.filter', 'uses' => 'Api\LocationsController@filter']);
     Route::get('locations/reset', ['as' => 'locations.reset', 'uses' => 'Api\LocationsController@reset']);


### PR DESCRIPTION
## Summary
- create `Api\MenusController` with CRUD actions
- create `MenuResource` and `MenuCollection`
- expose `menus` API routes
- document menu endpoints and schema in OpenAPI `api.yml`

## Testing
- `composer tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68661b6b2e9083228949b78585182170