### PR TITLE
Add TagType API endpoints and OpenAPI spec

### DIFF
--- a/app/Filters/TagTypeFilters.php
+++ b/app/Filters/TagTypeFilters.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Filters;
+
+use Illuminate\Database\Eloquent\Builder;
+
+class TagTypeFilters extends QueryFilter
+{
+    public function name(?string $value = null): Builder
+    {
+        if (isset($value)) {
+            return $this->builder->where('name', 'like', '%'.$value.'%');
+        }
+
+        return $this->builder;
+    }
+}
+

--- a/app/Http/Controllers/Api/TagTypesController.php
+++ b/app/Http/Controllers/Api/TagTypesController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Filters\TagTypeFilters;
+use App\Http\Controllers\Controller;
+use App\Http\ResultBuilder\ListEntityResultBuilder;
+use App\Models\TagType;
+use App\Services\SessionStore\ListParameterSessionStore;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class TagTypesController extends Controller
+{
+    protected TagTypeFilters $filter;
+
+    public function __construct(TagTypeFilters $filter)
+    {
+        $this->filter = $filter;
+        parent::__construct();
+    }
+
+    public function index(
+        Request $request,
+        ListParameterSessionStore $listParamSessionStore,
+        ListEntityResultBuilder $listEntityResultBuilder
+    ): JsonResponse {
+        $listParamSessionStore->setBaseIndex('internal_tag_type');
+        $listParamSessionStore->setKeyPrefix('internal_tag_type_index');
+
+        $baseQuery = TagType::query()->select('tag_types.*');
+
+        $listEntityResultBuilder
+            ->setFilter($this->filter)
+            ->setQueryBuilder($baseQuery)
+            ->setDefaultSort(['tag_types.name' => 'asc']);
+
+        $listResultSet = $listEntityResultBuilder->listResultSetFactory();
+        $query = $listResultSet->getList();
+        $tagTypes = $query->paginate($listResultSet->getLimit());
+
+        return response()->json($tagTypes);
+    }
+
+    public function filter(
+        Request $request,
+        ListParameterSessionStore $listParamSessionStore,
+        ListEntityResultBuilder $listEntityResultBuilder
+    ): JsonResponse {
+        return $this->index($request, $listParamSessionStore, $listEntityResultBuilder);
+    }
+
+    public function show(TagType $tagType): JsonResponse
+    {
+        return response()->json($tagType);
+    }
+}
+

--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -30,14 +30,14 @@ tags:
   - name: occurrence-weeks
   - name: occurrence-days
   - name: photos
-    - name: posts
-    - name: roles
-    - name: series
-    - name: tags
-    - name: tag-types
-    - name: threads
-    - name: users
-    - name: visibilities
+  - name: posts
+  - name: roles
+  - name: series
+  - name: tags
+  - name: tag-types
+  - name: threads
+  - name: users
+  - name: visibilities
 components:
   responses:
     NotFound:
@@ -1930,52 +1930,52 @@ components:
           format: date-time
           description: Date and time that the tag was last updated
           readOnly: true
-      Tags:
-        allOf: # Combines the BasicErrorModel and the inline model
-          - $ref: "#/components/schemas/Pagination"
-          - type: object
-            properties:
-              data:
-                type: array
-                items: { "$ref": "#/components/schemas/Tag" }
-      TagType:
-        type: object
-        required:
-          - name
-        properties:
-          id:
-            type: integer
-            readOnly: true
-            example: 1
-          name:
-            type: string
-            example: Genre
-          created_at:
-            type: string
-            example: "2018-03-20T09:12:28Z"
-            format: date-time
-            description: Date and time that the tag type was created
-            readOnly: true
-          updated_at:
-            type: string
-            example: "2018-03-20T09:12:28Z"
-            format: date-time
-            description: Date and time that the tag type was last updated
-            readOnly: true
-      TagTypes:
-        allOf: [$ref: "#/components/schemas/Pagination"]
-        type: object
-        properties:
-          data:
-            type: array
-            description: List of the current page of tag types
-            items:
-              "$ref": "#/components/schemas/TagType"
-      Role:
-        type: object
-        required:
-          - name
-          - slug
+    Tags:
+      allOf: # Combines the BasicErrorModel and the inline model
+        - $ref: "#/components/schemas/Pagination"
+        - type: object
+          properties:
+            data:
+              type: array
+              items: { "$ref": "#/components/schemas/Tag" }
+    TagType:
+      type: object
+      required:
+        - name
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          example: 1
+        name:
+          type: string
+          example: Genre
+        created_at:
+          type: string
+          example: "2018-03-20T09:12:28Z"
+          format: date-time
+          description: Date and time that the tag type was created
+          readOnly: true
+        updated_at:
+          type: string
+          example: "2018-03-20T09:12:28Z"
+          format: date-time
+          description: Date and time that the tag type was last updated
+          readOnly: true
+    TagTypes:
+      allOf: [$ref: "#/components/schemas/Pagination"]
+      type: object
+      properties:
+        data:
+          type: array
+          description: List of the current page of tag types
+          items:
+            "$ref": "#/components/schemas/TagType"
+    Role:
+      type: object
+      required:
+        - name
+        - slug
       properties:
         id:
           type: integer

