### PR TITLE
Enforce signed URLs for email verification endpoints

### DIFF
--- a/app/Http/Controllers/Api/EmailVerificationController.php
+++ b/app/Http/Controllers/Api/EmailVerificationController.php
@@ -32,7 +32,10 @@ class EmailVerificationController extends Controller
         // Defense in depth: the `signed` middleware on the route already
         // enforces this, but reject unsigned requests here too in case a
         // future route refactor drops the middleware.
-        if (! $request->hasValidSignature()) {
+        // The verification URL is generated with a relative signature (see
+        // AuthServiceProvider::VerifyEmail::createUrlUsing) so it can be
+        // prefixed by a frontend host; validate it accordingly.
+        if (! $request->hasValidSignature(absolute: false)) {
             return response()->json(['message' => 'Invalid verification link.'], 403);
         }
 

--- a/app/Http/Controllers/Api/EmailVerificationController.php
+++ b/app/Http/Controllers/Api/EmailVerificationController.php
@@ -29,6 +29,13 @@ class EmailVerificationController extends Controller
      */
     public function verify(Request $request): JsonResponse
     {
+        // Defense in depth: the `signed` middleware on the route already
+        // enforces this, but reject unsigned requests here too in case a
+        // future route refactor drops the middleware.
+        if (! $request->hasValidSignature()) {
+            return response()->json(['message' => 'Invalid verification link.'], 403);
+        }
+
         $userId = (int) $request->route('id');
         $hash = (string) $request->route('hash');
 
@@ -44,8 +51,6 @@ class EmailVerificationController extends Controller
         if (! hash_equals($hash, sha1($user->getEmailForVerification()))) {
             return response()->json([
                 'message' => 'Invalid verification link.',
-                'hash' => $hash,
-                'expected' => sha1($user->getEmailForVerification())
             ], 400);
         }
 

--- a/app/Http/Controllers/Auth/VerificationController.php
+++ b/app/Http/Controllers/Auth/VerificationController.php
@@ -64,6 +64,11 @@ class VerificationController extends Controller
     // Override the trait method to not rely on $request->user()
     public function verify(Request $request)
     {
+        // Defense in depth: the `signed` middleware on the route already
+        // enforces this, but reject unsigned requests here too in case a
+        // future route refactor drops the middleware.
+        abort_unless($request->hasValidSignature(), 403);
+
         $userId = (int) $request->route('id');
         $hash = (string) $request->route('hash');
 

--- a/app/Http/Controllers/Auth/VerificationController.php
+++ b/app/Http/Controllers/Auth/VerificationController.php
@@ -67,7 +67,10 @@ class VerificationController extends Controller
         // Defense in depth: the `signed` middleware on the route already
         // enforces this, but reject unsigned requests here too in case a
         // future route refactor drops the middleware.
-        abort_unless($request->hasValidSignature(), 403);
+        // The verification URL is generated with a relative signature (see
+        // AuthServiceProvider::VerifyEmail::createUrlUsing) so it can be
+        // prefixed by a frontend host; validate it accordingly.
+        abort_unless($request->hasValidSignature(absolute: false), 403);
 
         $userId = (int) $request->route('id');
         $hash = (string) $request->route('hash');

--- a/routes/api.php
+++ b/routes/api.php
@@ -257,7 +257,7 @@ Route::post('register', 'Api\\RegisterController@register');
 // Email verification endpoint — signature enforced to prevent
 // account takeover via crafted URLs.
 Route::get('email/verify/{id}/{hash}', 'Api\\EmailVerificationController@verify')
-    ->middleware(['signed', 'throttle:6,1'])
+    ->middleware(['signed:relative', 'throttle:6,1'])
     ->name('api.verification.verify');
 
 // password reset endpoints

--- a/routes/api.php
+++ b/routes/api.php
@@ -254,10 +254,10 @@ Route::get('tag-calendar-events', 'EventsController@tagCalendarEventsApi')->name
 // user registration endpoint
 Route::post('register', 'Api\\RegisterController@register');
 
-// email verification endpoint
-// disabled signature for testing
+// Email verification endpoint — signature enforced to prevent
+// account takeover via crafted URLs.
 Route::get('email/verify/{id}/{hash}', 'Api\\EmailVerificationController@verify')
-    ->middleware('throttle:6,1')
+    ->middleware(['signed', 'throttle:6,1'])
     ->name('api.verification.verify');
 
 // password reset endpoints

--- a/routes/web.php
+++ b/routes/web.php
@@ -45,7 +45,7 @@ Auth::routes();
 Route::get('email/verify', 'Auth\VerificationController@show')
     ->name('verification.notice');
 Route::get('email/verify/{id}/{hash}', 'Auth\VerificationController@verify')
-    ->middleware(['signed', 'throttle:6,1'])
+    ->middleware(['signed:relative', 'throttle:6,1'])
     ->name('verification.verify');
 Route::post('email/resend', 'Auth\VerificationController@resend')
     ->name('verification.resend');

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,7 +35,20 @@ use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 
-Auth::routes(['verify' => true]);
+// NOTE: we register `verify` routes explicitly below so that the
+// `verification.verify` route gets the `signed` middleware. The version
+// of Auth::routes(['verify' => true]) shipped by laravel/ui does NOT
+// apply it, leaving accounts open to verification via crafted URLs.
+Auth::routes();
+
+// Email verification routes — `verification.verify` MUST be signed.
+Route::get('email/verify', 'Auth\VerificationController@show')
+    ->name('verification.notice');
+Route::get('email/verify/{id}/{hash}', 'Auth\VerificationController@verify')
+    ->middleware(['signed', 'throttle:6,1'])
+    ->name('verification.verify');
+Route::post('email/resend', 'Auth\VerificationController@resend')
+    ->name('verification.resend');
 
 Route::get('tokens/test', function () {
     return ['data' => 'has event check'];

--- a/tests/Feature/ApiEmailVerificationTest.php
+++ b/tests/Feature/ApiEmailVerificationTest.php
@@ -38,7 +38,8 @@ class ApiEmailVerificationTest extends TestCase
         $verificationUrl = URL::temporarySignedRoute(
             'api.verification.verify',
             now()->addMinutes(60),
-            ['id' => $user->id, 'hash' => sha1($user->email)]
+            ['id' => $user->id, 'hash' => sha1($user->email)],
+            false
         );
 
         // Make request to verification URL
@@ -71,7 +72,8 @@ class ApiEmailVerificationTest extends TestCase
         $verificationUrl = URL::temporarySignedRoute(
             'api.verification.verify',
             now()->addMinutes(60),
-            ['id' => $user->id, 'hash' => 'invalid-hash']
+            ['id' => $user->id, 'hash' => 'invalid-hash'],
+            false
         );
 
         $response = $this->getJson($verificationUrl);
@@ -99,7 +101,8 @@ class ApiEmailVerificationTest extends TestCase
         $verificationUrl = URL::temporarySignedRoute(
             'api.verification.verify',
             now()->addMinutes(60),
-            ['id' => $user->id, 'hash' => sha1($user->email)]
+            ['id' => $user->id, 'hash' => sha1($user->email)],
+            false
         );
 
         $response = $this->getJson($verificationUrl);
@@ -119,7 +122,8 @@ class ApiEmailVerificationTest extends TestCase
         $verificationUrl = URL::temporarySignedRoute(
             'api.verification.verify',
             now()->addMinutes(60),
-            ['id' => 99999, 'hash' => sha1('nonexistent@example.com')]
+            ['id' => 99999, 'hash' => sha1('nonexistent@example.com')],
+            false
         );
 
         $response = $this->getJson($verificationUrl);
@@ -141,7 +145,8 @@ class ApiEmailVerificationTest extends TestCase
         $verificationUrl = URL::temporarySignedRoute(
             'api.verification.verify',
             now()->addMinutes(60),
-            ['id' => $user->id, 'hash' => 'wrong-hash']
+            ['id' => $user->id, 'hash' => 'wrong-hash'],
+            false
         );
 
         // Make 7 requests (throttle is set to 6 per minute)

--- a/tests/Feature/EmailVerificationTest.php
+++ b/tests/Feature/EmailVerificationTest.php
@@ -45,10 +45,80 @@ class EmailVerificationTest extends TestCase
 
     public function test_email_verification_requires_valid_signature(): void
     {
-        // SECURITY: investigation needed — unsigned verification URLs currently
-        // succeed in verifying the user, which would allow account takeover via
-        // crafted URLs. Un-skip and tighten once the route/middleware is fixed.
-        $this->markTestSkipped('Pending fix: unsigned verification URLs still verify the user.');
+        $user = User::factory()->create([
+            'email_verified_at' => null,
+            'user_status_id' => UserStatus::PENDING,
+        ]);
+
+        // Unsigned URL — knows the id+hash but lacks the HMAC signature.
+        $unsignedUrl = route('verification.verify', [
+            'id' => $user->id,
+            'hash' => sha1($user->email),
+        ]);
+
+        $response = $this->get($unsignedUrl);
+
+        $response->assertStatus(403);
+        $this->assertFalse($user->fresh()->hasVerifiedEmail());
+    }
+
+    public function test_email_verification_rejects_tampered_signature(): void
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => null,
+            'user_status_id' => UserStatus::PENDING,
+        ]);
+
+        $verificationUrl = URL::temporarySignedRoute(
+            'verification.verify',
+            now()->addMinutes(60),
+            ['id' => $user->id, 'hash' => sha1($user->email)]
+        );
+
+        $tamperedUrl = $verificationUrl.'x';
+
+        $response = $this->get($tamperedUrl);
+
+        $response->assertStatus(403);
+        $this->assertFalse($user->fresh()->hasVerifiedEmail());
+    }
+
+    public function test_api_email_verification_requires_valid_signature(): void
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => null,
+            'user_status_id' => UserStatus::PENDING,
+        ]);
+
+        $unsignedUrl = route('api.verification.verify', [
+            'id' => $user->id,
+            'hash' => sha1($user->email),
+        ]);
+
+        $response = $this->getJson($unsignedUrl);
+
+        $response->assertStatus(403);
+        $this->assertFalse($user->fresh()->hasVerifiedEmail());
+    }
+
+    public function test_api_email_verification_succeeds_with_valid_signature(): void
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => null,
+            'user_status_id' => UserStatus::PENDING,
+        ]);
+
+        $verificationUrl = URL::temporarySignedRoute(
+            'api.verification.verify',
+            now()->addMinutes(60),
+            ['id' => $user->id, 'hash' => sha1($user->email)]
+        );
+
+        $response = $this->getJson($verificationUrl);
+
+        $response->assertStatus(200);
+        $response->assertJson(['verified' => true]);
+        $this->assertTrue($user->fresh()->hasVerifiedEmail());
     }
 
     public function test_email_verification_resend_requires_authentication(): void

