### PR TITLE
feat: add entity relationship endpoints

### DIFF
--- a/app/Http/Controllers/Api/EntitiesController.php
+++ b/app/Http/Controllers/Api/EntitiesController.php
@@ -17,6 +17,7 @@ use App\Models\Follow;
 use App\Models\Photo;
 use App\Models\Link;
 use App\Models\Location;
+use App\Models\Contact;
 use App\Models\Role;
 use App\Models\Tag;
 use App\Models\User;
@@ -91,6 +92,7 @@ class EntitiesController extends Controller
             'unfollowJson',
             'addLocation',
             'addLink',
+            'addContact',
         ]);
 
         parent::__construct();
@@ -756,6 +758,31 @@ class EntitiesController extends Controller
         return response()->json([], 404);
     }
 
+    /**
+     * Add a contact to an entity.
+     */
+    public function addContact(int $id, Request $request): JsonResponse
+    {
+        $this->validate($request, [
+            'name' => ['required', 'min:3'],
+            'type' => ['required', 'min:3'],
+            'visibility_id' => ['required', 'integer'],
+            'email' => ['nullable', 'email'],
+            'phone' => ['nullable', 'string'],
+            'other' => ['nullable', 'string'],
+        ]);
+
+        if ($entity = Entity::find($id)) {
+            $input = $request->only(['name', 'email', 'phone', 'other', 'type', 'visibility_id']);
+            $contact = Contact::create($input);
+            $entity->contacts()->attach($contact->id);
+
+            return response()->json($contact, 201);
+        }
+
+        return response()->json([], 404);
+    }
+
     protected function makePhoto(UploadedFile $file): Photo
     {
         return Photo::named($file->getClientOriginalName())->makeThumbnail();
@@ -1044,6 +1071,39 @@ class EntitiesController extends Controller
         
         // converts array of embeds into json embed list
         return response()->json($embeds);
+    }
+
+    public function links(?Entity $entity): JsonResponse
+    {
+        if (!$entity) {
+            abort(404);
+        }
+
+        $links = $entity->links()->get();
+
+        return response()->json($links);
+    }
+
+    public function locations(?Entity $entity): JsonResponse
+    {
+        if (!$entity) {
+            abort(404);
+        }
+
+        $locations = $entity->locations()->get();
+
+        return response()->json($locations);
+    }
+
+    public function contacts(?Entity $entity): JsonResponse
+    {
+        if (!$entity) {
+            abort(404);
+        }
+
+        $contacts = $entity->contacts()->get();
+
+        return response()->json($contacts);
     }
 
     public function photos(?Entity $entity): JsonResponse

--- a/app/Http/Controllers/Api/EntitiesController.php
+++ b/app/Http/Controllers/Api/EntitiesController.php
@@ -8,6 +8,7 @@ use App\Http\Requests\EntityRequest;
 use App\Http\Resources\EntityCollection;
 use App\Http\Resources\EntityResource;
 use App\Http\ResultBuilder\ListEntityResultBuilder;
+use App\Models\Action;
 use App\Models\Activity;
 use App\Models\Alias;
 use App\Models\Entity;
@@ -734,6 +735,9 @@ class EntitiesController extends Controller
             $link = Link::create($input);
             $entity->links()->attach($link->id);
 
+            // add to activity log
+            Activity::log($link, $this->user, Action::CREATE);
+
             return response()->json($link, 201);
         }
 
@@ -765,6 +769,9 @@ class EntitiesController extends Controller
                 }
                 $link->update($input);
 
+                // add to activity log
+                Activity::log($link, $this->user, Action::UPDATE);
+
                 return response()->json($link);
             }
         }
@@ -791,6 +798,9 @@ class EntitiesController extends Controller
             $location = new Location($input);
             $location->created_by = $request->user()->id;
             $location->save();
+
+            // add a location to activity log
+            Activity::log($location, $this->user, Action::CREATE);
 
             return response()->json($location, 201);
         }
