### PR TITLE
Add photo management endpoints

### DIFF
--- a/app/Http/Controllers/Api/PhotosController.php
+++ b/app/Http/Controllers/Api/PhotosController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Photo;
+use Illuminate\Http\JsonResponse;
+
+class PhotosController extends Controller
+{
+    /**
+     * Set the photo as primary.
+     */
+    public function setPrimary(Photo $photo): JsonResponse
+    {
+        if (!$this->user || $photo->created_by !== $this->user->id) {
+            return response()->json(['status' => 'Permission Denied'], 403);
+        }
+
+        $photo->is_primary = 1;
+        $photo->save();
+
+        return response()->json($photo);
+    }
+
+    /**
+     * Unset the primary flag for the photo.
+     */
+    public function unsetPrimary(Photo $photo): JsonResponse
+    {
+        if (!$this->user || $photo->created_by !== $this->user->id) {
+            return response()->json(['status' => 'Permission Denied'], 403);
+        }
+
+        $photo->is_primary = 0;
+        $photo->save();
+
+        return response()->json($photo);
+    }
+
+    /**
+     * Delete the photo record and file.
+     */
+    public function destroy(Photo $photo): JsonResponse
+    {
+        if (!$this->user || $photo->created_by !== $this->user->id) {
+            return response()->json(['status' => 'Permission Denied'], 403);
+        }
+
+        $photo->delete();
+
+        return response()->json([], 204);
+    }
+}

--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -33,6 +33,7 @@ tags:
   - name: threads
   - name: users
   - name: visibilities
+  - name: photos
 components:
   responses:
     NotFound:
@@ -5162,6 +5163,70 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Events"
+  /api/photos/{photoId}/set-primary:
+    post:
+      parameters:
+        - name: photoId
+          description: The unique identifier of the photo
+          in: path
+          required: true
+          schema:
+            type: integer
+            readOnly: true
+            example: 1
+      tags:
+        - photos
+      summary: Set Photo Primary
+      operationId: setPhotoPrimary
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PhotoResponse"
+  /api/photos/{photoId}/unset-primary:
+    post:
+      parameters:
+        - name: photoId
+          description: The unique identifier of the photo
+          in: path
+          required: true
+          schema:
+            type: integer
+            readOnly: true
+            example: 1
+      tags:
+        - photos
+      summary: Unset Photo Primary
+      operationId: unsetPhotoPrimary
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PhotoResponse"
+  /api/photos/{photoId}:
+    delete:
+      parameters:
+        - name: photoId
+          description: The unique identifier of the photo
+          in: path
+          required: true
+          schema:
+            type: integer
+            readOnly: true
+            example: 1
+      tags:
+        - photos
+      summary: Delete Photo
+      operationId: deletePhoto
+      responses:
+        "204":
+          description: Successful response
+          content:
+            application/json: {}
   /api/visibilities:
     get:
       tags:

--- a/routes/api.php
+++ b/routes/api.php
@@ -160,6 +160,11 @@ Route::middleware('auth.either')->name('api.')->group(function () {
 
     Route::match(['get', 'post'], 'visibilities/filter', ['as' => 'visibilities.filter', 'uses' => 'Api\VisibilitiesController@filter']);
     Route::resource('visibilities', 'Api\VisibilitiesController')->only(['index', 'show']);
+
+    // photo management endpoints
+    Route::post('photos/{photo}/set-primary', 'Api\\PhotosController@setPrimary');
+    Route::post('photos/{photo}/unset-primary', 'Api\\PhotosController@unsetPrimary');
+    Route::delete('photos/{photo}', 'Api\\PhotosController@destroy');
 });
 
 // routes protected by the shield middleware


### PR DESCRIPTION
## Summary
- add PhotosController for API
- expose POST endpoints to set/unset primary and a DELETE endpoint for photos
- document the new endpoints and add `photos` tag in OpenAPI spec

## Testing
- `composer test` *(fails: Failed to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68797bfe2af08322ae87339d6cd58a6a