### PR TITLE
Enable filtering for events attending endpoint

### DIFF
--- a/app/Http/Controllers/Api/EventsController.php
+++ b/app/Http/Controllers/Api/EventsController.php
@@ -166,13 +166,12 @@ class EventsController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return Response|View
      */
     public function indexAttending(
         Request $request,
         ListParameterSessionStore $listParamSessionStore,
         ListEntityResultBuilder $listEntityResultBuilder
-    ) {
+    ): JsonResponse {
         // check who the authenticated user is
         $this->user = $request->user();
         if (!$this->user) {

--- a/app/Http/Controllers/Api/EventsController.php
+++ b/app/Http/Controllers/Api/EventsController.php
@@ -103,7 +103,7 @@ class EventsController extends Controller
 
         // this is causing issues in some places, but do we need it?
         // $this->middleware('auth:sanctum');
-        $this->middleware('auth:sanctum')->only(['attendJson', 'unattendJson','store']);
+        $this->middleware('auth:sanctum')->only(['attendJson', 'unattendJson', 'store', 'update', 'destroy']);
 
         parent::__construct();
     }
@@ -160,6 +160,53 @@ class EventsController extends Controller
             ])
             ->paginate($listResultSet->getLimit());
     
+        return response()->json(new EventCollection($events));
+    }
+
+    /**
+     * Display a listing of the resource.
+     *
+     * @return Response|View
+     */
+    public function indexAttending(
+        Request $request,
+        ListParameterSessionStore $listParamSessionStore,
+        ListEntityResultBuilder $listEntityResultBuilder
+    ) {
+        // check who the authenticated user is
+        $this->user = $request->user();
+        if (!$this->user) {
+            abort(403, 'Unauthorized action.');
+        }
+
+        // initialized listParamSessionStore with baseindex key
+        $listParamSessionStore->setBaseIndex('internal_event');
+        $listParamSessionStore->setKeyPrefix('internal_event_attending');
+
+        // set the index tab in the session
+        $listParamSessionStore->setIndexTab(action([EventsController::class, 'index']));
+
+        // create the base query including any required joins; needs select to make sure only event entities are returned
+        $baseQuery = $this->user->getAttending()->leftJoin('event_types', 'events.event_type_id', '=', 'event_types.id')->select('events.*');
+
+        // set the default filter to starting today, can override
+        $defaultFilter = ['start_at' => ['start' => Carbon::now()->format('Y-m-d')]];
+
+        $listEntityResultBuilder
+            ->setFilter($this->filter)
+            ->setQueryBuilder($baseQuery)
+            ->setDefaultFilters($defaultFilter)
+            ->setDefaultSort(['events.start_at' => 'asc']);
+
+        // get the result set from the builder
+        $listResultSet = $listEntityResultBuilder->listResultSetFactory();
+        $query = $listResultSet->getList();
+
+        // get the events
+        $events = $query
+            ->with('visibility', 'venue','tags', 'entities','series','eventType','threads')
+            ->paginate($listResultSet->getLimit());
+
         return response()->json(new EventCollection($events));
     }
 

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -783,8 +783,7 @@ class UsersController extends Controller
         $listResultSet = $listEntityResultBuilder->listResultSetFactory();
         $query = $listResultSet->getList();
 
