### PR TITLE
Add proper schema.org JSON-LD structured data to entity pages

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -36,7 +36,8 @@
       "Bash(then ls /var/www/dev-events/resources/views/$dir/*.blade.php)",
       "Bash(xargs:*)",
       "Bash(if [ -f \"/var/www/dev-events/resources/views/$dir/show-tw.blade.php\" ])",
-      "Bash(elif [ -f \"/var/www/dev-events/resources/views/$dir/show.blade.php\" ])"
+      "Bash(elif [ -f \"/var/www/dev-events/resources/views/$dir/show.blade.php\" ])",
+      "WebFetch(domain:schema.org)"
     ],
     "deny": [],
     "ask": []

--- a/resources/views/entities/json-ld.blade.php
+++ b/resources/views/entities/json-ld.blade.php
@@ -1,60 +1,10 @@
 @php
-    $primaryPhoto = $entity->getPrimaryPhoto();
-    $primaryLocation = $entity->getPrimaryLocation();
-    $aliases = $entity->aliases->pluck('name')->filter()->values();
-    $tags = $entity->tags->pluck('name')->filter()->values();
-
-    $sameAs = [];
-    if (!empty($entity->instagram_username)) {
-        $sameAs[] = 'https://www.instagram.com/' . $entity->instagram_username;
-    }
-    if (!empty($entity->facebook_username)) {
-        $sameAs[] = 'https://www.facebook.com/' . $entity->facebook_username;
-    }
-    if (!empty($entity->twitter_username)) {
-        $sameAs[] = 'https://twitter.com/' . $entity->twitter_username;
-    }
-    foreach ($entity->links as $link) {
-        if (!empty($link->url) && (str_contains($link->url, 'soundcloud.com') || str_contains($link->url, 'bandcamp.com'))) {
-            $sameAs[] = $link->url;
-        }
-    }
-    $sameAs = array_values(array_unique($sameAs));
+    $jsonLd           = $entity->getJsonLd();
+    $breadcrumbJsonLd = $entity->getBreadcrumbJsonLd();
 @endphp
 <script type="application/ld+json">
-{
-    "@context": "https://schema.org",
-    "@type": "{{ $entity->getSchemaType() }}",
-    "name": "{{ $entity->name }}"
-    @if ($aliases->isNotEmpty())
-    ,"alternateName": {!! json_encode($aliases->all()) !!}
-    @endif
-    ,"url": "{{ url('/entities/' . $entity->slug) }}"
-    @if ($primaryPhoto)
-    ,"image": "{{ Storage::disk('external')->url($primaryPhoto->getStoragePath()) }}"
-    @endif
-    ,"description": "{{ addslashes($entity->getSeoDescriptionFormat()) }}"
-    @if ($tags->isNotEmpty())
-    ,"genre": {!! json_encode($tags->all()) !!}
-    @endif
-    @if ($primaryLocation && !empty($primaryLocation->city))
-    ,"location": {
-        "@type": "Place",
-        "name": "{{ $primaryLocation->city }}{{ !empty($primaryLocation->state) ? ', ' . $primaryLocation->state : '' }}"
-        @if (!empty($primaryLocation->address_one))
-        ,"address": {
-            "@type": "PostalAddress",
-            "streetAddress": "{{ $primaryLocation->address_one }}",
-            "addressLocality": "{{ $primaryLocation->city }}",
-            "addressRegion": "{{ $primaryLocation->state }}",
-            "postalCode": "{{ $primaryLocation->postcode }}",
-            "addressCountry": "{{ $primaryLocation->country }}"
-        }
-        @endif
-    }
-    @endif
-    @if (!empty($sameAs))
-    ,"sameAs": {!! json_encode($sameAs) !!}
-    @endif
-}
+{!! json_encode($jsonLd, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) !!}
+</script>
+<script type="application/ld+json">
+{!! json_encode($breadcrumbJsonLd, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) !!}
 </script>

--- a/tests/Feature/CreateSeriesEventsTest.php
+++ b/tests/Feature/CreateSeriesEventsTest.php
@@ -160,6 +160,7 @@ class CreateSeriesEventsTest extends TestCase
             'founded_at' => Carbon::now()->subWeeks(2),
             'start_at' => Carbon::now()->addWeeks(1)->setTime(20, 0, 0),
             'cancelled_at' => null,
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
         ]);
 
         // Attach entities to series
@@ -202,6 +203,7 @@ class CreateSeriesEventsTest extends TestCase
             'founded_at' => Carbon::now()->subWeeks(2),
             'start_at' => Carbon::now()->addWeeks(1)->setTime(20, 0, 0),
             'cancelled_at' => null,
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
         ]);
 
         // Attach tags to series


### PR DESCRIPTION
Generate type-appropriate JSON-LD (MusicGroup, MusicVenue, Person, Organization) from PHP model methods rather than Blade logic. Includes @id, alternateName, genre/knowsAbout, homeLocation/address, hasOccupation, mainEntityOfPage, sameAs from social fields and identity platform links, and a BreadcrumbList block for scene graph navigation.