### PR TITLE
improve JSON-LD structured data across event, series, and entity pages

### DIFF
--- a/resources/views/entities/json-ld.blade.php
+++ b/resources/views/entities/json-ld.blade.php
@@ -1,6 +1,35 @@
 @php
     $jsonLd           = $entity->getJsonLd();
     $breadcrumbJsonLd = $entity->getBreadcrumbJsonLd();
+
+    // Add upcoming events array — powers the Google event carousel on venue/artist pages
+    if (!empty($relatedEvents) && count($relatedEvents) > 0) {
+        $eventItems = [];
+        foreach ($relatedEvents as $ev) {
+            $eventItem = [
+                '@type'     => 'Event',
+                'name'      => $ev->name,
+                'url'       => route('events.show', $ev->slug),
+                'startDate' => $ev->start_at ? $ev->start_at->format(DateTimeInterface::ISO8601) : null,
+            ];
+            if (!empty($ev->venue_id) && $ev->venue) {
+                $eventItem['location'] = ['@type' => 'Place', 'name' => $ev->venue->name];
+            } else {
+                $eventItem['location'] = [
+                    '@type'   => 'Place',
+                    'name'    => 'TBA',
+                    'address' => [
+                        '@type'           => 'PostalAddress',
+                        'addressLocality' => 'Pittsburgh',
+                        'addressRegion'   => 'PA',
+                        'addressCountry'  => 'US',
+                    ],
+                ];
+            }
+            $eventItems[] = $eventItem;
+        }
+        $jsonLd['event'] = $eventItems;
+    }
 @endphp
 <script type="application/ld+json">
 {!! json_encode($jsonLd, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) !!}

--- a/resources/views/events/index-json-ld.blade.php
+++ b/resources/views/events/index-json-ld.blade.php
@@ -35,14 +35,45 @@
         $items[] = $item;
     }
 
+    $isTagPage  = isset($tag);
+    $pageUrl    = $isTagPage ? route('events.tag', $tag->slug) : route('events.index');
+    $pageName   = $isTagPage ? (ucfirst($tag->name) . ' Events') : 'Events';
+    $pageDesc   = $isTagPage
+        ? ('Events tagged with ' . $tag->name . ' in Pittsburgh')
+        : 'Upcoming events, concerts and shows in Pittsburgh';
+
     $jsonLd = [
+        '@context'    => 'https://schema.org',
+        '@type'       => 'CollectionPage',
+        'name'        => $pageName,
+        'url'         => $pageUrl,
+        'description' => $pageDesc,
+        'mainEntity'  => [
+            '@type'           => 'ItemList',
+            'itemListElement' => $items,
+        ],
+    ];
+
+    $breadcrumbItems = [
+        ['@type' => 'ListItem', 'position' => 1, 'name' => 'Events', 'item' => route('events.index')],
+    ];
+    if ($isTagPage) {
+        $breadcrumbItems[] = [
+            '@type'    => 'ListItem',
+            'position' => 2,
+            'name'     => ucfirst($tag->name),
+            'item'     => $pageUrl,
+        ];
+    }
+    $breadcrumbJsonLd = [
         '@context'        => 'https://schema.org',
-        '@type'           => 'ItemList',
-        'name'            => 'Events',
-        'url'             => route('events.index'),
-        'itemListElement' => $items,
+        '@type'           => 'BreadcrumbList',
+        'itemListElement' => $breadcrumbItems,
     ];
 @endphp
 <script type="application/ld+json">
 {!! json_encode($jsonLd, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) !!}
+</script>
+<script type="application/ld+json">
+{!! json_encode($breadcrumbJsonLd, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) !!}
 </script>

--- a/resources/views/pages/home-json-ld.blade.php
+++ b/resources/views/pages/home-json-ld.blade.php
@@ -14,13 +14,24 @@
         ],
     ];
 
+    $orgSameAs = array_values(array_filter([
+        config('app.social_facebook')  ?: null,
+        config('app.social_instagram') ?: null,
+        config('app.social_twitter')   ?: null,
+    ]));
+
     $organizationJsonLd = [
         '@context'    => 'https://schema.org',
         '@type'       => 'Organization',
         'name'        => config('app.app_name'),
         'url'         => config('app.url'),
+        'logo'        => config('app.url') . '/images/arcane-city-icon-96x96.png',
         'description' => 'A calendar and guide to events, venues, artists, promoters, and series.',
     ];
+
+    if (!empty($orgSameAs)) {
+        $organizationJsonLd['sameAs'] = $orgSameAs;
+    }
 @endphp
 <script type="application/ld+json">
 {!! json_encode($websiteJsonLd, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) !!}

