### PR TITLE
Add attendees list to event API response

### DIFF
--- a/app/Http/Resources/EventResource.php
+++ b/app/Http/Resources/EventResource.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 use App\Models\Event;
 
 // Resource for minimal relationship data
+use App\Http\Resources\MinimalUserResource;
 use App\Http\Resources\MinimalResource;
 
 /**
@@ -35,6 +36,7 @@ class EventResource extends JsonResource
             'promoter' => $this->promoter ? new MinimalResource($this->promoter) : null,
             'venue' => $this->venue ? new MinimalResource($this->venue) : null,
             'attending' => $this->attending,
+            'attendees' => MinimalUserResource::collection($this->attendees),
             'like' => $this->like,
             'presale_price' => $this->presale_price,
             'door_price' => $this->door_price,

--- a/app/Http/Resources/MinimalUserResource.php
+++ b/app/Http/Resources/MinimalUserResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Minimal user resource returning id and username.
+ */
+class MinimalUserResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array<string, mixed>
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->resource->id,
+            'username' => $this->resource->name,
+        ];
+    }
+}

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -19,6 +19,7 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
+use App\Models\User;
 
 /**
  * App\Models\Event.
@@ -500,6 +501,14 @@ class Event extends Model
     {
         return $this->hasMany('App\Models\EventResponse');
     }
+    /**
+     * Users marked as attending this event.
+     */
+    public function attendees(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, "event_responses")->wherePivot("response_type_id", 1);
+    }
+
 
     /**
      * Get the count of users attending this event.

--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -525,6 +525,10 @@ components:
           description: The number of users who marked that they are attending the event
           type: integer
           example: 10
+        attendees:
+          type: array
+          description: List of users attending the event
+          items: { "$ref": "#/components/schemas/MinimalUser" }
         like:
           description: The number of users who marked that they like the event
           type: integer
@@ -1973,6 +1977,18 @@ components:
           type: string
           description: Email address of the user
           example: john.smith@gmail.com
+          maxLength: 255
+    MinimalUser:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          example: 1
+        username:
+          type: string
+          description: Name of the user
+          example: john.smith
           maxLength: 255
     UserResponse:
       type: object


### PR DESCRIPTION
## Summary
- add `attendees` relation on `Event` model
- expose attending users via new `attendees` property in `EventResource`
- add `MinimalUserResource` for user id/username pairs
- document the new property in `api.yml` with `MinimalUser` schema

## Testing
- `phpunit` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68676797b8c483229807974789602cc7