@@ -821,6 +831,9 @@ class EntitiesController extends Controller
                 $input = $request->all();
                 $location->update($input);
 
+                // add to activity log
+                Activity::log($location, $this->user, Action::UPDATE);
+
                 return response()->json($location);
             }
         }
@@ -846,6 +859,8 @@ class EntitiesController extends Controller
             $input = $request->only(['name', 'email', 'phone', 'other', 'type', 'visibility_id']);
             $contact = Contact::create($input);
             $entity->contacts()->attach($contact->id);
+
+            Activity::log($contact, $this->user, Action::CREATE);
 
             return response()->json($contact, 201);
         }
@@ -877,6 +892,7 @@ class EntitiesController extends Controller
                 $input = $request->only(['name', 'email', 'phone', 'other', 'type', 'visibility_id']);
                 $contact->update($input);
 
+                Activity::log($contact, $this->user, Action::UPDATE);
                 return response()->json($contact);
             }
         }
@@ -895,6 +911,9 @@ class EntitiesController extends Controller
                 if ($request->user()->id !== ($link->created_by ?? $entity->created_by)) {
                     return response()->json([], 403);
                 }
+
+                // add to activity log
+                Activity::log($link, $this->user, Action::DELETE);
 
                 $entity->links()->detach($linkId);
                 $link->delete();
@@ -918,6 +937,9 @@ class EntitiesController extends Controller
                     return response()->json([], 403);
                 }
 
+                // add to activity log
+                Activity::log($location, $this->user, Action::DELETE);
+
                 $location->delete();
 
                 return response()->json([], 204);
@@ -938,6 +960,9 @@ class EntitiesController extends Controller
                 if ($request->user()->id !== ($contact->created_by ?? $entity->created_by)) {
                     return response()->json([], 403);
                 }
+
+                // add to activity log
+                Activity::log($contact, $this->user, Action::DELETE);
 
                 $entity->contacts()->detach($contactId);
                 $contact->delete();

--- a/app/Http/Controllers/Api/EntitiesController.php
+++ b/app/Http/Controllers/Api/EntitiesController.php
@@ -96,6 +96,9 @@ class EntitiesController extends Controller
             'updateLocation',
             'updateLink',
             'updateContact',
+            'deleteLink',
+            'deleteLocation',
+            'deleteContact',
         ]);
 
         parent::__construct();
@@ -875,6 +878,71 @@ class EntitiesController extends Controller
                 $contact->update($input);
 
                 return response()->json($contact);
