### PR TITLE
Log password reset requests and completions

### DIFF
--- a/app/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/Auth/ForgotPasswordController.php
@@ -3,7 +3,12 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Models\Action;
+use App\Models\Activity;
+use App\Models\User;
 use Illuminate\Foundation\Auth\SendsPasswordResetEmails;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Password;
 
 class ForgotPasswordController extends Controller
 {
@@ -19,4 +24,31 @@ class ForgotPasswordController extends Controller
     */
 
     use SendsPasswordResetEmails;
+
+    public function sendResetLinkEmail(Request $request)
+    {
+        $this->validateEmail($request);
+
+        $email = $request->input('email');
+        /** @var User|null $user */
+        $user = User::where('email', $email)->first();
+
+        $activity = new Activity();
+        $activity->user_id = $user?->id;
+        $activity->object_table = 'User';
+        $activity->object_id = $user?->id;
+        $activity->object_name = $email;
+        $activity->action_id = Action::PASSWORD_RESET_REQUEST;
+        $activity->message = 'Password reset link requested for ' . $email;
+        $activity->ip_address = $request->ip();
+        $activity->save();
+
+        $response = $this->broker()->sendResetLink(
+            $this->credentials($request)
+        );
+
+        return $response == Password::RESET_LINK_SENT
+                    ? $this->sendResetLinkResponse($request, $response)
+                    : $this->sendResetLinkFailedResponse($request, $response);
+    }
 }

--- a/app/Models/Action.php
+++ b/app/Models/Action.php
@@ -24,6 +24,10 @@ class Action extends Eloquent
     const LOCK = 8;
     const UNLOCK = 9;
 
+    // Additional actions
+    const PASSWORD_RESET_REQUEST = 17;
+    const PASSWORD_RESET = 18;
+
     /**
      * The storage format of the model's date columns.
      *


### PR DESCRIPTION
## Summary
- track password reset events with new action constants
- log activity when a reset link is requested, capturing the email address
- log activity after a password is successfully reset

## Testing
- `php -l app/Models/Action.php app/Http/Controllers/Auth/ForgotPasswordController.php app/Http/Controllers/Auth/ResetPasswordController.php`
- `composer tests` *(fails: require vendor/autoload.php)*
- `composer install` *(fails: GitHub 403 for package downloads)*

------
https://chatgpt.com/codex/tasks/task_e_689ad3e2f80883229d5575daaa0f936e