### PR TITLE
Add API for event statuses

### DIFF
--- a/app/Filters/EventStatusFilters.php
+++ b/app/Filters/EventStatusFilters.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Filters;
+
+use Illuminate\Database\Eloquent\Builder;
+
+class EventStatusFilters extends QueryFilter
+{
+    public function name(?string $value = null): Builder
+    {
+        if (isset($value)) {
+            return $this->builder->where('name', $value);
+        }
+        return $this->builder;
+    }
+}

--- a/app/Http/Controllers/Api/EventStatusesController.php
+++ b/app/Http/Controllers/Api/EventStatusesController.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Filters\EventStatusFilters;
+use App\Models\Activity;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\EventStatusRequest;
+use App\Http\ResultBuilder\ListEntityResultBuilder;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use App\Models\EventStatus;
+use App\Services\SessionStore\ListParameterSessionStore;
+use Exception;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Log;
+
+class EventStatusesController extends Controller
+{
+    protected int $defaultLimit;
+    protected string $defaultSort;
+    protected string $defaultSortDirection;
+    protected array $defaultSortCriteria;
+    protected int $limit;
+    protected string $sort;
+    protected string $sortDirection;
+    protected array $filters;
+    protected bool $hasFilter;
+    protected string $prefix;
+    protected EventStatusFilters $filter;
+
+    public function __construct(EventStatusFilters $filter)
+    {
+        $this->filter = $filter;
+
+        $this->prefix = 'app.event-statuses.';
+
+        $this->defaultLimit = 10;
+        $this->defaultSort = 'name';
+        $this->defaultSortDirection = 'asc';
+        $this->defaultSortCriteria = ['event_statuses.name' => 'asc'];
+
+        $this->limit = $this->defaultLimit;
+        $this->sort = $this->defaultSort;
+        $this->sortDirection = $this->defaultSortDirection;
+
+        $this->hasFilter = false;
+        parent::__construct();
+    }
+
+    public function index(
+        Request $request,
+        ListParameterSessionStore $listParamSessionStore,
+        ListEntityResultBuilder $listEntityResultBuilder
+    ): JsonResponse {
+        $listParamSessionStore->setBaseIndex('internal_event_status');
+        $listParamSessionStore->setKeyPrefix('internal_event_status_index');
+
+        $listParamSessionStore->setIndexTab(action([EventStatusesController::class, 'index']));
+
+        $baseQuery = EventStatus::query()->select('event_statuses.*');
+
+        $listEntityResultBuilder
+            ->setFilter($this->filter)
+            ->setQueryBuilder($baseQuery)
+            ->setDefaultSort(['event_statuses.name' => 'asc']);
+
+        $listResultSet = $listEntityResultBuilder->listResultSetFactory();
+
+        $query = $listResultSet->getList();
+
+        $eventStatuses = $query->paginate($listResultSet->getLimit());
+
+        return response()->json($eventStatuses);
+    }
+
+    public function rppReset(
+        Request $request,
+        ListParameterSessionStore $listParamSessionStore
+    ): RedirectResponse {
+        $keyPrefix = $request->get('key') ?? 'internal_event_status_index';
+        $listParamSessionStore->setBaseIndex('internal_event_status');
+        $listParamSessionStore->setKeyPrefix($keyPrefix);
+
+        $listParamSessionStore->clearSort();
+
+        return redirect()->route('event-statuses.index');
+    }
+
+    public function reset(
+        Request $request,
+        ListParameterSessionStore $listParamSessionStore
+    ): Response {
+        $keyPrefix = $request->get('key') ?? 'internal_event_status_index';
+        $listParamSessionStore->setBaseIndex('internal_event_status');
+        $listParamSessionStore->setKeyPrefix($keyPrefix);
+
+        $listParamSessionStore->clearFilter();
+        $listParamSessionStore->clearSort();
+
+        return redirect()->route('event-statuses.index');
+    }
+
+    public function buildCriteria(Request $request): Builder
+    {
+        $query = EventStatus::orderBy($this->sort, $this->sortDirection);
+
+        return $query;
+    }
+
+    public function store(EventStatusRequest $request): JsonResponse
+    {
+        $input = $request->all();
+
+        $eventStatus = EventStatus::create($input);
+
+        return response()->json($eventStatus);
+    }
+
+    public function show(EventStatus $eventStatus): JsonResponse
+    {
+        return response()->json($eventStatus);
+    }
+
+    public function update(EventStatus $eventStatus, EventStatusRequest $request): JsonResponse
+    {
+        $eventStatus->fill($request->input())->save();
+
+        return response()->json($eventStatus);
+    }
+
+    public function destroy(EventStatus $eventStatus): JsonResponse
+    {
+        $name = $eventStatus->name;
+
+        try {
+            $eventStatus->delete();
+        } catch (Exception $e) {
+            Log::error(sprintf('Could not delete the event status %s', $name));
+        }
+
+        Activity::log($eventStatus, $this->user, 3);
+
+        return response()->json([], 204);
+    }
+
+    protected function getFilterOptions(): array
+    {
+        return [];
+    }
+
+    protected function getListControlOptions(): array
+    {
+        return [
+            'limitOptions' => [5 => 5, 10 => 10, 25 => 25, 100 => 100, 1000 => 1000],
+            'sortOptions' => ['event_statuses.name' => 'Name', 'event_statuses.created_at' => 'Created At'],
+            'directionOptions' => ['asc' => 'asc', 'desc' => 'desc'],
+        ];
+    }
+}

