### PR TITLE
Add events-attending API route

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -13,6 +13,7 @@ use App\Mail\UserActivation;
 use App\Mail\UserSuspended;
 use App\Mail\UserUpdate;
 use App\Mail\WeeklyUpdate;
+use App\Http\Resources\EventCollection;
 use App\Models\Activity;
 use App\Models\Group;
 use App\Models\Photo;
@@ -746,6 +747,28 @@ class UsersController extends Controller
         }
 
         return back();
+    }
+
+    public function eventsAttending(User $user, Request $request): JsonResponse
+    {
+        $limit = (int) $request->input('limit', 25);
+
+        $events = $user->getAttending()
+            ->visible($this->user)
+            ->with([
+                'visibility',
+                'venue',
+                'eventStatus',
+                'eventType',
+                'promoter',
+                'series',
+                'tags',
+                'entities',
+            ])
+            ->orderBy('events.start_at', 'asc')
+            ->paginate($limit);
+
+        return response()->json(new EventCollection($events));
     }
 
     protected function getListControlOptions(): array

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -337,6 +337,7 @@ class User extends Authenticatable implements AuthorizableContract, CanResetPass
 
     /**
      * Return a list of events the user is attending.
+     * @return Builder<Event>
      */
     public function getAttending(): Builder
     {

--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -4599,8 +4599,30 @@ paths:
       responses:
         "204":
           description: Successful response
+        content:
+          application/json: {}
+  /api/users/{userId}/events-attending:
+    get:
+      parameters:
+        - name: userId
+          description: The unique identifier of the user
+          in: path
+          required: true
+          schema:
+            type: integer
+            readOnly: true
+            example: 1
+      tags:
+        - users
+      summary: Get Events the User is Attending
+      operationId: getUserAttendingEvents
+      responses:
+        "200":
+          description: Successful response
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Events"
   /api/visibilities:
     get:
       tags:

--- a/routes/api.php
+++ b/routes/api.php
@@ -142,6 +142,7 @@ Route::middleware('auth.either')->name('api.')->group(function () {
     Route::match(['get', 'post'], 'users/filter', ['as' => 'users.filter', 'uses' => 'Api\UsersController@filter']);
     Route::get('users/reset', ['as' => 'users.reset', 'uses' => 'Api\UsersController@reset']);
     Route::get('users/rpp-reset', ['as' => 'users.rppReset', 'uses' => 'Api\UsersController@rppReset']);
+    Route::get('users/{user}/events-attending', ['as' => 'users.events-attending', 'uses' => 'Api\UsersController@eventsAttending']);
     Route::resource('users', 'Api\UsersController');
 
     Route::match(['get', 'post'], 'visibilities/filter', ['as' => 'visibilities.filter', 'uses' => 'Api\VisibilitiesController@filter']);


### PR DESCRIPTION
## Summary
- add route to list events a user is attending
- implement `eventsAttending` method in API UsersController
- document new endpoint in OpenAPI spec

## Testing
- `composer phpstan` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686626a4a6388322b997c2547a2f404a