### PR TITLE
Add popular endpoints for core resources

### DIFF
--- a/app/Http/Controllers/Api/EntitiesController.php
+++ b/app/Http/Controllers/Api/EntitiesController.php
@@ -179,6 +179,12 @@ class EntitiesController extends Controller
             ->orderBy(DB::raw('events_count + follows_count'), 'desc')
             ->paginate($limit);
 
+        $entities->getCollection()->transform(function ($entity) {
+            $entity->popularity_score = $entity->events_count + $entity->follows_count;
+
+            return $entity;
+        });
+
         return response()->json(new EntityCollection($entities));
     }
 

--- a/app/Http/Controllers/Api/EventsController.php
+++ b/app/Http/Controllers/Api/EventsController.php
@@ -184,6 +184,12 @@ class EventsController extends Controller
             ->orderByDesc('attendees_count')
             ->paginate($limit);
 
+        $events->getCollection()->transform(function ($event) {
+            $event->popularity_score = $event->attendees_count;
+
+            return $event;
+        });
+
         return response()->json(new EventCollection($events));
     }
 

--- a/app/Http/Controllers/Api/SeriesController.php
+++ b/app/Http/Controllers/Api/SeriesController.php
@@ -222,6 +222,12 @@ class SeriesController extends Controller
             ->orderByDesc('attendees_count')
             ->paginate($limit);
 
+        $series->getCollection()->transform(function ($item) {
+            $item->popularity_score = $item->attendees_count;
+
+            return $item;
+        });
+
         return response()->json(new SeriesCollection($series));
     }
 

--- a/app/Http/Controllers/Api/TagsController.php
+++ b/app/Http/Controllers/Api/TagsController.php
@@ -167,6 +167,12 @@ class TagsController extends Controller
             ->orderBy(DB::raw('events_count + follows_count'), 'desc')
             ->paginate($limit);
 
+        $tags->getCollection()->transform(function ($tag) {
+            $tag->popularity_score = $tag->events_count + $tag->follows_count;
+
+            return $tag;
+        });
+
         return response()->json(new TagCollection($tags));
     }
 

--- a/app/Http/Resources/EntityResource.php
+++ b/app/Http/Resources/EntityResource.php
@@ -19,7 +19,7 @@ class EntityResource extends JsonResource
      */
     public function toArray($request)
     {
-        return [
+        $data = [
             'id' => $this->id,
             'name' => $this->name,
             'slug' => $this->slug,
@@ -57,5 +57,11 @@ class EntityResource extends JsonResource
                 ];
             })->toArray(),
         ];
+
+        if (isset($this->popularity_score)) {
+            $data['popularity_score'] = $this->popularity_score;
+        }
+
+        return $data;
     }
 }

--- a/app/Http/Resources/EventResource.php
+++ b/app/Http/Resources/EventResource.php
@@ -23,7 +23,7 @@ class EventResource extends JsonResource
      */
     public function toArray($request)
     {
-        return [
+        $data = [
             'id' => $this->id,
             'name' => $this->name,
             'slug' => $this->slug,
@@ -64,5 +64,11 @@ class EventResource extends JsonResource
                 ];
             })->toArray(),
         ];
+
+        if (isset($this->popularity_score)) {
+            $data['popularity_score'] = $this->popularity_score;
+        }
+
+        return $data;
     }
 }

--- a/app/Http/Resources/SeriesResource.php
+++ b/app/Http/Resources/SeriesResource.php
@@ -19,7 +19,7 @@ class SeriesResource extends JsonResource
      */
     public function toArray($request)
     {
-        return [
+        $data = [
             'id' => $this->id,
             'name' => $this->name,
             'slug' => $this->slug,
@@ -59,5 +59,11 @@ class SeriesResource extends JsonResource
             'next_event' => $this->nextEvent(),
             'next_start_at' => $this->nextPlannedStartAt(),
         ];
+
+        if (isset($this->popularity_score)) {
+            $data['popularity_score'] = $this->popularity_score;
+        }
+
+        return $data;
     }
 }