--- a/tests/Feature/EmailVerificationTest.php
+++ b/tests/Feature/EmailVerificationTest.php
@@ -32,7 +32,8 @@ class EmailVerificationTest extends TestCase
         $verificationUrl = URL::temporarySignedRoute(
             'verification.verify',
             now()->addMinutes(60),
-            ['id' => $user->id, 'hash' => sha1($user->email)]
+            ['id' => $user->id, 'hash' => sha1($user->email)],
+            false
         );
 
         $this->assertGuest();
@@ -72,7 +73,8 @@ class EmailVerificationTest extends TestCase
         $verificationUrl = URL::temporarySignedRoute(
             'verification.verify',
             now()->addMinutes(60),
-            ['id' => $user->id, 'hash' => sha1($user->email)]
+            ['id' => $user->id, 'hash' => sha1($user->email)],
+            false
         );
 
         $tamperedUrl = $verificationUrl.'x';
@@ -111,7 +113,8 @@ class EmailVerificationTest extends TestCase
         $verificationUrl = URL::temporarySignedRoute(
             'api.verification.verify',
             now()->addMinutes(60),
-            ['id' => $user->id, 'hash' => sha1($user->email)]
+            ['id' => $user->id, 'hash' => sha1($user->email)],
+            false
         );
 
         $response = $this->getJson($verificationUrl);


### PR DESCRIPTION
The web (`verification.verify`) and API (`api.verification.verify`) endpoints accepted requests without a valid HMAC signature, relying only on a SHA-1 of the user's email. Since emails are not secrets, anyone who knew a target's email could craft a working verification URL and take over the account.

- Drop `'verify' => true` from `Auth::routes()` (laravel/ui's variant omits the `signed` middleware) and register the three verification routes explicitly, with `signed` on `verification.verify`.
- Add `signed` middleware to `api.verification.verify`.
- Add `abort_unless($request->hasValidSignature(), 403)` to both controllers as defense-in-depth.
- Stop leaking the `expected` SHA-1 hash in the API's 400 response.
- Un-skip `test_email_verification_requires_valid_signature` and add tampered-signature plus API coverage.