### PR TITLE
Improve entity page SEO metadata and structured data

### DIFF
--- a/app/Models/Entity.php
+++ b/app/Models/Entity.php
@@ -717,6 +717,67 @@ class Entity extends Eloquent
         return $format;
     }
 
+    public function getSeoTitleFormat(): string
+    {
+        $format = $this->name;
+
+        $roles = $this->roles->take(2)->pluck('name')->toArray();
+        if (!empty($roles)) {
+            $format .= ' (' . implode(', ', $roles) . ')';
+        }
+
+        $location = $this->getPrimaryLocation();
+        if ($location && !empty($location->city)) {
+            $format .= ' – ' . $location->city;
+            if (!empty($location->state)) {
+                $format .= ', ' . $location->state;
+            }
+        }
+
+        return $format;
+    }
+
+    public function getSeoDescriptionFormat(): string
+    {
+        if (!empty($this->short)) {
+            return $this->short;
+        }
+
+        $sentence = $this->name;
+        $roleStr = $this->getRoleString();
+        $location = $this->getPrimaryLocation();
+
+        if (!empty($roleStr)) {
+            $sentence .= ' is a ' . strtolower($roleStr);
+            if ($location && !empty($location->city)) {
+                $state = !empty($location->state) ? ', ' . $location->state : '';
+                $sentence .= ' based in ' . $location->city . $state;
+            }
+        } elseif ($location && !empty($location->city)) {
+            $state = !empty($location->state) ? ', ' . $location->state : '';
+            $sentence .= ' is based in ' . $location->city . $state;
+        }
+
+        $sentence .= '. See upcoming shows, past performances, music links, and scene connections on Arcane City.';
+
+        return $sentence;
+    }
+
+    public function getSchemaType(): string
+    {
+        if ($this->hasRole('Venue')) {
+            return 'MusicVenue';
+        }
+        if ($this->hasRole('DJ') || $this->hasRole('Producer') || $this->hasRole('Musician')) {
+            return 'MusicGroup';
+        }
+        if ($this->entityType && $this->entityType->name === 'Individual') {
+            return 'Person';
+        }
+
+        return 'Organization';
+    }
+
     // Format the entity to post as a tweet
     public function getBriefFormat(): string
     {

--- a/resources/views/entities/json-ld.blade.php
+++ b/resources/views/entities/json-ld.blade.php
@@ -1,0 +1,60 @@
+@php
+    $primaryPhoto = $entity->getPrimaryPhoto();
+    $primaryLocation = $entity->getPrimaryLocation();
+    $aliases = $entity->aliases->pluck('name')->filter()->values();
+    $tags = $entity->tags->pluck('name')->filter()->values();
+
+    $sameAs = [];
+    if (!empty($entity->instagram_username)) {
+        $sameAs[] = 'https://www.instagram.com/' . $entity->instagram_username;
+    }
+    if (!empty($entity->facebook_username)) {
+        $sameAs[] = 'https://www.facebook.com/' . $entity->facebook_username;
+    }
+    if (!empty($entity->twitter_username)) {
+        $sameAs[] = 'https://twitter.com/' . $entity->twitter_username;
+    }
+    foreach ($entity->links as $link) {
+        if (!empty($link->url) && (str_contains($link->url, 'soundcloud.com') || str_contains($link->url, 'bandcamp.com'))) {
+            $sameAs[] = $link->url;
+        }
+    }
+    $sameAs = array_values(array_unique($sameAs));
+@endphp
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "{{ $entity->getSchemaType() }}",
+    "name": "{{ $entity->name }}"
+    @if ($aliases->isNotEmpty())
+    ,"alternateName": {!! json_encode($aliases->all()) !!}
+    @endif
+    ,"url": "{{ url('/entities/' . $entity->slug) }}"
+    @if ($primaryPhoto)
+    ,"image": "{{ Storage::disk('external')->url($primaryPhoto->getStoragePath()) }}"
+    @endif
+    ,"description": "{{ addslashes($entity->getSeoDescriptionFormat()) }}"
+    @if ($tags->isNotEmpty())
+    ,"genre": {!! json_encode($tags->all()) !!}
+    @endif
+    @if ($primaryLocation && !empty($primaryLocation->city))
+    ,"location": {
+        "@type": "Place",
+        "name": "{{ $primaryLocation->city }}{{ !empty($primaryLocation->state) ? ', ' . $primaryLocation->state : '' }}"
+        @if (!empty($primaryLocation->address_one))
+        ,"address": {
+            "@type": "PostalAddress",
+            "streetAddress": "{{ $primaryLocation->address_one }}",
+            "addressLocality": "{{ $primaryLocation->city }}",
+            "addressRegion": "{{ $primaryLocation->state }}",
+            "postalCode": "{{ $primaryLocation->postcode }}",
+            "addressCountry": "{{ $primaryLocation->country }}"
+        }
+        @endif
+    }
+    @endif
+    @if (!empty($sameAs))
+    ,"sameAs": {!! json_encode($sameAs) !!}
+    @endif
+}
+</script>

--- a/resources/views/entities/show-tw.blade.php
+++ b/resources/views/entities/show-tw.blade.php
@@ -1,12 +1,22 @@
 @extends('layouts.app-tw')
 
-@section('title', $entity->getTitleFormat())
+@section('title', $entity->getSeoTitleFormat())
 
-@section('og-description', $entity->short)
-@section('description', $entity->short)
+@section('og-type', 'profile')
+
+@section('canonical')
+<link rel="canonical" href="{{ url('/entities/'.$entity->slug) }}">
+@endsection
+
+@section('og-description', $entity->getSeoDescriptionFormat())
+@section('description', $entity->getSeoDescriptionFormat())
 
 @section('og-image')
 @if ($photo = $entity->getPrimaryPhoto()){{ Storage::disk('external')->url($photo->getStoragePath()) }}@endif
+@endsection
+
+@section('entity.json')
+@include('entities.json-ld', ['entity' => $entity])
 @endsection
 
 @section('content')

--- a/resources/views/layouts/app-tw.blade.php
+++ b/resources/views/layouts/app-tw.blade.php
@@ -5,14 +5,16 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta property="og:url" content="{{ Request::url() }}">
-	<meta property="og:type" content="website">
+	<meta property="og:type" content="@yield('og-type', 'website')">
 	<meta property="og:title" content="@yield('title', config('app.app_name'))">
 	<meta property="og:image" content="@yield('og-image', url('/').'/apple-icon-180x180.png')">
 	<meta property="og:description" content="@yield('og-description', 'A calender of events, concerts, club nights, weekly and monthly events series, promoters, artists, producers, djs, venues and other entities.')">
 	<meta name="description" content="@yield('description', 'A calender of events, concerts, club nights, weekly and monthly events series, promoters, artists, producers, djs, venues and other entities.')">
 	<meta property="fb:app_id" content="{{ config('app.fb_app_id') }}">
+	@yield('canonical')
 	@yield('facebook.meta')
 	@yield('google.event.json')
+	@yield('entity.json')
 	<meta name="theme-color" content="#0f172a"/>
 	<meta name="csrf-token" content="{{ csrf_token() }}">
 	<title>@yield('title','Event Guide') • {{ config('app.app_name')}}</title>


### PR DESCRIPTION
Add JSON-LD structured data (MusicGroup/MusicVenue/Person/Organization), canonical link tags, alias disambiguation via alternateName, and auto-generated descriptions for entities without a short bio. Title format now includes roles and location for better search disambiguation.