### PR TITLE
Add follow/unfollow API routes

### DIFF
--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -3292,6 +3292,48 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PhotoResponse"
+  /api/entities/{slug}/follow:
+    post:
+      parameters:
+        - name: slug
+          description: The unique identifier of the entity
+          in: path
+          required: true
+          schema:
+            type: string
+            readOnly: true
+            example: "strobe"
+      tags:
+        - entities
+      summary: Follow Entity
+      operationId: followEntityBySlug
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EntityResponse"
+  /api/entities/{slug}/unfollow:
+    post:
+      parameters:
+        - name: slug
+          description: The unique identifier of the entity
+          in: path
+          required: true
+          schema:
+            type: string
+            readOnly: true
+            example: "strobe"
+      tags:
+        - entities
+      summary: Unfollow Entity
+      operationId: unfollowEntityBySlug
+      responses:
+        "204":
+          description: Successful response
+          content:
+            application/json: {}
   /api/entity-statuses:
     get:
       tags:
@@ -4549,6 +4591,48 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PhotoResponse"
+  /api/series/{slug}/follow:
+    post:
+      parameters:
+        - name: slug
+          description: The unique identifier of the series
+          in: path
+          required: true
+          schema:
+            type: string
+            readOnly: true
+            example: "strobe"
+      tags:
+        - series
+      summary: Follow Series
+      operationId: followSeriesBySlug
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SeriesResponse"
+  /api/series/{slug}/unfollow:
+    post:
+      parameters:
+        - name: slug
+          description: The unique identifier of the series
+          in: path
+          required: true
+          schema:
+            type: string
+            readOnly: true
+            example: "strobe"
+      tags:
+        - series
+      summary: Unfollow Series
+      operationId: unfollowSeriesBySlug
+      responses:
+        "204":
+          description: Successful response
+          content:
+            application/json: {}
   /api/tags:
     post:
       tags:

--- a/routes/api.php
+++ b/routes/api.php
@@ -85,6 +85,8 @@ Route::middleware('auth.either')->name('api.')->group(function () {
     Route::get('entities/{entity}/embeds', ['as' => 'entities.embeds', 'uses' => 'Api\EntitiesController@embeds']);
     Route::get('entities/{entity}/minimal-embeds', ['as' => 'entities.minimalEmbeds', 'uses' => 'Api\EntitiesController@minimalEmbeds']);
     Route::post('entities/{id}/photos', 'Api\EntitiesController@addPhoto');
+    Route::post('entities/{entity}/follow', 'Api\EntitiesController@followJson')->middleware('auth:sanctum');
+    Route::post('entities/{entity}/unfollow', 'Api\EntitiesController@unfollowJson')->middleware('auth:sanctum');
     Route::resource('entities', 'Api\EntitiesController');
 
     Route::match(['get', 'post'], 'entity-types/filter', ['as' => 'entityType.filter', 'uses' => 'Api\EntityTypesController@filter']);
@@ -128,6 +130,8 @@ Route::middleware('auth.either')->name('api.')->group(function () {
     Route::get('series/{series}/photos', ['as' => 'series.photos', 'uses' => 'Api\SeriesController@photos']);
     Route::get('series/{series}/all-photos', ['as' => 'series.allPhotos', 'uses' => 'Api\SeriesController@allPhotos']);
     Route::post('series/{id}/photos', 'Api\SeriesController@addPhoto');
+    Route::post('series/{series}/follow', 'Api\SeriesController@followJson')->middleware('auth:sanctum');
+    Route::post('series/{series}/unfollow', 'Api\SeriesController@unfollowJson')->middleware('auth:sanctum');
     Route::resource('series', 'Api\SeriesController');
 
     Route::match(['get', 'post'], 'tags/filter', ['as' => 'tags.filter', 'uses' => 'Api\TagsController@filter']);


### PR DESCRIPTION
## Summary
- add Sanctum-protected follow/unfollow actions for entities and series
- document the new endpoints in the OpenAPI spec

## Testing
- `composer test` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_6879f2dffd0c83229a45ff18d5bd0f39