--- a/app/Http/Requests/EventStatusRequest.php
+++ b/app/Http/Requests/EventStatusRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Requests;
+
+class EventStatusRequest extends Request
+{
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function rules()
+    {
+        return [
+            'name' => 'required|min:3|max:255|unique:event_statuses,name',
+        ];
+    }
+}

--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -21,6 +21,7 @@ tags:
   - name: entity-types
   - name: events
   - name: event-types
+  - name: event-statuses
   - name: forums
   - name: links
   - name: menus
@@ -3504,6 +3505,140 @@ paths:
         - event-types
       summary: Delete Event Type
       operationId: deleteEventTypeById
+      responses:
+        "204":
+          description: Successful response
+          content:
+            application/json: {}
+  /api/event-statuses:
+    get:
+      tags:
+        - event-statuses
+      summary: Get Event Statuses
+      operationId: getEventStatuses
+      parameters:
+        - name: filters[name]
+          in: query
+          required: false
+          description: A filter query of the event status name
+          schema:
+            type: string
+            example: "Draft"
+        - name: limit
+          in: query
+          required: false
+          description: The limit on the number of results to return per page
+          schema:
+            type: integer
+            example: 25
+        - name: page
+          in: query
+          required: false
+          description: The page number to return
+          schema:
+            type: integer
+            example: 1
+        - name: sort
+          in: query
+          required: false
+          description: A column to be used to sort the query
+          schema:
+            type: string
+            example: name
+        - name: direction
+          in: query
+          required: false
+          description: A string indicating the sort direction of the query (asc or desc)
+          schema:
+            type: string
+            example: asc
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pagination"
+    post:
+      tags:
+        - event-statuses
+      summary: Create event status
+      operationId: createEventStatus
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EventStatus"
+      responses:
+        "201":
+          description: Successful response
+          content:
+            application/json: {}
+  /api/event-statuses/{eventStatusId}:
+    get:
+      parameters:
+        - name: eventStatusId
+          description: The unique identifier of the event status
+          in: path
+          required: true
+          schema:
+            description: The unique identifier of an event status
+            type: integer
+            readOnly: true
+            example: 1
+      tags:
+        - event-statuses
+      summary: Get EventStatus
+      operationId: getEventStatusById
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventStatus"
+    put:
+      parameters:
+        - name: eventStatusId
+          description: The unique identifier of the event status
+          in: path
+          required: true
+          schema:
+            description: The unique identifier of an event status
+            type: integer
+            readOnly: true
+            example: 1
+      tags:
+        - event-statuses
+      summary: Update Event Status
+      operationId: updateEventStatusById
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EventStatus"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventStatus"
+    delete:
+      parameters:
+        - name: eventStatusId
+          description: The unique identifier of the event status
+          in: path
+          required: true
+          schema:
+            description: The unique identifier of an event status
+            type: integer
+            readOnly: true
+            example: 1
+      tags:
+        - event-statuses
+      summary: Delete Event Status
+      operationId: deleteEventStatusById
       responses:
         "204":
           description: Successful response

--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -350,9 +350,9 @@ components:
           description: Full description of the entity
           example: A two level bar and venue that specializes in indie music and vegetarian food
         entity_type:
