### PR TITLE
Add tag description and expose tag_type_id in API

### DIFF
--- a/app/Http/Requests/TagRequest.php
+++ b/app/Http/Requests/TagRequest.php
@@ -21,6 +21,8 @@ class TagRequest extends Request
         return [
             'name' => 'required|min:3|max:16',
             'slug' => Rule::unique('tags')->ignore(isset($this->tag) ? $this->tag->id : ''),
+            'tag_type_id' => 'nullable|exists:tag_types,id',
+            'description' => 'nullable|string',
         ];
     }
 }

--- a/app/Http/Resources/TagResource.php
+++ b/app/Http/Resources/TagResource.php
@@ -22,9 +22,11 @@ class TagResource extends JsonResource
             'id' => $this->id,
             'name' => $this->name,
             'slug' => $this->slug,
+            'description' => $this->description,
+            'tag_type_id' => $this->tag_type_id,
             'tag_type' => $this->tagType,
             'created_at' => $this->created_at,
-            'updated_at' => $this->updated_at
+            'updated_at' => $this->updated_at,
             ];
     }
 }

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Collection;
  * @property int|null $user_id
  * @property string   $name
  * @property string   $slug
+ * @property string|null $description
  * @property TagType  $tagType
  * @property int|null $tag_type_id
  * @property DateTime $created_at
@@ -25,7 +26,7 @@ class Tag extends Eloquent
     use HasFactory;
 
     protected $fillable = [
-        'name', 'tag_type_id', 'slug',
+        'name', 'tag_type_id', 'slug', 'description',
     ];
 
     public function getRouteKeyName()

--- a/database/factories/TagFactory.php
+++ b/database/factories/TagFactory.php
@@ -30,6 +30,7 @@ class TagFactory extends Factory
             'tag_type_id' => function () {
                 return TagType::all()->random()->id;
             },
+            'description' => $this->faker->sentence,
             'created_at' => Carbon::now(),
             'updated_at' => Carbon::now()
         ];

--- a/database/migrations/2024_05_30_000000_add_description_to_tags_table.php
+++ b/database/migrations/2024_05_30_000000_add_description_to_tags_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasTable('tags')) {
+            return;
+        }
+        Schema::table('tags', function (Blueprint $table) {
+            if (!Schema::hasColumn('tags', 'description')) {
+                $table->text('description')->nullable();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('tags')) {
+            return;
+        }
+        Schema::table('tags', function (Blueprint $table) {
+            if (Schema::hasColumn('tags', 'description')) {
+                $table->dropColumn('description');
+            }
+        });
+    }
+};

--- a/database/seeders/TagsTableSeeder.php
+++ b/database/seeders/TagsTableSeeder.php
@@ -18,18 +18,21 @@ class TagsTableSeeder extends Seeder
             'name' => 'Jungle',
             'tag_type_id' => $type->id,
             'slug' => 'jungle',
+            'description' => 'Jungle genre',
         ]);
 
         Tag::create([
             'name' => 'Club Music',
             'tag_type_id' => $type->id,
             'slug' => 'club-music',
+            'description' => 'Club Music genre',
         ]);
 
         Tag::create([
             'name' => 'Footwork',
             'tag_type_id' => $type->id,
             'slug' => 'footwork',
+            'description' => 'Footwork genre',
         ]);
     }
 }

--- a/public/postman/schemas/action-api.yml
+++ b/public/postman/schemas/action-api.yml
@@ -1463,7 +1463,6 @@ components:
       type: object
       required:
         - name
-        - tag_type_id
       properties:
         id:
           type: integer
@@ -1482,6 +1481,7 @@ components:
         tag_type_id:
           type: integer
           readOnly: true
+          nullable: true
           example: 1
           description: Relation to the tag type table that defines the type of tag
         created_at:

--- a/public/postman/schemas/api-3.0.0.yml
+++ b/public/postman/schemas/api-3.0.0.yml
@@ -1649,7 +1649,6 @@ components:
       type: object
       required:
         - name
-        - tag_type_id
       properties:
         id:
           type: integer
@@ -1668,6 +1667,7 @@ components:
         tag_type_id:
           type: integer
           readOnly: true
+          nullable: true
           example: 1
           description: Relation to the tag type table that defines the type of tag
         created_at:

--- a/public/postman/schemas/api-3.0.3.yml
+++ b/public/postman/schemas/api-3.0.3.yml
@@ -1785,7 +1785,6 @@ components:
       type: object
       required:
         - name
-        - tag_type_id
       properties:
         id:
           type: integer
@@ -1801,9 +1800,14 @@ components:
           maxLength: 255
           description: A unique identifier name for the tag in kebab-case
           example: post-punk
+        description:
+          type: string
+          nullable: true
+          description: Full description of the tag
+          example: "A genre focused on bass-heavy breakbeats"
         tag_type_id:
           type: integer
-          readOnly: true
+          nullable: true
           example: 1
           description: Relation to the tag type table that defines the type of tag
         created_at:

--- a/public/postman/schemas/api-3.1.0.yml
+++ b/public/postman/schemas/api-3.1.0.yml
@@ -1649,7 +1649,6 @@ components:
       type: object
       required:
         - name
-        - tag_type_id
       properties:
         id:
           type: integer
@@ -1665,9 +1664,14 @@ components:
           maxLength: 255
           description: A unique identifier name for the tag in kebab-case
           example: post-punk
+        description:
+          type: string
+          nullable: true
+          description: Full description of the tag
+          example: "A genre focused on bass-heavy breakbeats"
         tag_type_id:
           type: integer
-          readOnly: true
+          nullable: true
           example: 1
           description: Relation to the tag type table that defines the type of tag
         created_at:

--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -1891,7 +1891,6 @@ components:
       type: object
       required:
         - name
-        - tag_type_id
       properties:
         id:
           type: integer
@@ -1907,9 +1906,14 @@ components:
           maxLength: 255
           description: A unique identifier name for the tag in kebab-case
           example: post-punk
+        description:
+          type: string
+          nullable: true
+          description: Full description of the tag
+          example: "A genre focused on bass-heavy breakbeats"
         tag_type_id:
           type: integer
-          readOnly: true
+          nullable: true
           example: 1
           description: Relation to the tag type table that defines the type of tag
         created_at:

--- a/public/postman/schemas/minimal-api.yml
+++ b/public/postman/schemas/minimal-api.yml
@@ -1254,7 +1254,6 @@ components:
       type: object
       required:
         - name
-        - tag_type_id
       properties:
         id:
           type: integer
@@ -1273,6 +1272,7 @@ components:
         tag_type_id:
           type: integer
           readOnly: true
+          nullable: true
           example: 1
           description: Relation to the tag type table that defines the type of tag
         created_at:


### PR DESCRIPTION
## Summary
- allow tags to store a description
- expose `description` and optional `tag_type_id` via API and validation
- document new fields in the OpenAPI specs

## Testing
- `composer tests` *(fails: Failed opening required '/workspace/events-tracker/bootstrap/../vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_6896238691208322b402b0c3531cdcdc