--- a/app/Http/Resources/TagResource.php
+++ b/app/Http/Resources/TagResource.php
@@ -18,7 +18,7 @@ class TagResource extends JsonResource
      */
     public function toArray($request)
     {
-        return [
+        $data = [
             'id' => $this->id,
             'name' => $this->name,
             'slug' => $this->slug,
@@ -28,7 +28,13 @@ class TagResource extends JsonResource
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
             'created_by' => $this->created_by,
-            'updated_by' => $this->updated_by
-            ];
+            'updated_by' => $this->updated_by,
+        ];
+
+        if (isset($this->popularity_score)) {
+            $data['popularity_score'] = $this->popularity_score;
+        }
+
+        return $data;
     }
 }

--- a/app/Models/Entity.php
+++ b/app/Models/Entity.php
@@ -68,6 +68,8 @@ use Storage;
  * @property \Illuminate\Database\Eloquent\Collection|\App\Models\Thread[]   $threads
  * @property int|null                                                        $threads_count
  * @property \App\Models\User                                                $user
+ * @property int|null                                                        $popularity_score
+
  *
  * @method static Builder|Entity active()
  * @method static Builder|Entity filter(\App\Filters\QueryFilter $filters)

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -83,6 +83,7 @@ use App\Models\User;
  * @property \App\Models\User                                                                                          $user
  * @property \App\Models\Entity|null                                                                                   $venue
  * @property \App\Models\Visibility|null                                                                               $visibility
+ * @property int|null                                                                                                  $popularity_score
  * @mixin \Illuminate\Database\Eloquent\Relations\Relation
  * @method static Builder|Event filter(\App\Filters\QueryFilter $filters)
  * @method static Builder|Event future()

--- a/app/Models/Series.php
+++ b/app/Models/Series.php
@@ -5,7 +5,6 @@ namespace App\Models;
 use Carbon\Carbon;
 use DateTime;
 use Storage;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -16,6 +15,8 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Database\Eloquent\Builder;
+use App\Filters\SeriesFilters;
 
 /**
  * App\Models\Series.
@@ -74,6 +75,8 @@ use Illuminate\Support\Facades\Date;
  * @property User|null                                                     $user
  * @property \App\Models\Entity|null                                       $venue
  * @property \App\Models\Visibility|null                                   $visibility
+ * @property int|null                                                      $attendees_count
+ * @property int|null                                                      $popularity_score
  *
  * @method static \Illuminate\Database\Eloquent\Builder|Series active()
  * @method static \Illuminate\Database\Eloquent\Builder|Series future()
@@ -900,5 +903,13 @@ class Series extends Eloquent
         }                    
 
         return null;
+    }
+
+    /**
+     * Apply SeriesFilters to the query.
+     */
+    public function scopeFilter(Builder $query, SeriesFilters $filters): Builder
+    {
+        return $filters->apply($query);
     }
 }

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -10,6 +10,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Builder;
+use App\Filters\TagFilters;
 
 /**
  * @property int      $id
@@ -21,6 +23,7 @@ use Illuminate\Support\Collection;
  * @property TagType  $tagType
  * @property int|null $tag_type_id
  * @property DateTime $created_at
+ * @property int|null $popularity_score
  */
 class Tag extends Eloquent
 {
@@ -161,5 +164,13 @@ class Tag extends Eloquent
         arsort($total);
 
         return array_slice($total, 0, 5);
+    }
+
+    /**
+     * Apply TagFilters to the query.
+     */
+    public function scopeFilter(Builder $query, TagFilters $filters): Builder
+    {
+        return $filters->apply($query);
     }
 }

--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -406,6 +406,10 @@ components:
         tags:
           type: array
           items: { "$ref": "#/components/schemas/Tag" }
