### PR TITLE
Add API attendance endpoints

### DIFF
--- a/app/Http/Controllers/Api/EventsController.php
+++ b/app/Http/Controllers/Api/EventsController.php
@@ -1035,13 +1035,20 @@ class EventsController extends Controller
     {
         $user = $request->user();
 
-        $response = new EventResponse();
-        $response->event()->associate($event);
-        $response->user()->associate($user);
-        $response->response_type_id = 1;
-        $response->save();
+        $response = EventResponse::where('event_id', $event->id)
+            ->where('user_id', $user->id)
+            ->where('response_type_id', 1)
+            ->first();
 
-        Activity::log($event, $user, 6);
+        if (!$response) {
+            $response = new EventResponse();
+            $response->event()->associate($event);
+            $response->user()->associate($user);
+            $response->response_type_id = 1;
+            $response->save();
+
+            Activity::log($event, $user, 6);
+        }
 
         return response()->json(new EventResource($event));
     }

--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -2834,6 +2834,47 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PhotoResponse"
+  /api/events/{id}/attend:
+    post:
+      parameters:
+        - name: id
+          description: The unique identifier of the event
+          in: path
+          required: true
+          schema:
+            type: integer
+            readOnly: true
+            example: 1
+      tags:
+        - events
+      summary: Attend Event
+      operationId: attendEventById
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventResponse"
+    delete:
+      parameters:
+        - name: id
+          description: The unique identifier of the event
+          in: path
+          required: true
+          schema:
+            type: integer
+            readOnly: true
+            example: 1
+      tags:
+        - events
+      summary: Unattend Event
+      operationId: unattendEventById
+      responses:
+        "204":
+          description: Successful response
+          content:
+            application/json: {}
   /api/entities:
     post:
       tags:

--- a/routes/api.php
+++ b/routes/api.php
@@ -75,7 +75,10 @@ Route::middleware('auth.either')->name('api.')->group(function () {
     Route::post('events/{id}/photos', 'Api\EventsController@addPhoto');
     Route::get('events/{event}/embeds', ['as' => 'events.embeds', 'uses' => 'Api\EventsController@embeds']);
     Route::get('events/{event}/minimal-embeds', ['as' => 'events.minimalEmbeds', 'uses' => 'Api\EventsController@minimalEmbeds']);
-    
+
+    Route::post('events/{event}/attend', 'Api\EventsController@attendJson');
+    Route::delete('events/{event}/attend', 'Api\EventsController@unattendJson');
+
     Route::resource('events', 'Api\EventsController');
 
     Route::get('entities/{entity}/photos', ['as' => 'entities.photos', 'uses' => 'Api\EntitiesController@photos']);

--- a/tests/Feature/ApiEventAttendanceTest.php
+++ b/tests/Feature/ApiEventAttendanceTest.php
@@ -60,4 +60,29 @@ class ApiEventAttendanceTest extends TestCase
             'response_type_id' => 1,
         ]);
     }
+
+    public function test_attend_request_does_not_create_duplicates()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user, 'sanctum');
+
+        ResponseType::factory()->create(['id' => 1, 'name' => 'Attending']);
+
+        $event = Event::factory()->create();
+
+        EventResponse::create([
+            'event_id' => $event->id,
+            'user_id' => $user->id,
+            'response_type_id' => 1,
+        ]);
+
+        $response = $this->postJson("/api/events/{$event->id}/attend");
+
+        $response->assertStatus(200);
+
+        $this->assertEquals(1, EventResponse::where('event_id', $event->id)
+            ->where('user_id', $user->id)
+            ->where('response_type_id', 1)
+            ->count());
+    }
 }

--- a/tests/Feature/ApiEventAttendanceTest.php
+++ b/tests/Feature/ApiEventAttendanceTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\EventResponse;
+use App\Models\ResponseType;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ApiEventAttendanceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    public function test_user_can_attend_event()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user, 'sanctum');
+
+        ResponseType::factory()->create(['id' => 1, 'name' => 'Attending']);
+
+        $event = Event::factory()->create();
+
+        $response = $this->postJson("/api/events/{$event->id}/attend");
+
+        $response->assertStatus(200);
+
+        $this->assertDatabaseHas('event_responses', [
+            'event_id' => $event->id,
+            'user_id' => $user->id,
+            'response_type_id' => 1,
+        ]);
+    }
+
+    public function test_user_can_unattend_event()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user, 'sanctum');
+
+        ResponseType::factory()->create(['id' => 1, 'name' => 'Attending']);
+
+        $event = Event::factory()->create();
+
+        EventResponse::create([
+            'event_id' => $event->id,
+            'user_id' => $user->id,
+            'response_type_id' => 1,
+        ]);
+
+        $response = $this->deleteJson("/api/events/{$event->id}/attend");
+
+        $response->assertStatus(204);
+
+        $this->assertDatabaseMissing('event_responses', [
+            'event_id' => $event->id,
+            'user_id' => $user->id,
+            'response_type_id' => 1,
+        ]);
+    }
+}

--- a/tests/Feature/ApiEventAttendanceTest.php
+++ b/tests/Feature/ApiEventAttendanceTest.php
@@ -20,7 +20,7 @@ class ApiEventAttendanceTest extends TestCase
         $user = User::factory()->create();
         $this->actingAs($user, 'sanctum');
 
-        ResponseType::factory()->create(['id' => 1, 'name' => 'Attending']);
+        // ResponseType::factory()->create(['id' => 1, 'name' => 'Attending']);
 
         $event = Event::factory()->create();
 
@@ -40,7 +40,7 @@ class ApiEventAttendanceTest extends TestCase
         $user = User::factory()->create();
         $this->actingAs($user, 'sanctum');
 
-        ResponseType::factory()->create(['id' => 1, 'name' => 'Attending']);
+        // ResponseType::factory()->create(['id' => 1, 'name' => 'Attending']);
 
         $event = Event::factory()->create();
 
@@ -66,7 +66,7 @@ class ApiEventAttendanceTest extends TestCase
         $user = User::factory()->create();
         $this->actingAs($user, 'sanctum');
 
-        ResponseType::factory()->create(['id' => 1, 'name' => 'Attending']);
+        // ResponseType::factory()->create(['id' => 1, 'name' => 'Attending']);
 
         $event = Event::factory()->create();
 


### PR DESCRIPTION
## Summary
- implement POST and DELETE /events/{id}/attend endpoints
- add attendJson and unattendJson controller actions
- cover new endpoints with tests

## Testing
- `phpunit` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68670504f5948322bc6826391836a868