### PR TITLE
Tier 5 Phase C: ImageHandler and FlyerAnalysisService tests

### DIFF
--- a/tests/Feature/Services/FlyerAnalysisServiceTest.php
+++ b/tests/Feature/Services/FlyerAnalysisServiceTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Feature\Services;
+
+use App\Services\FlyerAnalysisService;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class FlyerAnalysisServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+        config()->set('ai.provider', 'anthropic');
+        config()->set('ai.anthropic.api_key', 'test-key');
+        config()->set('ai.anthropic.api_url', 'https://api.anthropic.com/v1/messages');
+    }
+
+    private function flyer(): UploadedFile
+    {
+        return UploadedFile::fake()->image('flyer.jpg');
+    }
+
+    public function test_returns_decoded_json_payload_on_success(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => Http::response([
+                'content' => [['text' => '{"name":"Test Event","start_at":"2026-08-15 20:00"}']],
+            ], 200),
+        ]);
+
+        $result = (new FlyerAnalysisService())->analyze($this->flyer());
+
+        $this->assertSame('Test Event', $result['name']);
+        $this->assertSame('2026-08-15 20:00', $result['start_at']);
+    }
+
+    public function test_strips_markdown_code_fences_from_model_response(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => Http::response([
+                'content' => [['text' => "```json\n{\"name\":\"Fenced Event\"}\n```"]],
+            ], 200),
+        ]);
+
+        $result = (new FlyerAnalysisService())->analyze($this->flyer());
+
+        $this->assertSame('Fenced Event', $result['name']);
+    }
+
+    public function test_api_failure_throws_runtime_exception(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => Http::response(['error' => 'overloaded'], 503),
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The flyer could not be analysed');
+
+        (new FlyerAnalysisService())->analyze($this->flyer());
+    }
+
+    public function test_unparseable_response_throws_runtime_exception(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => Http::response([
+                'content' => [['text' => 'this is not json']],
+            ], 200),
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('AI returned an unexpected response');
+
+        (new FlyerAnalysisService())->analyze($this->flyer());
+    }
+
+    public function test_missing_api_key_throws(): void
+    {
+        config()->set('ai.anthropic.api_key', '');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Anthropic API key is not configured');
+
+        (new FlyerAnalysisService())->analyze($this->flyer());
+    }
+
+    public function test_unknown_provider_throws(): void
+    {
+        config()->set('ai.provider', 'openai');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unsupported AI provider');
+
+        (new FlyerAnalysisService())->analyze($this->flyer());
+    }
+}

--- a/tests/Feature/Services/ImageHandlerTest.php
+++ b/tests/Feature/Services/ImageHandlerTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Feature\Services;
+
+use App\Services\ImageHandler;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Intervention\Image\Facades\Image;
+use Mockery;
+use Tests\TestCase;
+
+class ImageHandlerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    /**
+     * Replace Intervention's Image facade with a self-chained mock so the
+     * tests do not depend on real image-processing or network-style URL
+     * fetching (Storage::fake('external')->url() is a placeholder).
+     *
+     * Each call to Image::make() returns a mock whose chained methods (fit,
+     * encode, save, destroy) return the mock itself. basePath() returns a
+     * real temp file path so the production code's unlink() succeeds.
+     */
+    private function stubImageFacade(): void
+    {
+        $mock = Mockery::mock();
+        $mock->shouldReceive('fit')->andReturnSelf();
+        $mock->shouldReceive('encode')->andReturnSelf();
+        $mock->shouldReceive('save')->andReturnSelf();
+        $mock->shouldReceive('destroy')->andReturnNull();
+        $mock->shouldReceive('basePath')->andReturnUsing(function () {
+            $tmp = tempnam(sys_get_temp_dir(), 'imghandler-');
+
+            return $tmp;
+        });
+
+        Image::shouldReceive('make')->andReturn($mock);
+    }
+
+    public function test_make_photo_stores_uploaded_file_on_external_disk(): void
+    {
+        Storage::fake('external');
+        $this->stubImageFacade();
+
+        $file = UploadedFile::fake()->image('event.png');
+        (new ImageHandler())->makePhoto($file);
+
+        // The original upload lands on the external disk under photos/ with a
+        // timestamp_event.png filename (the webp/thumb variants are rewrites
+        // performed by Photo::makeWebp / Photo::makeThumbnail).
+        $stored = Storage::disk('external')->allFiles('photos');
+        $original = array_filter($stored, fn ($p) => (bool) preg_match('#^photos/\d+_event\.png$#', $p));
+
+        $this->assertNotEmpty($original, 'Expected the timestamped original upload to be on the external disk.');
+    }
+
+    public function test_make_photo_returns_photo_with_path_and_thumbnail_set(): void
+    {
+        Storage::fake('external');
+        $this->stubImageFacade();
+
+        // After makeWebp() the Photo's name is rewritten to the .webp variant
+        // (see Photo::makeWebp → saveAs($webpName)). Assert the final shape.
+        $file = UploadedFile::fake()->image('promo.png');
+        $photo = (new ImageHandler())->makePhoto($file);
+
+        $this->assertStringEndsWith('.webp', $photo->name);
+        $this->assertSame('photos/'.$photo->name, $photo->path);
+        $this->assertStringStartsWith('photos/tn-', $photo->thumbnail);
+    }
+
+    public function test_make_photo_preserves_original_extension_in_uploaded_file(): void
+    {
+        Storage::fake('external');
+        $this->stubImageFacade();
+
+        $file = UploadedFile::fake()->image('flyer.jpg');
+        (new ImageHandler())->makePhoto($file);
+
+        // Find what was originally uploaded; .jpg before webp re-saves over it.
+        $stored = Storage::disk('external')->allFiles('photos');
+        $jpgs = array_filter($stored, fn ($p) => str_ends_with($p, '_flyer.jpg'));
+
+        $this->assertNotEmpty($jpgs, 'Expected the original .jpg upload to be stored.');
+    }
+}


### PR DESCRIPTION
- FlyerAnalysisService: assert the success path decodes the model's JSON payload, markdown code fences are stripped, API failures and unparseable model output throw RuntimeException with informative messages, missing api_key throws, and an unknown ai.provider throws. Uses Http::fake() so nothing leaves the host.
- ImageHandler::makePhoto: assert the uploaded file lands on the external disk under photos/ with a timestamp_originalname filename, the returned Photo has its path/thumbnail attributes wired through Photo::makeWebp + Photo::makeThumbnail, and the original-extension upload is preserved alongside the .webp rewrite. The Intervention Image facade is stubbed via Mockery so the test never fetches over HTTP or touches real image bytes.

generateCoverImage is intentionally not covered — it depends on a physical TrueType font file and writes outside the Storage facade, which is not worth the test scaffolding for an Instagram-only path.