### PR TITLE
Warn users of existing events when selecting a start date

### DIFF
--- a/resources/views/events/create.blade.php
+++ b/resources/views/events/create.blade.php
@@ -43,7 +43,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const minDate = picker.getAttribute('data-min-date');
         const maxDate = picker.getAttribute('data-max-date');
 
-        flatpickr(picker, {
+        const config = {
             enableTime: enableTime,
             dateFormat: dateFormat,
             altInput: true,
@@ -51,8 +51,46 @@ document.addEventListener('DOMContentLoaded', function() {
             time_24hr: false,
             minDate: minDate,
             maxDate: maxDate,
-        });
+        };
+
+        if (picker.id === 'start_at') {
+            config.onChange = function(selectedDates) {
+                if (selectedDates.length === 0) return;
+                const d = selectedDates[0];
+                const year = d.getFullYear();
+                const month = String(d.getMonth() + 1).padStart(2, '0');
+                const day = String(d.getDate()).padStart(2, '0');
+                checkEventsOnDate(year, month, day, null);
+            };
+        }
+
+        flatpickr(picker, config);
     });
 });
+
+function checkEventsOnDate(year, month, day, excludeSlug) {
+    const warning = document.getElementById('events-on-date-warning');
+    const list = document.getElementById('events-on-date-list');
+    if (!warning || !list) return;
+
+    fetch(`/api/events/by-date/${year}/${month}/${day}`)
+        .then(r => r.json())
+        .then(data => {
+            const events = (data.data || []).filter(e => e.slug !== excludeSlug);
+            if (events.length === 0) {
+                warning.classList.add('hidden');
+                return;
+            }
+            list.innerHTML = events.map(e => {
+                const venue = e.venue ? ` @ ${e.venue.name}` : '';
+                const time = e.start_at
+                    ? new Date(e.start_at).toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'})
+                    : '';
+                return `<li><a href="/events/${e.slug}" target="_blank" class="underline hover:no-underline">${e.name}</a>${venue}${time ? ' &mdash; ' + time : ''}</li>`;
+            }).join('');
+            warning.classList.remove('hidden');
+        })
+        .catch(() => warning.classList.add('hidden'));
+}
 </script>
 @stop

--- a/resources/views/events/form.blade.php
+++ b/resources/views/events/form.blade.php
@@ -173,6 +173,25 @@
         </x-ui.form-group>
     </div>
 
+    {{-- Duplicate Warning Panel --}}
+    <div id="events-on-date-warning"
+         class="hidden col-span-12 rounded-md border border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-700 p-4 text-sm"
+         role="alert">
+        <div class="flex items-start gap-2">
+            <i class="bi bi-exclamation-triangle-fill text-amber-600 dark:text-amber-400 mt-0.5 flex-shrink-0"></i>
+            <div>
+                <p class="font-medium text-amber-800 dark:text-amber-300 mb-2">
+                    Other events are already scheduled on this date:
+                </p>
+                <ul id="events-on-date-list" class="space-y-1 text-amber-700 dark:text-amber-400 list-disc list-inside">
+                </ul>
+                <p class="mt-2 text-amber-600 dark:text-amber-500 text-xs">
+                    You can still submit this event if it is different from the above.
+                </p>
+            </div>
+        </div>
+    </div>
+
     <div class="col-span-12 md:col-span-4">
         <x-ui.form-group
             name="end_at"

--- a/resources/views/events/show-tw.blade.php
+++ b/resources/views/events/show-tw.blade.php
@@ -263,9 +263,9 @@
 				@endunless						</div>
 					</div>
 
-			<!-- Photo Upload -->
-			@if ($user && (Auth::user()->id == $event->user?->id || $user->hasGroup('super_admin') ))
-			<div class="rounded-lg border border-border bg-card shadow p-2 pt-2 space-y-4">
+					<!-- Photo Upload -->
+					@if ($user && (Auth::user()->id == $event->user?->id || $user->hasGroup('super_admin') ))
+					<div class="rounded-lg border border-border bg-card shadow p-2 pt-2 space-y-4">
 						<form action="/events/{{ $event->id }}/photos" class="dropzone border-2 border-dashed border-gray-300 dark:border-gray-700 rounded-lg p-4 text-center cursor-pointer hover:border-gray-400 dark:hover:border-gray-600 transition-colors" id="myDropzone" method="POST">
 							<input type="hidden" name="_token" value="{{ csrf_token() }}">
 						</form>


### PR DESCRIPTION
When creating or editing an event, selecting a start date now triggers a live check against the existing events API. If other events are scheduled on the same date, an amber warning panel appears below the start date field listing them with venue and time, with links to each. The warning is informational only — submission is not blocked. On the edit form, the current event is excluded from the results.