+            }
+        }
+
+        return response()->json([], 404);
+    }
+
+    /**
+     * Delete a link from an entity.
+     */
+    public function deleteLink(int $id, int $linkId, Request $request): JsonResponse
+    {
+        if ($entity = Entity::find($id)) {
+            $link = $entity->links()->find($linkId);
+            if ($link) {
+                if ($request->user()->id !== ($link->created_by ?? $entity->created_by)) {
+                    return response()->json([], 403);
+                }
+
+                $entity->links()->detach($linkId);
+                $link->delete();
+
+                return response()->json([], 204);
+            }
+        }
+
+        return response()->json([], 404);
+    }
+
+    /**
+     * Delete a location from an entity.
+     */
+    public function deleteLocation(int $id, int $locationId, Request $request): JsonResponse
+    {
+        if ($entity = Entity::find($id)) {
+            $location = $entity->locations()->find($locationId);
+            if ($location) {
+                if ($request->user()->id !== ($location->created_by ?? $entity->created_by)) {
+                    return response()->json([], 403);
+                }
+
+                $location->delete();
+
+                return response()->json([], 204);
+            }
+        }
+
+        return response()->json([], 404);
+    }
+
+    /**
+     * Delete a contact from an entity.
+     */
+    public function deleteContact(int $id, int $contactId, Request $request): JsonResponse
+    {
+        if ($entity = Entity::find($id)) {
+            $contact = $entity->contacts()->find($contactId);
+            if ($contact) {
+                if ($request->user()->id !== ($contact->created_by ?? $entity->created_by)) {
+                    return response()->json([], 403);
+                }
+
+                $entity->contacts()->detach($contactId);
+                $contact->delete();
+
+                return response()->json([], 204);
             }
         }
 

--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -3726,6 +3726,41 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Link"
+  /api/entities/{id}/links/{linkId}:
+    put:
+      parameters:
+        - name: id
+          description: The unique identifier of the entity
+          in: path
+          required: true
+          schema:
+            type: integer
+            readOnly: true
+            example: 1
+        - name: linkId
+          description: The unique identifier of the link
+          in: path
+          required: true
+          schema:
+            type: integer
+            readOnly: true
+            example: 1
+      tags:
+        - entities
+      summary: Update Entity Link
+      operationId: updateEntityLinkById
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Link"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Link"
   /api/entities/{id}/locations:
     post:
       parameters:
@@ -3753,6 +3788,41 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Location"
+  /api/entities/{id}/locations/{locationId}:
+    put:
+      parameters:
+        - name: id
+          description: The unique identifier of the entity
+          in: path
+          required: true
+          schema:
+            type: integer
+            readOnly: true
+            example: 1
+        - name: locationId
+          description: The unique identifier of the location
+          in: path
+          required: true
+          schema:
+            type: integer
+            readOnly: true
+            example: 1
+      tags:
+        - entities
+      summary: Update Entity Location
+      operationId: updateEntityLocationById
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LocationRequest"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Location"
   /api/entities/{id}/contacts:
     post:
       parameters:
@@ -3775,6 +3845,41 @@ paths:
               $ref: "#/components/schemas/Contact"
       responses:
         "201":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Contact"
+  /api/entities/{id}/contacts/{contactId}:
+    put:
+      parameters:
+        - name: id
+          description: The unique identifier of the entity
+          in: path
+          required: true
+          schema:
+            type: integer
+            readOnly: true
+            example: 1
+        - name: contactId
+          description: The unique identifier of the contact
+          in: path
+          required: true
+          schema:
+            type: integer
+            readOnly: true
+            example: 1
+      tags:
+        - entities
+      summary: Update Entity Contact
+      operationId: updateEntityContactById
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Contact"
+      responses:
+        "200":
           description: Successful response
           content:
             application/json:

--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -3761,6 +3761,33 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Link"
+    delete:
+      parameters:
+        - name: id
+          description: The unique identifier of the entity
+          in: path
+          required: true
+          schema:
+            type: integer
+            readOnly: true
+            example: 1
+        - name: linkId
+          description: The unique identifier of the link
+          in: path
+          required: true
+          schema:
+            type: integer
+            readOnly: true
+            example: 1
+      tags:
+        - entities
+      summary: Delete Entity Link
+      operationId: deleteEntityLinkById
+      responses:
+        "204":
+          description: Successful response
+          content:
+            application/json: {}
   /api/entities/{id}/locations:
     post:
       parameters:
@@ -3823,6 +3850,33 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Location"
+    delete:
+      parameters:
+        - name: id
+          description: The unique identifier of the entity
+          in: path
+          required: true
+          schema:
+            type: integer
+            readOnly: true
+            example: 1
+        - name: locationId
+          description: The unique identifier of the location
+          in: path
+          required: true
+          schema:
+            type: integer
+            readOnly: true
+            example: 1
+      tags:
+        - entities
+      summary: Delete Entity Location
+      operationId: deleteEntityLocationById
+      responses:
+        "204":
+          description: Successful response
+          content:
+            application/json: {}
   /api/entities/{id}/contacts:
     post:
       parameters:
@@ -3885,6 +3939,33 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Contact"
+    delete:
+      parameters:
+        - name: id
+          description: The unique identifier of the entity
+          in: path
+          required: true
+          schema:
+            type: integer
+            readOnly: true
+            example: 1
+        - name: contactId
+          description: The unique identifier of the contact
+          in: path
+          required: true
+          schema:
+            type: integer
+            readOnly: true
+            example: 1
+      tags:
+        - entities
+      summary: Delete Entity Contact
+      operationId: deleteEntityContactById
+      responses:
+        "204":
+          description: Successful response
+          content:
+            application/json: {}
   /api/entities/{slug}/follow:
     post:
       parameters:

--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -1136,6 +1136,69 @@ components:
             data:
               type: array
               items: { "$ref": "#/components/schemas/Link" }
+    Contact:
+      type: object
+      required:
+        - name
+        - type
+        - visibility_id
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          example: 1
+        name:
+          type: string
+          maxLength: 255
+          description: Name of the contact
+          example: John Doe
+        email:
+          type: string
+          maxLength: 255
+          nullable: true
+          description: Email address of the contact
+          example: john@example.com
+        phone:
+          type: string
+          maxLength: 255
+          nullable: true
+          description: Phone number of the contact
+          example: "555-555-5555"
+        other:
+          type: string
+          maxLength: 255
+          nullable: true
+          description: Other contact information
+          example: "Discord: johndoe#1234"
+        type:
+          type: string
+          maxLength: 255
+          description: Type of contact
+          example: Email
+        visibility_id:
+          type: integer
+          description: The visibility id associated with the contact
+          example: 1
+        created_at:
+          type: string
+          example: "2018-03-20T09:12:28Z"
+          format: date-time
+          description: Date and time the contact was created
+          readOnly: true
+        updated_at:
+          type: string
+          example: "2018-03-20T09:12:28Z"
+          format: date-time
+          description: Date and time the contact was last updated
+          readOnly: true
+    Contacts:
+      allOf:
+        - $ref: "#/components/schemas/Pagination"
+        - type: object
+          properties:
+            data:
+              type: array
+              items: { "$ref": "#/components/schemas/Contact" }
     Menu:
       type: object
       required:
@@ -3539,6 +3602,72 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Photos"
+  /api/entities/{slug}/links:
+    get:
+      parameters:
+        - name: slug
+          description: The unique identifier of the entity
+          in: path
+          required: true
+          schema:
+            type: string
+            readOnly: true
+            example: "strobe"
+      tags:
+        - entities
+      summary: Get Entity Links
+      operationId: getEntityLinksBySlug
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Links"
+  /api/entities/{slug}/locations:
+    get:
+      parameters:
+        - name: slug
+          description: The unique identifier of the entity
+          in: path
+          required: true
+          schema:
+            type: string
+            readOnly: true
+            example: "strobe"
+      tags:
+        - entities
+      summary: Get Entity Locations
+      operationId: getEntityLocationsBySlug
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Location"
+  /api/entities/{slug}/contacts:
+    get:
+      parameters:
+        - name: slug
+          description: The unique identifier of the entity
+          in: path
+          required: true
+          schema:
+            type: string
+            readOnly: true
+            example: "strobe"
+      tags:
+        - entities
+      summary: Get Entity Contacts
+      operationId: getEntityContactsBySlug
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Contacts"
   /api/entities/{id}/photos:
     post:
       parameters:
@@ -3624,6 +3753,33 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Location"
+  /api/entities/{id}/contacts:
+    post:
+      parameters:
+        - name: id
+          description: The unique identifier of the entity
+          in: path
+          required: true
+          schema:
+            type: integer
+            readOnly: true
+            example: 1
+      tags:
+        - entities
+      summary: Add Entity Contact
+      operationId: addEntityContactById
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Contact"
+      responses:
+        "201":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Contact"
   /api/entities/{slug}/follow:
     post:
       parameters:

--- a/routes/api.php
+++ b/routes/api.php
@@ -93,6 +93,9 @@ Route::middleware('auth.either')->name('api.')->group(function () {
     Route::post('entities/{id}/links', 'Api\EntitiesController@addLink');
     Route::post('entities/{id}/locations', 'Api\EntitiesController@addLocation');
     Route::post('entities/{id}/contacts', 'Api\EntitiesController@addContact');
+    Route::put('entities/{id}/links/{linkId}', 'Api\EntitiesController@updateLink');
+    Route::put('entities/{id}/locations/{locationId}', 'Api\EntitiesController@updateLocation');
+    Route::put('entities/{id}/contacts/{contactId}', 'Api\EntitiesController@updateContact');
     Route::post('entities/{entity}/follow', 'Api\EntitiesController@followJson')->middleware('auth:sanctum');
     Route::post('entities/{entity}/unfollow', 'Api\EntitiesController@unfollowJson')->middleware('auth:sanctum');
     Route::resource('entities', 'Api\EntitiesController');

--- a/routes/api.php
+++ b/routes/api.php
@@ -84,11 +84,15 @@ Route::middleware('auth.either')->name('api.')->group(function () {
     Route::resource('events', 'Api\EventsController');
 
     Route::get('entities/{entity}/photos', ['as' => 'entities.photos', 'uses' => 'Api\EntitiesController@photos']);
+    Route::get('entities/{entity}/links', ['as' => 'entities.links', 'uses' => 'Api\EntitiesController@links']);
+    Route::get('entities/{entity}/locations', ['as' => 'entities.locations', 'uses' => 'Api\EntitiesController@locations']);
+    Route::get('entities/{entity}/contacts', ['as' => 'entities.contacts', 'uses' => 'Api\EntitiesController@contacts']);
     Route::get('entities/{entity}/embeds', ['as' => 'entities.embeds', 'uses' => 'Api\EntitiesController@embeds']);
     Route::get('entities/{entity}/minimal-embeds', ['as' => 'entities.minimalEmbeds', 'uses' => 'Api\EntitiesController@minimalEmbeds']);
     Route::post('entities/{id}/photos', 'Api\EntitiesController@addPhoto');
     Route::post('entities/{id}/links', 'Api\EntitiesController@addLink');
     Route::post('entities/{id}/locations', 'Api\EntitiesController@addLocation');
+    Route::post('entities/{id}/contacts', 'Api\EntitiesController@addContact');
     Route::post('entities/{entity}/follow', 'Api\EntitiesController@followJson')->middleware('auth:sanctum');
     Route::post('entities/{entity}/unfollow', 'Api\EntitiesController@unfollowJson')->middleware('auth:sanctum');
     Route::resource('entities', 'Api\EntitiesController');

--- a/routes/api.php
+++ b/routes/api.php
@@ -96,6 +96,9 @@ Route::middleware('auth.either')->name('api.')->group(function () {
     Route::put('entities/{id}/links/{linkId}', 'Api\EntitiesController@updateLink');
     Route::put('entities/{id}/locations/{locationId}', 'Api\EntitiesController@updateLocation');
     Route::put('entities/{id}/contacts/{contactId}', 'Api\EntitiesController@updateContact');
+    Route::delete('entities/{id}/links/{linkId}', 'Api\EntitiesController@deleteLink');
+    Route::delete('entities/{id}/locations/{locationId}', 'Api\EntitiesController@deleteLocation');
+    Route::delete('entities/{id}/contacts/{contactId}', 'Api\EntitiesController@deleteContact');
     Route::post('entities/{entity}/follow', 'Api\EntitiesController@followJson')->middleware('auth:sanctum');
     Route::post('entities/{entity}/unfollow', 'Api\EntitiesController@unfollowJson')->middleware('auth:sanctum');
     Route::resource('entities', 'Api\EntitiesController');


### PR DESCRIPTION
## Summary
- expose endpoints to fetch links, locations, and contacts for an entity
- allow creating contacts for entities with validation
- document new endpoints and contact schema in OpenAPI spec

## Testing
- `composer tests` *(fails: Failed opening required '/workspace/events-tracker/bootstrap/../vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_689276c30edc8322bd380621f808ad66