### PR TITLE
Allow filtering entities by name or exact alias

### DIFF
--- a/app/Filters/EntityFilters.php
+++ b/app/Filters/EntityFilters.php
@@ -8,11 +8,16 @@ class EntityFilters extends QueryFilter
 {
     public function name(?string $value = null): Builder
     {
-        if (isset($value)) {
-            return $this->builder->where('entities.name', 'like', '%'.$value.'%');
-        } else {
+        if (!isset($value)) {
             return $this->builder;
         }
+
+        return $this->builder->where(function ($query) use ($value) {
+            $query->where('entities.name', 'like', '%'.$value.'%')
+                ->orWhereHas('aliases', function ($q) use ($value) {
+                    $q->where('name', '=', $value);
+                });
+        });
     }
 
     public function description(?string $value = null): Builder

--- a/app/Http/Resources/EntityResource.php
+++ b/app/Http/Resources/EntityResource.php
@@ -55,7 +55,9 @@ class EntityResource extends JsonResource
                     'path' => $photo->getPath(),
                     'thumbnail_path' => $photo->getThumbnailPath(),
                 ];
-            })->toArray(),
+            },
+            )->toArray(),
+            'aliases' => MinimalResource::collection($this->aliases)->resolve(),
         ];
 
         if (isset($this->popularity_score)) {

--- a/tests/Feature/ApiEntityFiltersTest.php
+++ b/tests/Feature/ApiEntityFiltersTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Alias;
+use App\Models\Entity;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ApiEntityFiltersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    public function testFilterMatchesNameOrAlias()
+    {
+        $user = User::factory()->create(['user_status_id' => 1]);
+        $this->actingAs($user);
+
+        $nameMatch = Entity::factory()->create([
+            'name' => 'Alpha Co',
+            'slug' => 'alpha-co',
+        ]);
+
+        $aliasEntity = Entity::factory()->create([
+            'name' => 'Other Co',
+            'slug' => 'other-co',
+        ]);
+
+        $alias = Alias::create(['name' => 'Alpha']);
+        $aliasEntity->aliases()->attach($alias);
+
+        $other = Entity::factory()->create([
+            'name' => 'Gamma Co',
+            'slug' => 'gamma-co',
+        ]);
+
+        $response = $this->getJson('/api/entities?filters[name]=Alpha');
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['name' => 'Alpha Co'])
+            ->assertJsonFragment(['name' => 'Other Co'])
+            ->assertJsonMissing(['name' => 'Gamma Co']);
+    }
+}
+


### PR DESCRIPTION
## Summary
- match entity name or exact alias when filtering by name
- cover name and alias filtering in API tests

## Testing
- ⚠️ `composer install --no-interaction` *(failed: Failed to clone https://github.com/voku/portable-ascii.git via https, ssh protocols, aborting. fatal: unable to access 'https://github.com/voku/portable-ascii.git/': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a6309d9b948322bff300c57bc0ca6a