+        popularity_score:
+          type: integer
+          description: Calculated popularity for the entity
+          readOnly: true
     Entities:
       allOf: [$ref: "#/components/schemas/Pagination"]
       type: object
@@ -739,6 +743,10 @@ components:
           description: The price of the show at the door
           type: number
           example: 19.99
+        popularity_score:
+          type: integer
+          description: Calculated popularity for the event
+          readOnly: true
         soundcheck_at:
           type: string
           example: "2018-03-20T09:12:28Z"
@@ -1884,6 +1892,10 @@ components:
           $ref: "#/components/schemas/UserSimple"
         updated_by:
           $ref: "#/components/schemas/UserSimple"
+        popularity_score:
+          type: integer
+          description: Calculated popularity for the series
+          readOnly: true
     Seriess:
       allOf: [$ref: "#/components/schemas/Pagination"]
       type: object
@@ -1933,6 +1945,10 @@ components:
           example: "2018-03-20T09:12:28Z"
           format: date-time
           description: Date and time that the tag was last updated
+          readOnly: true
+        popularity_score:
+          type: integer
+          description: Calculated popularity for the tag
           readOnly: true
     Tags:
       allOf: # Combines the BasicErrorModel and the inline model

--- a/public/postman/schemas/api.yml
+++ b/public/postman/schemas/api.yml
@@ -3108,6 +3108,41 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Events"
+  /api/events/popular:
+    get:
+      tags:
+        - events
+      summary: Get Most Popular Events
+      operationId: getPopularEvents
+      parameters:
+        - name: days
+          in: query
+          required: false
+          description: Number of days to consider when calculating popularity
+          schema:
+            type: integer
+            default: 30
+        - name: limit
+          in: query
+          required: false
+          description: Limit of results to return
+          schema:
+            type: integer
+            default: 30
+        - name: filters[name]
+          in: query
+          required: false
+          description: A filter query of the event name
+          schema:
+            type: string
+            example: "Lazercrunk"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Events"
   /api/events/by-date/{year}:
     get:
       parameters:
@@ -3508,6 +3543,41 @@ paths:
           schema:
             type: string
             example: asc
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Entities"
+  /api/entities/popular:
+    get:
+      tags:
+        - entities
+      summary: Get Most Popular Entities
+      operationId: getPopularEntities
+      parameters:
+        - name: days
+          in: query
+          required: false
+          description: Number of days to consider when calculating popularity
+          schema:
+            type: integer
+            default: 30
+        - name: limit
+          in: query
+          required: false
+          description: Limit of results to return
+          schema:
+            type: integer
+            default: 30
+        - name: filters[name]
+          in: query
+          required: false
+          description: A filter query of the entity name
+          schema:
+            type: string
+            example: "cutups"
       responses:
         "200":
           description: Successful response
@@ -5419,6 +5489,41 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Seriess"
+  /api/series/popular:
+    get:
+      tags:
+        - series
+      summary: Get Most Popular Series
+      operationId: getPopularSeries
+      parameters:
+        - name: days
+          in: query
+          required: false
+          description: Number of days to consider when calculating popularity
+          schema:
+            type: integer
+            default: 30
+        - name: limit
+          in: query
+          required: false
+          description: Limit of results to return
+          schema:
+            type: integer
+            default: 30
+        - name: filters[name]
+          in: query
+          required: false
+          description: A filter query of the series name
+          schema:
+            type: string
+            example: "Lazercrunk"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Seriess"
   /api/series/{slug}:
     parameters:
       - name: slug
