### PR TITLE
Show primary and ticket links on series page

### DIFF
--- a/resources/views/series/show.blade.php
+++ b/resources/views/series/show.blade.php
@@ -77,10 +77,25 @@
 		@endif
 		</p>
 
-		<br>
-		@if ($series->facebook_username)
-				<b>Facebook:</b> <a href="https://facebook.com/{{ $series->facebook_username }}" target="_">{{$series->facebook_username}}</a>
-		@endif
+                <br>
+                @if ($link = $series->primary_link)
+                <a href="{{ $link }}" target="_" title="Primary link">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-link-45deg" viewBox="0 0 16 16">
+                                <path d="M4.715 6.542 3.343 7.914a3 3 0 1 0 4.243 4.243l1.828-1.829A3 3 0 0 0 8.586 5.5L8 6.086a1.002 1.002 0 0 0-.154.199 2 2 0 0 1 .861 3.337L6.88 11.45a2 2 0 1 1-2.83-2.83l.793-.792a4.018 4.018 0 0 1-.128-1.287z"/>
+                                <path d="M6.586 4.672A3 3 0 0 0 7.414 9.5l.775-.776a2 2 0 0 1-.896-3.346L9.12 3.55a2 2 0 1 1 2.83 2.83l-.793.792c.112.42.155.855.128 1.287l1.372-1.372a3 3 0 1 0-4.243-4.243L6.586 4.672z"/>
+                          </svg>
+                </a>
+                @endif
+
+                @if ($ticket = $series->ticket_link)
+                <a href="{{ $ticket }}" target="_" title="Ticket link">
+                        <i class="bi-ticket-perforated"></i>
+                </a>
+                @endif
+
+                @if ($series->facebook_username)
+                                <b>Facebook:</b> <a href="https://facebook.com/{{ $series->facebook_username }}" target="_">{{$series->facebook_username}}</a>
+                @endif
 
 		@if ($series->twitter_username)
 				<b>Twitter:</b> <a href="https://twitter.com/{{ $series->twitter_username }}" target="_">{{ '@' }}{{ $series->twitter_username }}</a>


### PR DESCRIPTION
## Summary
- show primary and ticket link icons on series detail page

## Testing
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e11b4ccf0832291da57afd7ab860c