--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -30,13 +30,14 @@ tags:
   - name: occurrence-weeks
   - name: occurrence-days
   - name: photos
-  - name: posts
-  - name: roles
-  - name: series
-  - name: tags
-  - name: threads
-  - name: users
-  - name: visibilities
+    - name: posts
+    - name: roles
+    - name: series
+    - name: tags
+    - name: tag-types
+    - name: threads
+    - name: users
+    - name: visibilities
 components:
   responses:
     NotFound:
@@ -1929,19 +1930,52 @@ components:
           format: date-time
           description: Date and time that the tag was last updated
           readOnly: true
-    Tags:
-      allOf: # Combines the BasicErrorModel and the inline model
-        - $ref: "#/components/schemas/Pagination"
-        - type: object
-          properties:
-            data:
-              type: array
-              items: { "$ref": "#/components/schemas/Tag" }
-    Role:
-      type: object
-      required:
-        - name
-        - slug
+      Tags:
+        allOf: # Combines the BasicErrorModel and the inline model
+          - $ref: "#/components/schemas/Pagination"
+          - type: object
+            properties:
+              data:
+                type: array
+                items: { "$ref": "#/components/schemas/Tag" }
+      TagType:
+        type: object
+        required:
+          - name
+        properties:
+          id:
+            type: integer
+            readOnly: true
+            example: 1
+          name:
+            type: string
+            example: Genre
+          created_at:
+            type: string
+            example: "2018-03-20T09:12:28Z"
+            format: date-time
+            description: Date and time that the tag type was created
+            readOnly: true
+          updated_at:
+            type: string
+            example: "2018-03-20T09:12:28Z"
+            format: date-time
+            description: Date and time that the tag type was last updated
+            readOnly: true
+      TagTypes:
+        allOf: [$ref: "#/components/schemas/Pagination"]
+        type: object
+        properties:
+          data:
+            type: array
+            description: List of the current page of tag types
+            items:
+              "$ref": "#/components/schemas/TagType"
+      Role:
+        type: object
+        required:
+          - name
+          - slug
       properties:
         id:
           type: integer
@@ -5678,6 +5712,77 @@ paths:
           description: Successful response
           content:
             application/json: {}
+  /api/tag-types:
+    get:
+      tags:
+        - tag-types
+      summary: Get Tag Types
+      operationId: getTagTypes
+      parameters:
+        - name: filters[name]
+          in: query
+          required: false
+          description: A filter query of the tag type name
+          schema:
+            type: string
+            example: "Genre"
+        - name: limit
+          in: query
+          required: false
+          description: The limit on the number of results to return per page
+          schema:
+            type: integer
+            example: 25
+        - name: page
+          in: query
+          required: false
+          description: The page number to return
+          schema:
+            type: integer
+            example: 1
+        - name: sort
+          in: query
+          required: false
+          description: A column to be used to sort the query
+          schema:
+            type: string
+            example: name
+        - name: direction
+          in: query
+          required: false
+          description: A string indicating the sort direction of the query (asc or desc)
+          schema:
+            type: string
+            example: asc
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TagTypes"
+  /api/tag-types/{tagTypeId}:
+    parameters:
+      - name: tagTypeId
+        description: The unique identifier of the tag type
+        in: path
+        required: true
+        schema:
+          type: integer
+          readOnly: true
+          example: 1
+    get:
+      tags:
+        - tag-types
+      summary: Get Tag Type
+      operationId: getTagTypeById
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TagType"
   /api/threads:
     get:
       tags:

--- a/routes/api.php
+++ b/routes/api.php
@@ -154,6 +154,9 @@ Route::middleware('auth.either')->name('api.')->group(function () {
     Route::post('tags/{tag}/follow', 'Api\TagsController@followJson')->middleware('auth:sanctum');
     Route::post('tags/{tag}/unfollow', 'Api\TagsController@unfollowJson')->middleware('auth:sanctum');
     Route::resource('tags', 'Api\TagsController');
+    Route::match(['get', 'post'], 'tag-types/filter', ['as' => 'tag-types.filter', 'uses' => 'Api\TagTypesController@filter']);
+    Route::resource('tag-types', 'Api\TagTypesController')->only(['index', 'show']);
+
 
     Route::match(['get', 'post'], 'roles/filter', ['as' => 'roles.filter', 'uses' => 'Api\RolesController@filter']);
     Route::get('roles/reset', ['as' => 'roles.reset', 'uses' => 'Api\RolesController@reset']);


### PR DESCRIPTION
## Summary
- add `TagTypesController` and `TagTypeFilters` for listing and viewing tag types
- register API routes for tag type list and detail
- document tag type endpoints in the OpenAPI spec

## Testing
- `php -l app/Filters/TagTypeFilters.php app/Http/Controllers/Api/TagTypesController.php`
- `composer install` *(fails: GitHub authentication required)*

------
https://chatgpt.com/codex/tasks/task_e_689bc3036dfc8322b8664ec1f7a472e4