--- a/resources/views/series/json-ld.blade.php
+++ b/resources/views/series/json-ld.blade.php
@@ -1,0 +1,90 @@
+@php
+    $canonicalUrl = route('series.show', $series->slug);
+
+    $seriesJsonLd = [
+        '@context'         => 'https://schema.org',
+        '@type'            => 'EventSeries',
+        '@id'              => $canonicalUrl . '#series',
+        'name'             => $series->name,
+        'url'              => $canonicalUrl,
+        'mainEntityOfPage' => ['@type' => 'WebPage', '@id' => $canonicalUrl],
+    ];
+
+    if ($series->short) {
+        $seriesJsonLd['description'] = $series->short;
+    }
+
+    if ($photo = $series->getPrimaryPhoto()) {
+        $seriesJsonLd['image'] = Storage::disk('external')->url($photo->getStoragePath());
+    }
+
+    if ($series->venue) {
+        $seriesJsonLd['location'] = [
+            '@type' => 'Place',
+            'name'  => $series->venue->name,
+            'url'   => route('entities.show', $series->venue->slug),
+        ];
+        $venueLocation = $series->venue->getPrimaryLocation();
+        if ($venueLocation && !empty($venueLocation->address_one)) {
+            $seriesJsonLd['location']['address'] = [
+                '@type'           => 'PostalAddress',
+                'streetAddress'   => $venueLocation->address_one,
+                'addressLocality' => $venueLocation->city,
+                'addressRegion'   => $venueLocation->state ?? '',
+                'postalCode'      => $venueLocation->postcode ?? '',
+                'addressCountry'  => $venueLocation->country ?? 'US',
+            ];
+        }
+    }
+
+    // Add upcoming instances as subEvents
+    if (isset($events) && count($events) > 0) {
+        $subEvents = [];
+        foreach ($events as $ev) {
+            if (!$ev->start_at || $ev->start_at->lt(now())) {
+                continue;
+            }
+            $subEvent = [
+                '@type'     => 'Event',
+                'name'      => $ev->name,
+                'url'       => route('events.show', $ev->slug),
+                'startDate' => $ev->start_at->format(DateTimeInterface::ISO8601),
+            ];
+            if (!empty($ev->venue_id) && $ev->venue) {
+                $subEvent['location'] = ['@type' => 'Place', 'name' => $ev->venue->name];
+            } elseif ($series->venue) {
+                $subEvent['location'] = ['@type' => 'Place', 'name' => $series->venue->name];
+            } else {
+                $subEvent['location'] = [
+                    '@type'   => 'Place',
+                    'name'    => 'TBA',
+                    'address' => [
+                        '@type'           => 'PostalAddress',
+                        'addressLocality' => 'Pittsburgh',
+                        'addressRegion'   => 'PA',
+                        'addressCountry'  => 'US',
+                    ],
+                ];
+            }
+            $subEvents[] = $subEvent;
+        }
+        if (!empty($subEvents)) {
+            $seriesJsonLd['subEvent'] = $subEvents;
+        }
+    }
+
+    $breadcrumbJsonLd = [
+        '@context'        => 'https://schema.org',
+        '@type'           => 'BreadcrumbList',
+        'itemListElement' => [
+            ['@type' => 'ListItem', 'position' => 1, 'name' => 'Series', 'item' => route('series.index')],
+            ['@type' => 'ListItem', 'position' => 2, 'name' => $series->name, 'item' => $canonicalUrl],
+        ],
+    ];
+@endphp
+<script type="application/ld+json">
+{!! json_encode($seriesJsonLd, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) !!}
+</script>
+<script type="application/ld+json">
+{!! json_encode($breadcrumbJsonLd, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) !!}
+</script>

--- a/resources/views/series/show-tw.blade.php
+++ b/resources/views/series/show-tw.blade.php
@@ -7,6 +7,10 @@
 @if ($photo = $series->getPrimaryPhoto()){{ Storage::disk('external')->url($photo->getStoragePath()) }}@endif
 @endsection
 
+@section('page.json')
+@include('series.json-ld')
+@endsection
+
 @section('content')
 
 <!-- Back Button -->


### PR DESCRIPTION
- Fix missing location on venue-less events (Critical GSC failure)
- Add upcoming event carousel array to entity show pages
- Add EventSeries + BreadcrumbList JSON-LD to series show pages
- Upgrade events index/tag pages from ItemList to CollectionPage + BreadcrumbList
- Add logo and sameAs social links to Organization on homepage