-        $events = $query->visible($this->user)
-            ->with([
+        $events = $query->with([
                 'visibility',
                 'venue',
                 'eventStatus',

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -9,6 +9,7 @@ use App\Http\Requests\UserRequest;
 use App\Http\Resources\UserCollection;
 use App\Http\Resources\UserResource;
 use App\Http\ResultBuilder\ListEntityResultBuilder;
+use App\Filters\EventFilters;
 use App\Mail\UserActivation;
 use App\Mail\UserSuspended;
 use App\Mail\UserUpdate;
@@ -755,12 +756,34 @@ class UsersController extends Controller
         return back();
     }
 
-    public function eventsAttending(User $user, Request $request): JsonResponse
-    {
-        $limit = (int) $request->input('limit', 25);
+    public function eventsAttending(
+        User $user,
+        Request $request,
+        ListParameterSessionStore $listParamSessionStore,
+        ListEntityResultBuilder $listEntityResultBuilder,
+        EventFilters $eventFilters
+    ): JsonResponse {
+        // initialize the list parameter session store for this route
+        $listParamSessionStore->setBaseIndex('api_user_event');
+        $listParamSessionStore->setKeyPrefix('api_user_event_index');
 
-        $events = $user->getAttending()
-            ->visible($this->user)
+        // base query of events the user is attending
+        $baseQuery = $user->getAttending()
+            ->leftJoin('event_types', 'events.event_type_id', '=', 'event_types.id')
+            ->leftJoin('entities as venue', 'events.venue_id', '=', 'venue.id')
+            ->leftJoin('entities as promoter', 'events.promoter_id', '=', 'promoter.id')
+            ->select('events.*');
+
+        $listEntityResultBuilder
+            ->setFilter($eventFilters)
+            ->setQueryBuilder($baseQuery)
+            ->setDefaultSort(['events.start_at' => 'asc']);
+
+        // build the result set with filters, sorting and limit
+        $listResultSet = $listEntityResultBuilder->listResultSetFactory();
+        $query = $listResultSet->getList();
+
+        $events = $query->visible($this->user)
             ->with([
                 'visibility',
                 'venue',
@@ -771,8 +794,7 @@ class UsersController extends Controller
                 'tags',
                 'entities',
             ])
-            ->orderBy('events.start_at', 'asc')
-            ->paginate($limit);
+            ->paginate($listResultSet->getLimit());
 
         return response()->json(new EventCollection($events));
     }

--- a/public/postman/schemas/action-api.yml
+++ b/public/postman/schemas/action-api.yml
@@ -1765,7 +1765,7 @@ paths:
       tags:
         - events
       summary: Create Event
-      operationId: getCreateEvent
+      operationId: createEvent
       requestBody:
         content:
           application/json:
@@ -1908,6 +1908,132 @@ paths:
           schema:
             type: string
             example: asc
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Events"
+  /api/events/attending:
+    get:
+      parameters:
+        - name: filters[name]
+          in: query
+          required: false
+          description: A filter query of the event name
+          schema:
+            type: string
+            example: "Lazercrunk"
+        - name: filters[venue]
+          in: query
+          required: false
+          description: A filter query of the venue name
+          schema:
+            type: string
+            example: "Brillobox"
+        - name: filters[promoter]
+          in: query
+          required: false
+          description: A filter query of the promoter name
+          schema:
+            type: string
+            example: "Cutups"
+        - name: filters[related]
+          in: query
+          required: false
+          description: A filter query of related entity name
+          schema:
+            type: string
+            example: "0h85"
+        - name: filters[series]
+          in: query
+          required: false
+          description: A filter query of related series name
+          schema:
+            type: string
+            example: "Lazercrunk"
+        - name: filters[event_type]
+          in: query
+          required: false
+          description: A filter query of related event type name
+          schema:
+            type: string
+            example: "Concert"
+        - name: filters[start_at][start]
+          in: query
+          required: false
+          description: A filter query of the start time starting
+          schema:
+            type: string
+            example: "2022-01-01 1:00:00"
+        - name: filters[start_at][end]
+          in: query
+          required: false
+          description: A filter query of the start time ending
+          schema:
+            type: string
+            example: "2022-02-01 2:00:00"
+        - name: filters[end_at][start]
+          in: query
+          required: false
+          description: A filter query of the end time starting
+          schema:
+            type: string
+            example: "2022-02-01 1:00:00"
+        - name: filters[end_at][end]
+          in: query
+          required: false
+          description: A filter query of the end time ending
+          schema:
+            type: string
+            example: "2022-01-01 2:00:00"
+        - name: filters[ages]
+          in: query
+          required: false
+          description: A filter query of the end time ending
+          schema:
+            type: integer
+            example: 21
+        - name: filters[tag]
+          in: query
+          required: false
+          description: A filter query of the event tags
+          schema:
+            type: string
+            example: "electronic"
+        - name: limit
+          in: query
+          required: false
+          description: The limit on the number of results to return per page
+          schema:
+            type: integer
+            example: 25
+        - name: page
+          in: query
+          required: false
+          description: The page number to return
+          schema:
+            type: integer
+            example: 1
+        - name: sort
+          in: query
+          required: false
+          description: A column to be used to sort the query
+          schema:
+            type: string
+            example: name
+        - name: direction
+          in: query
+          required: false
+          description: A string indicating the sort direction of the query (asc or desc)
+          schema:
+            type: string
+            example: asc
+      tags:
+        - events
+      summary: Get Events the Authenticated User is Attending
+      operationId: getAttendingEvents
       responses:
         "200":
           description: Successful response

--- a/public/postman/schemas/api-3.0.3.yml
+++ b/public/postman/schemas/api-3.0.3.yml
@@ -5148,6 +5148,118 @@ paths:
             type: integer
             readOnly: true
             example: 1
+        - name: filters[name]
+          in: query
+          required: false
+          description: A filter query of the event name
+          schema:
+            type: string
+            example: "Lazercrunk"
+        - name: filters[venue]
+          in: query
+          required: false
+          description: A filter query of the venue name
+          schema:
+            type: string
+            example: "Brillobox"
+        - name: filters[promoter]
+          in: query
+          required: false
+          description: A filter query of the promoter name
+          schema:
+            type: string
+            example: "Cutups"
+        - name: filters[related]
+          in: query
+          required: false
+          description: A filter query of related entity name
+          schema:
+            type: string
+            example: "0h85"
+        - name: filters[series]
+          in: query
+          required: false
+          description: A filter query of related series name
+          schema:
+            type: string
+            example: "Lazercrunk"
+        - name: filters[event_type]
+          in: query
+          required: false
+          description: A filter query of related event type name
+          schema:
+            type: string
+            example: "Concert"
+        - name: filters[start_at][start]
+          in: query
+          required: false
+          description: A filter query of the start time starting
+          schema:
+            type: string
+            example: "2022-01-01 1:00:00"
+        - name: filters[start_at][end]
+          in: query
+          required: false
+          description: A filter query of the start time ending
+          schema:
+            type: string
+            example: "2022-02-01 2:00:00"
+        - name: filters[end_at][start]
+          in: query
+          required: false
+          description: A filter query of the end time starting
+          schema:
+            type: string
+            example: "2022-02-01 1:00:00"
+        - name: filters[end_at][end]
+          in: query
+          required: false
+          description: A filter query of the end time ending
+          schema:
+            type: string
+            example: "2022-01-01 2:00:00"
+        - name: filters[ages]
+          in: query
+          required: false
+          description: A filter query of the end time ending
+          schema:
+            type: integer
+            example: 21
+        - name: filters[tag]
+          in: query
+          required: false
+          description: A filter query of the event tags
+          schema:
+            type: string
+            example: "electronic"
+        - name: limit
+          in: query
+          required: false
+          description: The limit on the number of results to return per page
+          schema:
+            type: integer
+            example: 25
+        - name: page
+          in: query
+          required: false
+          description: The page number to return
+          schema:
+            type: integer
+            example: 1
+        - name: sort
+          in: query
+          required: false
+          description: A column to be used to sort the query
+          schema:
+            type: string
+            example: name
+        - name: direction
+          in: query
+          required: false
+          description: A string indicating the sort direction of the query (asc or desc)
+          schema:
+            type: string
+            example: asc
       tags:
         - users
       summary: Get Events the User is Attending

--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -2574,7 +2574,7 @@ paths:
       tags:
         - events
       summary: Create Event
-      operationId: getCreateEvent
+      operationId: createEvent
       requestBody:
         content:
           application/json:
@@ -2717,6 +2717,132 @@ paths:
           schema:
             type: string
             example: asc
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Events"
+  /api/events/attending:
+    get:
+      parameters:
+        - name: filters[name]
+          in: query
+          required: false
+          description: A filter query of the event name
+          schema:
+            type: string
+            example: "Lazercrunk"
+        - name: filters[venue]
+          in: query
+          required: false
+          description: A filter query of the venue name
+          schema:
+            type: string
+            example: "Brillobox"
+        - name: filters[promoter]
+          in: query
+          required: false
+          description: A filter query of the promoter name
+          schema:
+            type: string
+            example: "Cutups"
+        - name: filters[related]
+          in: query
+          required: false
+          description: A filter query of related entity name
+          schema:
+            type: string
+            example: "0h85"
+        - name: filters[series]
+          in: query
+          required: false
+          description: A filter query of related series name
+          schema:
+            type: string
+            example: "Lazercrunk"
+        - name: filters[event_type]
+          in: query
+          required: false
+          description: A filter query of related event type name
+          schema:
+            type: string
+            example: "Concert"
+        - name: filters[start_at][start]
+          in: query
+          required: false
+          description: A filter query of the start time starting
+          schema:
+            type: string
+            example: "2022-01-01 1:00:00"
+        - name: filters[start_at][end]
+          in: query
+          required: false
+          description: A filter query of the start time ending
+          schema:
+            type: string
+            example: "2022-02-01 2:00:00"
+        - name: filters[end_at][start]
+          in: query
+          required: false
+          description: A filter query of the end time starting
+          schema:
+            type: string
+            example: "2022-02-01 1:00:00"
+        - name: filters[end_at][end]
+          in: query
+          required: false
+          description: A filter query of the end time ending
+          schema:
+            type: string
+            example: "2022-01-01 2:00:00"
+        - name: filters[ages]
+          in: query
+          required: false
+          description: A filter query of the end time ending
+          schema:
+            type: integer
+            example: 21
+        - name: filters[tag]
+          in: query
+          required: false
+          description: A filter query of the event tags
+          schema:
+            type: string
+            example: "electronic"
+        - name: limit
+          in: query
+          required: false
+          description: The limit on the number of results to return per page
+          schema:
+            type: integer
+            example: 25
+        - name: page
+          in: query
+          required: false
+          description: The page number to return
+          schema:
+            type: integer
+            example: 1
+        - name: sort
+          in: query
+          required: false
+          description: A column to be used to sort the query
+          schema:
+            type: string
+            example: name
+        - name: direction
+          in: query
+          required: false
+          description: A string indicating the sort direction of the query (asc or desc)
+          schema:
+            type: string
+            example: asc
+      tags:
+        - events
+      summary: Get Events the Authenticated User is Attending
+      operationId: getAttendingEvents
       responses:
         "200":
           description: Successful response

--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -5245,6 +5245,118 @@ paths:
             type: integer
             readOnly: true
             example: 1
+        - name: filters[name]
+          in: query
+          required: false
+          description: A filter query of the event name
+          schema:
+            type: string
+            example: "Lazercrunk"
+        - name: filters[venue]
+          in: query
+          required: false
+          description: A filter query of the venue name
+          schema:
+            type: string
+            example: "Brillobox"
+        - name: filters[promoter]
+          in: query
+          required: false
+          description: A filter query of the promoter name
+          schema:
+            type: string
+            example: "Cutups"
+        - name: filters[related]
+          in: query
+          required: false
+          description: A filter query of related entity name
+          schema:
+            type: string
+            example: "0h85"
+        - name: filters[series]
+          in: query
+          required: false
+          description: A filter query of related series name
+          schema:
+            type: string
+            example: "Lazercrunk"
+        - name: filters[event_type]
+          in: query
+          required: false
+          description: A filter query of related event type name
+          schema:
+            type: string
+            example: "Concert"
+        - name: filters[start_at][start]
+          in: query
+          required: false
+          description: A filter query of the start time starting
+          schema:
+            type: string
+            example: "2022-01-01 1:00:00"
+        - name: filters[start_at][end]
+          in: query
+          required: false
+          description: A filter query of the start time ending
+          schema:
+            type: string
+            example: "2022-02-01 2:00:00"
+        - name: filters[end_at][start]
+          in: query
+          required: false
+          description: A filter query of the end time starting
+          schema:
+            type: string
+            example: "2022-02-01 1:00:00"
+        - name: filters[end_at][end]
+          in: query
+          required: false
+          description: A filter query of the end time ending
+          schema:
+            type: string
+            example: "2022-01-01 2:00:00"
+        - name: filters[ages]
+          in: query
+          required: false
+          description: A filter query of the end time ending
+          schema:
+            type: integer
+            example: 21
+        - name: filters[tag]
+          in: query
+          required: false
+          description: A filter query of the event tags
+          schema:
+            type: string
+            example: "electronic"
+        - name: limit
+          in: query
+          required: false
+          description: The limit on the number of results to return per page
+          schema:
+            type: integer
+            example: 25
+        - name: page
+          in: query
+          required: false
+          description: The page number to return
+          schema:
+            type: integer
+            example: 1
+        - name: sort
+          in: query
+          required: false
+          description: A column to be used to sort the query
+          schema:
+            type: string
+            example: name
+        - name: direction
+          in: query
+          required: false
+          description: A string indicating the sort direction of the query (asc or desc)
+          schema:
+            type: string
+            example: asc
       tags:
         - users
       summary: Get Events the User is Attending

--- a/routes/api.php
+++ b/routes/api.php
@@ -62,6 +62,7 @@ Route::middleware('auth.either')->name('api.')->group(function () {
     Route::get('blogs/rpp-reset', ['as' => 'blogs.rppReset', 'uses' => 'Api\BlogsController@rppReset']);
     Route::resource('blogs', 'Api\BlogsController');
 
+    Route::get('events/attending', ['as' => 'events.attending', 'uses' => 'Api\EventsController@indexAttending']);
     Route::get('events/by-date/{year}/{month?}/{day?}', 'Api\EventsController@indexByDate')
     ->where('year', '[1-9][0-9][0-9][0-9]')
     ->where('month', '(0?[1-9]|1[012])')


### PR DESCRIPTION
## Summary
- add filters and sorting to `/users/{id}/events-attending`
- document query parameters for the new functionality

## Testing
- `composer test` *(fails: no vendor directory)*

------
https://chatgpt.com/codex/tasks/task_e_687f33a55dc8832285b7d62802fac4e9