### PR TITLE
Add OR tag filtering

### DIFF
--- a/app/Filters/EntityFilters.php
+++ b/app/Filters/EntityFilters.php
@@ -37,15 +37,40 @@ class EntityFilters extends QueryFilter
         }
     }
 
-    public function tag(?string $value = null): Builder
+    public function tag(mixed $value = null): Builder
     {
-        if (isset($value)) {
-            return $this->builder->whereHas('tags', function ($q) use ($value) {
-                $q->where('slug', '=', $value);
-            });
-        } else {
+        if (!isset($value)) {
             return $this->builder;
         }
+
+        $values = is_array($value) ? $value : array_filter(explode(',', (string) $value));
+
+        if (count($values) > 1) {
+            return $this->builder->whereHas('tags', function ($q) use ($values) {
+                $q->whereIn('slug', $values);
+            });
+        }
+
+        return $this->builder->whereHas('tags', function ($q) use ($values) {
+            $q->where('slug', '=', $values[0]);
+        });
+    }
+
+    public function tag_all(mixed $value = null): Builder
+    {
+        if (!isset($value)) {
+            return $this->builder;
+        }
+
+        $values = is_array($value) ? $value : array_filter(explode(',', (string) $value));
+
+        foreach ($values as $val) {
+            $this->builder->whereHas('tags', function ($q) use ($val) {
+                $q->where('slug', '=', $val);
+            });
+        }
+
+        return $this->builder;
     }
 
     public function role(?string $value = null): Builder

--- a/app/Filters/EventFilters.php
+++ b/app/Filters/EventFilters.php
@@ -37,15 +37,40 @@ class EventFilters extends QueryFilter
         }
     }
 
-    public function tag(?string $value = null): Builder
+    public function tag(mixed $value = null): Builder
     {
-        if (isset($value)) {
-            return $this->builder->whereHas('tags', function ($q) use ($value) {
-                $q->where('slug', '=', $value);
-            });
-        } else {
+        if (!isset($value)) {
             return $this->builder;
         }
+
+        $values = is_array($value) ? $value : array_filter(explode(',', (string) $value));
+
+        if (count($values) > 1) {
+            return $this->builder->whereHas('tags', function ($q) use ($values) {
+                $q->whereIn('slug', $values);
+            });
+        }
+
+        return $this->builder->whereHas('tags', function ($q) use ($values) {
+            $q->where('slug', '=', $values[0]);
+        });
+    }
+
+    public function tag_all(mixed $value = null): Builder
+    {
+        if (!isset($value)) {
+            return $this->builder;
+        }
+
+        $values = is_array($value) ? $value : array_filter(explode(',', (string) $value));
+
+        foreach ($values as $val) {
+            $this->builder->whereHas('tags', function ($q) use ($val) {
+                $q->where('slug', '=', $val);
+            });
+        }
+
+        return $this->builder;
     }
 
     public function related(?string $value = null): Builder

--- a/app/Filters/SeriesFilters.php
+++ b/app/Filters/SeriesFilters.php
@@ -37,15 +37,40 @@ class SeriesFilters extends QueryFilter
         }
     }
 
-    public function tag(?string $value = null): Builder
+    public function tag(mixed $value = null): Builder
     {
-        if (isset($value)) {
-            return $this->builder->whereHas('tags', function ($q) use ($value) {
-                $q->where('slug', '=', $value);
-            });
-        } else {
+        if (!isset($value)) {
             return $this->builder;
         }
+
+        $values = is_array($value) ? $value : array_filter(explode(',', (string) $value));
+
+        if (count($values) > 1) {
+            return $this->builder->whereHas('tags', function ($q) use ($values) {
+                $q->whereIn('slug', $values);
+            });
+        }
+
+        return $this->builder->whereHas('tags', function ($q) use ($values) {
+            $q->where('slug', '=', $values[0]);
+        });
+    }
+
+    public function tag_all(mixed $value = null): Builder
+    {
+        if (!isset($value)) {
+            return $this->builder;
+        }
+
+        $values = is_array($value) ? $value : array_filter(explode(',', (string) $value));
+
+        foreach ($values as $val) {
+            $this->builder->whereHas('tags', function ($q) use ($val) {
+                $q->where('slug', '=', $val);
+            });
+        }
+
+        return $this->builder;
     }
 
     public function related(?string $value = null): Builder

--- a/docs/api_notes.md
+++ b/docs/api_notes.md
@@ -24,4 +24,8 @@ You can apply filters to routes using the following:
   - Example: `GET /api/events?filters[name]=Event Name`
 - To order by a specific field, use the field name as the key and the value as the value.
   - Example: `GET /api/events?sort=model.property&direction=asc`
+- To filter events by multiple tags you can provide a comma separated list or repeat the `filters[tag]` parameter.
+  - `GET /api/events?filters[tag]=music,art`
+  - When you need events that contain *all* of the supplied tags, use `filters[tag_all]` instead.
+  - `GET /api/events?filters[tag_all]=music,art`
 


### PR DESCRIPTION
## Summary
- allow filtering events by multiple tags with `tag` filter
- support `tag_all` filter for AND matching
- document new tag filtering options in API notes

## Testing
- `php -l app/Filters/EventFilters.php`
- `composer test` *(fails: composer install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68826ba0c31c8322b7e4945065147f09