### PR TITLE
Fix series edit form not displaying existing tags and entities

### DIFF
--- a/resources/views/series/form.blade.php
+++ b/resources/views/series/form.blade.php
@@ -462,8 +462,9 @@
         data-tags="false"
         multiple
         :hasError="$errors->has('entities')">
+        @php $selectedEntities = old('entity_list', $series->entities->pluck('id')->toArray()); @endphp
         @foreach($entityOptions as $id => $name)
-            <option value="{{ $id }}">{{ $name }}</option>
+            <option value="{{ $id }}" {{ in_array($id, $selectedEntities) ? 'selected' : '' }}>{{ $name }}</option>
         @endforeach
     </x-ui.select>
 </x-ui.form-group>
@@ -483,8 +484,9 @@
         data-tags="false"
         multiple
         :hasError="$errors->has('tags')">
+        @php $selectedTags = old('tag_list', $series->tags->pluck('id')->toArray()); @endphp
         @foreach($tagOptions as $id => $name)
-            <option value="{{ $id }}">{{ $name }}</option>
+            <option value="{{ $id }}" {{ in_array($id, $selectedTags) ? 'selected' : '' }}>{{ $name }}</option>
         @endforeach
     </x-ui.select>
 </x-ui.form-group>


### PR DESCRIPTION
Pre-select related entities and tags on the series edit form by comparing each option against the series' current relationships, falling back to old input on validation failure.