### PR TITLE
Enforce slug formatting in API validation

### DIFF
--- a/app/Http/Controllers/Api/EntitiesController.php
+++ b/app/Http/Controllers/Api/EntitiesController.php
@@ -786,7 +786,7 @@ class EntitiesController extends Controller
     {
         $this->validate($request, [
             'name' => ['required', 'min:3'],
-            'slug' => ['required', 'min:3'],
+            'slug' => ['required', 'min:3', 'regex:/^[a-z0-9-]+$/'],
             'city' => ['required', 'min:3'],
             'visibility_id' => ['required'],
             'location_type_id' => ['required'],
@@ -815,7 +815,7 @@ class EntitiesController extends Controller
     {
         $this->validate($request, [
             'name' => ['sometimes', 'required', 'min:3'],
-            'slug' => ['sometimes', 'required', 'min:3'],
+            'slug' => ['sometimes', 'required', 'min:3', 'regex:/^[a-z0-9-]+$/'],
             'city' => ['sometimes', 'required', 'min:3'],
             'visibility_id' => ['sometimes', 'required'],
             'location_type_id' => ['sometimes', 'required'],

--- a/app/Http/Requests/BlogRequest.php
+++ b/app/Http/Requests/BlogRequest.php
@@ -25,7 +25,7 @@ class BlogRequest extends Request
     {
         return [
             'name' => 'required|min:3|max:255',
-            'slug' => 'required|min:3|max:255|unique:blogs,slug',
+            'slug' => 'required|min:3|max:255|regex:/^[a-z0-9-]+$/|unique:blogs,slug',
             'body' => 'required|min:3|max:65535',
             'visibility_id' => 'required|integer',
             'content_type_id' => 'required|integer',

--- a/app/Http/Requests/EntityRequest.php
+++ b/app/Http/Requests/EntityRequest.php
@@ -25,6 +25,7 @@ class EntityRequest extends Request
             'slug' => [
                 'required',
                 'string',
+                'regex:/^[a-z0-9-]+$/',
                 Rule::unique('entities', 'slug')->ignore($entitySlug),
             ],
             'short' => 'required|max:255',

--- a/app/Http/Requests/EntityTypeRequest.php
+++ b/app/Http/Requests/EntityTypeRequest.php
@@ -30,6 +30,7 @@ class EntityTypeRequest extends Request
             'slug' => [
                 'required',
                 'string',
+                'regex:/^[a-z0-9-]+$/',
                 Rule::unique('entity_types', 'slug')->ignore($entityTypeId),
             ],
             'short' => 'required|min:3|max:255',

--- a/app/Http/Requests/EventRequest.php
+++ b/app/Http/Requests/EventRequest.php
@@ -31,6 +31,7 @@ class EventRequest extends Request
             'slug' => [
                 'required',
                 'string',
+                'regex:/^[a-z0-9-]+$/',
                 Rule::unique('events', 'slug')->ignore($eventSlug),
             ],
             'short' => 'max:255',

--- a/app/Http/Requests/EventTypeRequest.php
+++ b/app/Http/Requests/EventTypeRequest.php
@@ -30,6 +30,7 @@ class EventTypeRequest extends Request
             'slug' => [
                 'required',
                 'string',
+                'regex:/^[a-z0-9-]+$/',
                 Rule::unique('event_types', 'slug')->ignore($eventTypeId),
             ],
         ];

--- a/app/Http/Requests/ForumRequest.php
+++ b/app/Http/Requests/ForumRequest.php
@@ -26,7 +26,7 @@ class ForumRequest extends Request
     {
         return [
             'name' => 'required|min:3',
-            'slug' => 'required|min:3',
+            'slug' => 'required|min:3|regex:/^[a-z0-9-]+$/',
             'visibility_id' => 'required',
         ];
     }

--- a/app/Http/Requests/LocationRequest.php
+++ b/app/Http/Requests/LocationRequest.php
@@ -28,7 +28,7 @@ class LocationRequest extends Request
     {
         return [
             'name' => 'required|min:3',
-            'slug' => 'required|min:3',
+            'slug' => 'required|min:3|regex:/^[a-z0-9-]+$/',
             'city' => 'required|min:3',
             'visibility_id' => 'required',
             'location_type_id' => 'required',

--- a/app/Http/Requests/MenuRequest.php
+++ b/app/Http/Requests/MenuRequest.php
@@ -23,7 +23,7 @@ class MenuRequest extends Request
     {
         return [
             'name' => 'required|min:3',
-            'slug' => 'required|min:3',
+            'slug' => 'required|min:3|regex:/^[a-z0-9-]+$/',
             'body' => 'required',
             'visibility_id' => 'required',
         ];

--- a/app/Http/Requests/RoleRequest.php
+++ b/app/Http/Requests/RoleRequest.php
@@ -26,6 +26,7 @@ class RoleRequest extends Request
             'slug' => [
                 'required',
                 'string',
+                'regex:/^[a-z0-9-]+$/',
                 Rule::unique('roles', 'slug')->ignore($roleId),
             ],
             'short' => 'nullable|max:255',

--- a/app/Http/Requests/SeriesRequest.php
+++ b/app/Http/Requests/SeriesRequest.php
@@ -38,6 +38,7 @@ class SeriesRequest extends Request
             'slug' => [
                 'required',
                 'string',
+                'regex:/^[a-z0-9-]+$/',
                 Rule::unique('series', 'slug')->ignore($seriesSlug),
             ],
             'short' => 'required|min:3|max:255',

--- a/app/Http/Requests/TagRequest.php
+++ b/app/Http/Requests/TagRequest.php
@@ -20,7 +20,11 @@ class TagRequest extends Request
     {
         return [
             'name' => 'required|min:3|max:16',
-            'slug' => Rule::unique('tags')->ignore(isset($this->tag) ? $this->tag->id : ''),
+            'slug' => [
+                'nullable',
+                'regex:/^[a-z0-9-]+$/',
+                Rule::unique('tags')->ignore(isset($this->tag) ? $this->tag->id : ''),
+            ],
             'tag_type_id' => 'nullable|exists:tag_types,id',
             'description' => 'nullable|string',
         ];

--- a/tests/Feature/EntitiesTest.php
+++ b/tests/Feature/EntitiesTest.php
@@ -61,7 +61,7 @@ class EntitiesTest extends TestCase
 
         // add an entity created by that user
         $entity = Entity::factory()
-            ->create(['created_by' => $user->id]);
+            ->create(['created_by' => $user->id, 'slug' => 'my-entity']);
 
         // try to edit the entity as the user who created
         $this->actingAs($user)
@@ -98,6 +98,7 @@ class EntitiesTest extends TestCase
         $this->signIn();
 
         $entity = Entity::factory()->make();
+        $entity->slug = 'new-entity';
 
         $response = $this->post('/entities', $entity->toArray());
 


### PR DESCRIPTION
## Summary
- restrict slug fields to lowercase alphanumerics and dashes in API request validators
- apply same slug rule to entity location endpoints

## Testing
- ⚠️ `composer install` (failed: curl error 56 with CONNECT tunnel 403)
- ⚠️ `./vendor/bin/phpunit` (failed: No such file or directory)
- ✅ `php -l app/Http/Controllers/Api/EntitiesController.php app/Http/Requests/BlogRequest.php app/Http/Requests/EntityRequest.php app/Http/Requests/EntityTypeRequest.php app/Http/Requests/EventRequest.php app/Http/Requests/EventTypeRequest.php app/Http/Requests/ForumRequest.php app/Http/Requests/LocationRequest.php app/Http/Requests/MenuRequest.php app/Http/Requests/RoleRequest.php app/Http/Requests/SeriesRequest.php app/Http/Requests/TagRequest.php`

------
https://chatgpt.com/codex/tasks/task_e_689f505d462c83228fd510bcd41cb121