-          $ref: "#/components/schemas/EntityType"
+          $ref: "#/components/schemas/EntityTypeResponse"
         entity_status:
-          $ref: "#/components/schemas/EntityStatus"
+          $ref: "#/components/schemas/EntityStatusResponse"
         created_by:
           $ref: "#/components/schemas/UserSimple"
         updated_by:
@@ -397,7 +397,7 @@ components:
           description: List of the current page of entities
           items:
             "$ref": "#/components/schemas/EntityResponse"
-    EntityType:
+    EntityTypeResponse:
       type: object
       required:
         - name
@@ -433,6 +433,30 @@ components:
           format: date-time
           description: Date and time that the entity type was last updated
           readOnly: true
+    EntityTypeRequest:
+      type: object
+      required:
+        - name
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          example: 1
+        name:
+          type: string
+          maxLength: 255
+          description: A name of an entity type
+          example: Group
+        slug:
+          type: string
+          maxLength: 255
+          description: A unique identifier name for the entity type in kebab-case
+          example: group-slug
+        short:
+          type: string
+          example: A multi-member entity
+          description: A brief description of the entity type
+          maxLength: 255
     EntityTypes:
       allOf: [$ref: "#/components/schemas/Pagination"]
       type: object
@@ -441,8 +465,8 @@ components:
           type: array
           description: List of the current page of events
           items:
-            "$ref": "#/components/schemas/EntityType"
-    EntityStatus:
+            "$ref": "#/components/schemas/EntityTypeResponse"
+    EntityStatusResponse:
       type: object
       required:
         - name
@@ -469,10 +493,24 @@ components:
           format: date-time
           description: Date and time that the entity status was last updated
           readOnly: true
+    EntityStatusRequest:
+      type: object
+      required:
+        - name
+      properties:
+        id:
+          description: The unique identifier of an entity type
+          type: integer
+          readOnly: true
+          example: 1
+        name:
+          type: string
+          maxLength: 255
+          description: A name of an entity status
+          example: Active
     EventRequest:
       type: object
       required:
-        - id
         - name
         - slug
         - start_at
@@ -772,9 +810,9 @@ components:
           example: a really fun dj night featuring performers from around the world and locally playing new electronic music
           maxLength: 65535
         event_status:
-          $ref: "#/components/schemas/EventStatus"
+          $ref: "#/components/schemas/EventStatusResponse"
         event_type:
-          $ref: "#/components/schemas/EventType"
+          $ref: "#/components/schemas/EventTypeResponse"
         promoter:
           $ref: "#/components/schemas/EntityResponse"
         venue:
@@ -866,7 +904,7 @@ components:
           description: List of the current page of events
           items:
             "$ref": "#/components/schemas/EventResponse"
-    EventStatus:
+    EventStatusResponse:
       type: object
       required:
         - name
@@ -892,6 +930,29 @@ components:
           format: date-time
           description: Date and time that the event status was last updated
           readOnly: true
+    EventStatusRequest:
+      type: object
+      required:
+        - name
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          example: 1
+        name:
+          type: string
+          maxLength: 255
+          description: A name of an event status
+          example: Active
+    EventStatuses:
+      allOf: [$ref: "#/components/schemas/Pagination"]
+      type: object
+      properties:
+        data:
+          type: array
+          description: List of the current page of event statueses
+          items:
+            "$ref": "#/components/schemas/EventStatusResponse"
     EventTypeRequest:
       type: object
       required:
@@ -913,7 +974,7 @@ components:
           example: An event featuring live performances
           description: A brief description of the event type
           maxLength: 255
-    EventType:
+    EventTypeResponse:
       type: object
       properties:
         id:
@@ -953,9 +1014,9 @@ components:
       properties:
         data:
           type: array
-          description: List of the current page of events
+          description: List of the current page of event types
           items:
-            "$ref": "#/components/schemas/EventType"
+            "$ref": "#/components/schemas/EventTypeResponse"
     Forum:
       type: object
       required:
@@ -1616,7 +1677,7 @@ components:
           example: a really fun monthly dj night featuring performers from around the world and locally playing new electronic music
           maxLength: 65535
         event_type:
-          $ref: "#/components/schemas/EventType"
+          $ref: "#/components/schemas/EventTypeResponse"
         occurrence_type:
           $ref: "#/components/schemas/OccurrenceType"
         occurrence_week:
@@ -3208,7 +3269,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EntityStatus"
+              $ref: "#/components/schemas/EntityStatusRequest"
       responses:
         "201":
           description: Successful response
@@ -3236,7 +3297,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EntityStatus"
+                $ref: "#/components/schemas/EntityStatusResponse"
     put:
       parameters:
         - name: entityStatusId
@@ -3256,14 +3317,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EntityStatus"
+              $ref: "#/components/schemas/EntityStatusRequest"
       responses:
         "200":
           description: Successful response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EntityStatus"
+                $ref: "#/components/schemas/EntityStatusResponse"
     delete:
       parameters:
         - name: entityStatusId
@@ -3342,7 +3403,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EntityType"
+              $ref: "#/components/schemas/EntityTypeRequest"
       responses:
         "201":
           description: Successful response
@@ -3369,7 +3430,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EntityType"
+                $ref: "#/components/schemas/EntityTypeResponse"
     put:
       tags:
         - entity-types
@@ -3379,14 +3440,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EntityType"
+              $ref: "#/components/schemas/EntityTypeRequest"
       responses:
         "200":
           description: Successful response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EntityType"
+                $ref: "#/components/schemas/EntityTypeResponse"
     delete:
       tags:
         - entity-types
@@ -3455,7 +3516,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EventType"
+              $ref: "#/components/schemas/EventTypeRequest"
       responses:
         "201":
           description: Successful response
@@ -3482,7 +3543,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EventType"
+                $ref: "#/components/schemas/EventTypeResponse"
     put:
       tags:
         - event-types
@@ -3492,14 +3553,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EventType"
+              $ref: "#/components/schemas/EventTypeRequest"
       responses:
         "200":
           description: Successful response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EventType"
+                $ref: "#/components/schemas/EventTypeResponse"
     delete:
       tags:
         - event-types
@@ -3568,7 +3629,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EventStatus"
+              $ref: "#/components/schemas/EventStatusRequest"
       responses:
         "201":
           description: Successful response
@@ -3596,7 +3657,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EventStatus"
+                $ref: "#/components/schemas/EventStatusResponse"
     put:
       parameters:
         - name: eventStatusId
@@ -3616,14 +3677,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EventStatus"
+              $ref: "#/components/schemas/EventStatusRequest"
       responses:
         "200":
           description: Successful response
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EventStatus"
+                $ref: "#/components/schemas/EventStatusResponse"
     delete:
       parameters:
         - name: eventStatusId
@@ -4891,8 +4952,8 @@ paths:
       responses:
         "204":
           description: Successful response
-        content:
-          application/json: {}
+          content:
+            application/json: {}
   /api/users/{userId}/events-attending:
     get:
       parameters:

--- a/routes/api.php
+++ b/routes/api.php
@@ -102,6 +102,11 @@ Route::middleware('auth.either')->name('api.')->group(function () {
     Route::get('event-types/rpp-reset', ['as' => 'event-types.rppReset', 'uses' => 'Api\EventTypesController@rppReset']);
     Route::resource('event-types', 'Api\EventTypesController');
 
+    Route::match(['get', 'post'], 'event-statuses/filter', ['as' => 'eventStatus.filter', 'uses' => 'Api\EventStatusesController@filter']);
+    Route::get('event-statuses/reset', ['as' => 'event-statuses.reset', 'uses' => 'Api\EventStatusesController@reset']);
+    Route::get('event-statuses/rpp-reset', ['as' => 'event-statuses.rppReset', 'uses' => 'Api\EventStatusesController@rppReset']);
+    Route::resource('event-statuses', 'Api\EventStatusesController');
+
     Route::match(['get', 'post'], 'forums/filter', ['as' => 'forums.filter', 'uses' => 'Api\ForumsController@filter']);
     Route::get('forums/reset', ['as' => 'forums.reset', 'uses' => 'Api\ForumsController@reset']);
     Route::get('forums/rpp-reset', ['as' => 'forums.rppReset', 'uses' => 'Api\ForumsController@rppReset']);


### PR DESCRIPTION
## Summary
- add `EventStatusFilters`
- add API controller for `event-statuses`
- add request validation for event status
- expose new routes for `/api/event-statuses`
- document event-status endpoints in `api.yml`

## Testing
- `composer tests` *(fails: command not found)*
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686ded31a6f48322bd3127593d07a41c