@@ -5662,6 +5767,41 @@ paths:
           schema:
             type: string
             example: asc
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Tags"
+  /api/tags/popular:
+    get:
+      tags:
+        - tags
+      summary: Get Most Popular Tags
+      operationId: getPopularTags
+      parameters:
+        - name: days
+          in: query
+          required: false
+          description: Number of days to consider when calculating popularity
+          schema:
+            type: integer
+            default: 30
+        - name: limit
+          in: query
+          required: false
+          description: Limit of results to return
+          schema:
+            type: integer
+            default: 30
+        - name: filters[name]
+          in: query
+          required: false
+          description: A filter query of the tag name
+          schema:
+            type: string
+            example: "techno"
       responses:
         "200":
           description: Successful response

--- a/routes/api.php
+++ b/routes/api.php
@@ -64,6 +64,7 @@ Route::middleware('auth.either')->name('api.')->group(function () {
 
     Route::get('events/attending', ['as' => 'events.attending', 'uses' => 'Api\EventsController@indexAttending']);
     Route::get('events/recommended', ['as' => 'events.recommended', 'uses' => 'Api\EventsController@indexRecommended'])->middleware('auth:sanctum');
+    Route::get('events/popular', ['as' => 'events.popular', 'uses' => 'Api\EventsController@popular']);
     Route::get('events/by-date/{year}/{month?}/{day?}', 'Api\EventsController@indexByDate')
     ->where('year', '[1-9][0-9][0-9][0-9]')
     ->where('month', '(0?[1-9]|1[012])')
@@ -101,6 +102,7 @@ Route::middleware('auth.either')->name('api.')->group(function () {
     Route::delete('entities/{id}/contacts/{contactId}', 'Api\EntitiesController@deleteContact');
     Route::post('entities/{entity}/follow', 'Api\EntitiesController@followJson')->middleware('auth:sanctum');
     Route::post('entities/{entity}/unfollow', 'Api\EntitiesController@unfollowJson')->middleware('auth:sanctum');
+    Route::get('entities/popular', ['as' => 'entities.popular', 'uses' => 'Api\EntitiesController@popular']);
     Route::resource('entities', 'Api\EntitiesController');
 
     Route::match(['get', 'post'], 'entity-types/filter', ['as' => 'entityType.filter', 'uses' => 'Api\EntityTypesController@filter']);
@@ -146,6 +148,7 @@ Route::middleware('auth.either')->name('api.')->group(function () {
     Route::post('series/{id}/photos', 'Api\SeriesController@addPhoto');
     Route::post('series/{series}/follow', 'Api\SeriesController@followJson')->middleware('auth:sanctum');
     Route::post('series/{series}/unfollow', 'Api\SeriesController@unfollowJson')->middleware('auth:sanctum');
+    Route::get('series/popular', ['as' => 'series.popular', 'uses' => 'Api\SeriesController@popular']);
     Route::resource('series', 'Api\SeriesController');
 
     Route::match(['get', 'post'], 'tags/filter', ['as' => 'tags.filter', 'uses' => 'Api\TagsController@filter']);
@@ -154,6 +157,7 @@ Route::middleware('auth.either')->name('api.')->group(function () {
     Route::post('tags/{tag}/follow', 'Api\TagsController@followJson')->middleware('auth:sanctum');
     Route::post('tags/{tag}/unfollow', 'Api\TagsController@unfollowJson')->middleware('auth:sanctum');
     Route::delete('tags/{tag}', 'Api\TagsController@destroy');
+    Route::get('tags/popular', ['as' => 'tags.popular', 'uses' => 'Api\TagsController@popular']);
     Route::resource('tags', 'Api\TagsController')->except(['destroy']);
     Route::match(['get', 'post'], 'tag-types/filter', ['as' => 'tag-types.filter', 'uses' => 'Api\TagTypesController@filter']);
     Route::resource('tag-types', 'Api\TagTypesController')->only(['index', 'show']);


### PR DESCRIPTION
## Summary
- add popularity API endpoints for events, entities, series, and tags
- expose routes and document in OpenAPI spec

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: GitHub API rate limit / token required)*

------
https://chatgpt.com/codex/tasks/task_e_68a34b3165a8832293ba7ac1a17a58d2