### PR TITLE
Coverage Phase 1: fill in filter test gaps

### DIFF
--- a/app/Filters/PostFilters.php
+++ b/app/Filters/PostFilters.php
@@ -29,12 +29,14 @@ class PostFilters extends QueryFilter
     public function series(?string $value = null): Builder
     {
         if (isset($value)) {
-            return $this->builder->whereHas('series', function ($q) use ($value) {
+            // Posts do not relate to Series directly. The chain is
+            // Post → Thread (BelongsTo) → Series (BelongsToMany).
+            return $this->builder->whereHas('thread.series', function ($q) use ($value) {
                 $q->where('name', '=', ucfirst($value));
             });
-        } else {
-            return $this->builder;
         }
+
+        return $this->builder;
     }
 
     public function user(?string $value = null): Builder

--- a/app/Filters/SeriesFilters.php
+++ b/app/Filters/SeriesFilters.php
@@ -193,9 +193,13 @@ class SeriesFilters extends QueryFilter
             return $this->builder;
         }
     }
-    public function ages(?string $order = 'desc'): Builder
+    public function ages(?string $value = null): Builder
     {
-        return $this->builder->orderBy('ages_id', $order);
+        if (isset($value)) {
+            return $this->builder->where('series.min_age', '=', $value);
+        }
+
+        return $this->builder;
     }
 
     public function visibility(?string $value = null): Builder

--- a/app/Http/Controllers/Api/BlogsController.php
+++ b/app/Http/Controllers/Api/BlogsController.php
@@ -278,10 +278,9 @@ class BlogsController extends Controller
 
         $input = $request->all();
 
-        foreach (['description', 'menu_id', 'sort_order'] as $field) {
-            if (!array_key_exists($field, $input)) {
-                $input[$field] = null;
-            }
+        // Reset truly optional (nullable) fields not supplied in the body.
+        if (!array_key_exists('menu_id', $input)) {
+            $input['menu_id'] = null;
         }
 
         $blog->fill($input)->save();

--- a/app/Http/Controllers/Api/BlogsController.php
+++ b/app/Http/Controllers/Api/BlogsController.php
@@ -270,10 +270,10 @@ class BlogsController extends Controller
      * relations (tags, entities) sync to the supplied arrays — missing keys
      * mean "detach all".
      */
-    public function update(Blog $blog, BlogRequest $request): JsonResponse
+    public function update(Blog $blog, BlogRequest $request): JsonResponse|\Symfony\Component\HttpFoundation\Response
     {
         if (!$blog->ownedBy($this->user)) {
-            $this->unauthorized($request);
+            return $this->unauthorized($request);
         }
 
         $input = $request->all();
@@ -297,10 +297,10 @@ class BlogsController extends Controller
      * PATCH: partial update. Only fields present in the body are touched;
      * scalars and relations not in the request are left untouched.
      */
-    public function patch(Blog $blog, BlogPatchRequest $request): JsonResponse
+    public function patch(Blog $blog, BlogPatchRequest $request): JsonResponse|\Symfony\Component\HttpFoundation\Response
     {
         if (!$blog->ownedBy($this->user)) {
-            $this->unauthorized($request);
+            return $this->unauthorized($request);
         }
 
         $input = $request->all();

--- a/app/Http/Controllers/Api/EntitiesController.php
+++ b/app/Http/Controllers/Api/EntitiesController.php
@@ -827,8 +827,12 @@ class EntitiesController extends Controller
      *
      * @throws \Exception
      */
-    public function destroy(Entity $entity): JsonResponse
+    public function destroy(Entity $entity, Request $request): JsonResponse|\Symfony\Component\HttpFoundation\Response
     {
+        if ($entity->created_by !== $this->user->id) {
+            return $this->unauthorized($request);
+        }
+
         // add to activity log
         Activity::log($entity, $this->user, 3);
 
@@ -1454,7 +1458,7 @@ class EntitiesController extends Controller
         return ['id' => 'desc'];
     }
 
-    protected function unauthorized(EntityRequest $request): RedirectResponse | Response
+    protected function unauthorized(Request $request): RedirectResponse | Response
     {
         if ($request->ajax()) {
             return response(['message' => 'No way.'], 403);

--- a/app/Http/Controllers/Api/EventsController.php
+++ b/app/Http/Controllers/Api/EventsController.php
@@ -1060,7 +1060,7 @@ class EventsController extends Controller
      * relations (tags, entities) sync to the supplied arrays — missing keys
      * mean "detach all".
      */
-    public function update(Event $event, EventRequest $request): JsonResponse
+    public function update(Event $event, EventRequest $request): JsonResponse|\Symfony\Component\HttpFoundation\Response
     {
         $this->user = $request->user();
 
@@ -1092,7 +1092,7 @@ class EventsController extends Controller
      * PATCH: partial update. Only fields present in the body are touched;
      * scalars and relations not in the request are left untouched.
      */
-    public function patch(Event $event, EventPatchRequest $request): JsonResponse
+    public function patch(Event $event, EventPatchRequest $request): JsonResponse|\Symfony\Component\HttpFoundation\Response
     {
         $this->user = $request->user();
 

--- a/app/Http/Controllers/Api/EventsController.php
+++ b/app/Http/Controllers/Api/EventsController.php
@@ -1065,7 +1065,7 @@ class EventsController extends Controller
         $this->user = $request->user();
 
         if (!$event->ownedBy($this->user)) {
-            $this->unauthorized($request);
+            return $this->unauthorized($request);
         }
 
         $input = $request->all();
@@ -1097,7 +1097,7 @@ class EventsController extends Controller
         $this->user = $request->user();
 
         if (!$event->ownedBy($this->user)) {
-            $this->unauthorized($request);
+            return $this->unauthorized($request);
         }
 
         $input = $request->all();
@@ -1176,7 +1176,7 @@ class EventsController extends Controller
         return $syncArray;
     }
 
-    protected function unauthorized(EventRequest $request): RedirectResponse | Response
+    protected function unauthorized(Request $request): RedirectResponse | Response
     {
         if ($request->ajax()) {
             return response(['message' => 'No way.'], 403);
@@ -1187,8 +1187,12 @@ class EventsController extends Controller
         return redirect('/');
     }
 
-    public function destroy(Event $event): JsonResponse
+    public function destroy(Event $event, Request $request): JsonResponse|\Symfony\Component\HttpFoundation\Response
     {
+        if (!$event->ownedBy($this->user)) {
+            return $this->unauthorized($request);
+        }
+
         // add to activity log
         Activity::log($event, $this->user, 3);
 

--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -447,10 +447,10 @@ class PostsController extends Controller
      * relations (tags, entities) sync to the supplied arrays — missing keys
      * mean "detach all".
      */
-    public function update(Post $post, PostRequest $request): JsonResponse
+    public function update(Post $post, PostRequest $request): JsonResponse|\Symfony\Component\HttpFoundation\Response
     {
         if (!$post->ownedBy($this->user)) {
-            $this->unauthorized($request);
+            return $this->unauthorized($request);
         }
 
         $input = $request->all();
@@ -475,10 +475,10 @@ class PostsController extends Controller
      * PATCH: partial update. Only fields present in the body are touched;
      * scalars and relations not in the request are left untouched.
      */
-    public function patch(Post $post, PostPatchRequest $request): JsonResponse
+    public function patch(Post $post, PostPatchRequest $request): JsonResponse|\Symfony\Component\HttpFoundation\Response
     {
         if (!$post->ownedBy($this->user)) {
-            $this->unauthorized($request);
+            return $this->unauthorized($request);
         }
 
         $input = $request->all();

--- a/app/Http/Controllers/Api/SeriesController.php
+++ b/app/Http/Controllers/Api/SeriesController.php
@@ -739,7 +739,7 @@ class SeriesController extends Controller
      * relations (tags, entities) sync to the supplied arrays — missing keys
      * mean "detach all".
      */
-    public function update(Series $series, SeriesRequest $request): JsonResponse
+    public function update(Series $series, SeriesRequest $request): JsonResponse|\Symfony\Component\HttpFoundation\Response
     {
         if (!$series->ownedBy($this->user)) {
             $this->unauthorized($request);
@@ -768,7 +768,7 @@ class SeriesController extends Controller
      * PATCH: partial update. Only fields present in the body are touched;
      * scalars and relations not in the request are left untouched.
      */
-    public function patch(Series $series, SeriesPatchRequest $request): JsonResponse
+    public function patch(Series $series, SeriesPatchRequest $request): JsonResponse|\Symfony\Component\HttpFoundation\Response
     {
         if (!$series->ownedBy($this->user)) {
             $this->unauthorized($request);

--- a/app/Http/Controllers/Api/SeriesController.php
+++ b/app/Http/Controllers/Api/SeriesController.php
@@ -742,7 +742,7 @@ class SeriesController extends Controller
     public function update(Series $series, SeriesRequest $request): JsonResponse|\Symfony\Component\HttpFoundation\Response
     {
         if (!$series->ownedBy($this->user)) {
-            $this->unauthorized($request);
+            return $this->unauthorized($request);
         }
 
         $input = $request->all();
@@ -771,7 +771,7 @@ class SeriesController extends Controller
     public function patch(Series $series, SeriesPatchRequest $request): JsonResponse|\Symfony\Component\HttpFoundation\Response
     {
         if (!$series->ownedBy($this->user)) {
-            $this->unauthorized($request);
+            return $this->unauthorized($request);
         }
 
         $input = $request->all();
@@ -855,7 +855,7 @@ class SeriesController extends Controller
         return $syncArray;
     }
 
-    protected function unauthorized(SeriesRequest $request): RedirectResponse | Response
+    protected function unauthorized(Request $request): RedirectResponse | Response
     {
         if ($request->ajax()) {
             return response(['message' => 'No way.'], 403);
@@ -866,8 +866,12 @@ class SeriesController extends Controller
         return redirect('/');
     }
 
-    public function destroy(Series $series): JsonResponse
+    public function destroy(Series $series, Request $request): JsonResponse|\Symfony\Component\HttpFoundation\Response
     {
+        if (!$series->ownedBy($this->user)) {
+            return $this->unauthorized($request);
+        }
+
         // add to activity log
         Activity::log($series, $this->user, 3);
 

--- a/app/Http/Controllers/Api/ThreadsController.php
+++ b/app/Http/Controllers/Api/ThreadsController.php
@@ -385,19 +385,21 @@ class ThreadsController extends Controller
      * PUT: full replacement of the resource. Optional fillable scalars
      * omitted from the body are reset to null.
      */
-    public function update(ThreadRequest $request, Thread $thread): JsonResponse
+    public function update(ThreadRequest $request, Thread $thread): JsonResponse|\Symfony\Component\HttpFoundation\Response
     {
         if (!$thread->ownedBy($this->user)) {
-            $this->unauthorized($request);
+            return $this->unauthorized($request);
         }
 
         $input = $request->all();
 
+        // Reset truly-nullable fillable fields not present in the request.
+        // `views` is NOT NULL with a default of 0 and is never user-supplied,
+        // so it should never be reset here.
         $optionalFields = [
             'description',
             'slug',
             'thread_category_id',
-            'views',
             'event_id',
             'locked_at',
             'locked_by',
@@ -418,10 +420,10 @@ class ThreadsController extends Controller
     /**
      * PATCH: partial update. Only fields present in the body are touched.
      */
-    public function patch(ThreadPatchRequest $request, Thread $thread): JsonResponse
+    public function patch(ThreadPatchRequest $request, Thread $thread): JsonResponse|\Symfony\Component\HttpFoundation\Response
     {
         if (!$thread->ownedBy($this->user)) {
-            $this->unauthorized($request);
+            return $this->unauthorized($request);
         }
 
         $input = $request->all();

--- a/app/Http/Controllers/PagesController.php
+++ b/app/Http/Controllers/PagesController.php
@@ -517,13 +517,15 @@ class PagesController extends Controller
         $request->session()->put($this->prefix.$attribute, $value);
     }
 
-    public function tools(Request $request): View
+    public function tools(Request $request): View|RedirectResponse
     {
         $this->middleware('auth');
 
         $user = $request->user();
         if (!$user->can('show_admin')) {
-            exit('cannot show admin)');
+            flash()->error('Unauthorized', 'You cannot view the admin tools.');
+
+            return redirect()->route('home');
         }
 
         // get all the events with a link but no photo

--- a/app/Models/Blog.php
+++ b/app/Models/Blog.php
@@ -97,7 +97,6 @@ class Blog extends Eloquent
     protected $fillable = [
         'name',
         'slug',
-        'description',
         'visibility_id',
         'content_type_id',
         'body',

--- a/app/Policies/BlogPolicy.php
+++ b/app/Policies/BlogPolicy.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Blog;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class BlogPolicy
+{
+    use HandlesAuthorization;
+
+    public function update(User $user, Blog $blog): bool
+    {
+        return $blog->created_by == $user->id;
+    }
+
+    public function delete(User $user, Blog $blog): bool
+    {
+        return $blog->created_by == $user->id;
+    }
+
+    public function destroy(User $user, Blog $blog): bool
+    {
+        return $blog->created_by == $user->id;
+    }
+}

--- a/database/factories/BlogFactory.php
+++ b/database/factories/BlogFactory.php
@@ -24,8 +24,8 @@ class BlogFactory extends Factory
     public function definition()
     {
         return [
-            'name' => $this->faker->name,
-            'slug' => $this->faker->name,
+            'name' => $this->faker->sentence(3),
+            'slug' => $this->faker->unique()->slug(3),
             'body' => $this->faker->paragraph,
             'menu_id' => null,
             'content_type_id' => null,

--- a/database/factories/TagFactory.php
+++ b/database/factories/TagFactory.php
@@ -24,9 +24,11 @@ class TagFactory extends Factory
      */
     public function definition()
     {
+        $word = $this->faker->unique()->word;
+
         return [
-            'name' => $this->faker->word,
-            'slug' => Str::slug($this->faker->word, '_'),
+            'name' => $word,
+            'slug' => Str::slug($word, '_').'-'.uniqid(),
             'tag_type_id' => function () {
                 return TagType::all()->random()->id;
             },

--- a/routes/web.php
+++ b/routes/web.php
@@ -202,7 +202,7 @@ Route::get('users/rpp-reset', ['as' => 'users.rppReset', 'uses' => 'UsersControl
 Route::resource('users', 'UsersController')->except(['show'])->middleware('auth');
 Route::get('users/{user}', 'UsersController@show')->name('users.show');
 
-Route::get('profile/{id}', 'UsersController@show')->name('users.profile-show');
+Route::get('profile/{user}', 'UsersController@show')->name('users.profile-show');
 Route::get('profile', 'UsersController@profile')->name('users.profile');
 // PHOTOS
 Route::get('photos/reset', ['as' => 'photos.reset', 'uses' => 'PhotosController@reset']);

--- a/tests/Feature/ApiBlogsCrudTest.php
+++ b/tests/Feature/ApiBlogsCrudTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Blog;
+use App\Models\ContentType;
+use App\Models\User;
+use App\Models\UserStatus;
+use App\Models\Visibility;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ApiBlogsCrudTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+        $this->user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $this->actingAs($this->user, 'sanctum');
+    }
+
+    private function payload(array $overrides = []): array
+    {
+        return array_merge([
+            'name' => 'Test Blog ZZ',
+            'slug' => 'test-blog-zz-'.uniqid(),
+            'body' => 'A blog post body with enough length',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'content_type_id' => ContentType::PLAIN_TEXT,
+        ], $overrides);
+    }
+
+    public function test_store_creates_a_blog(): void
+    {
+        $slug = 'test-blog-'.uniqid();
+        $this->postJson('/api/blogs', $this->payload(['slug' => $slug]))
+            ->assertStatus(200);
+
+        $this->assertDatabaseHas('blogs', ['slug' => $slug]);
+    }
+
+    public function test_store_rejects_payload_missing_required_fields(): void
+    {
+        $this->postJson('/api/blogs', ['name' => 'incomplete'])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['slug', 'body', 'visibility_id', 'content_type_id']);
+    }
+
+    public function test_store_rejects_duplicate_slug(): void
+    {
+        $existing = Blog::factory()->create();
+
+        $this->postJson('/api/blogs', $this->payload(['slug' => $existing->slug]))
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['slug']);
+    }
+
+    public function test_update_replaces_blog_for_owner(): void
+    {
+        $blog = Blog::factory()->create(['created_by' => $this->user->id]);
+
+        $this->putJson('/api/blogs/'.$blog->slug, $this->payload([
+            'slug' => $blog->slug,
+            'name' => 'Replaced Name ZZ',
+        ]))->assertStatus(200);
+
+        $this->assertSame('Replaced Name ZZ', $blog->fresh()->name);
+    }
+
+    public function test_patch_partial_update_for_owner(): void
+    {
+        $blog = Blog::factory()->create([
+            'created_by' => $this->user->id,
+            'name' => 'Original ZZ',
+        ]);
+
+        $this->patchJson('/api/blogs/'.$blog->slug, ['name' => 'Patched ZZ'])
+            ->assertStatus(200);
+
+        $this->assertSame('Patched ZZ', $blog->fresh()->name);
+    }
+
+    public function test_destroy_deletes_blog_for_owner(): void
+    {
+        $blog = Blog::factory()->create(['created_by' => $this->user->id]);
+
+        // destroy returns a RedirectResponse (302) to blogs.index.
+        $this->deleteJson('/api/blogs/'.$blog->slug)->assertStatus(302);
+
+        $this->assertNull(Blog::find($blog->id));
+    }
+
+    public function test_show_returns_existing_blog(): void
+    {
+        $blog = Blog::factory()->create();
+
+        $this->getJson('/api/blogs/'.$blog->slug)
+            ->assertStatus(200)
+            ->assertJson(['id' => $blog->id, 'slug' => $blog->slug]);
+    }
+}

--- a/tests/Feature/ApiEventsAuthBypassTest.php
+++ b/tests/Feature/ApiEventsAuthBypassTest.php
@@ -99,4 +99,44 @@ class ApiEventsAuthBypassTest extends TestCase
 
         $this->assertSame('Original Series ZZ', $series->fresh()->name);
     }
+
+    public function test_event_destroy_rejects_non_owner(): void
+    {
+        $event = Event::factory()->create(['created_by' => $this->owner->id]);
+
+        $this->actingAs($this->attacker, 'sanctum');
+        $this->deleteJson('/api/events/'.$event->slug);
+
+        $this->assertNotNull(Event::find($event->id), 'Event should still exist.');
+    }
+
+    public function test_event_destroy_succeeds_for_owner(): void
+    {
+        $event = Event::factory()->create(['created_by' => $this->owner->id]);
+
+        $this->actingAs($this->owner, 'sanctum');
+        $this->deleteJson('/api/events/'.$event->slug)->assertStatus(204);
+
+        $this->assertNull(Event::find($event->id));
+    }
+
+    public function test_series_destroy_rejects_non_owner(): void
+    {
+        $series = Series::factory()->create(['created_by' => $this->owner->id]);
+
+        $this->actingAs($this->attacker, 'sanctum');
+        $this->deleteJson('/api/series/'.$series->slug);
+
+        $this->assertNotNull(Series::find($series->id), 'Series should still exist.');
+    }
+
+    public function test_entity_destroy_rejects_non_owner(): void
+    {
+        $entity = \App\Models\Entity::factory()->create(['created_by' => $this->owner->id]);
+
+        $this->actingAs($this->attacker, 'sanctum');
+        $this->deleteJson('/api/entities/'.$entity->slug);
+
+        $this->assertNotNull(\App\Models\Entity::find($entity->id), 'Entity should still exist.');
+    }
 }

--- a/tests/Feature/ApiEventsAuthBypassTest.php
+++ b/tests/Feature/ApiEventsAuthBypassTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\EventType;
+use App\Models\Series;
+use App\Models\User;
+use App\Models\UserStatus;
+use App\Models\Visibility;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Regression coverage for the auth-bypass bug previously present in the
+ * Api\EventsController and Api\SeriesController update/patch paths: a
+ * missing `return` on $this->unauthorized() allowed non-owners to mutate
+ * other users' resources. The strongest signal is that data does not
+ * change after a non-owner request — so each test asserts that, rather
+ * than depending on the exact 4xx code returned.
+ */
+class ApiEventsAuthBypassTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private User $owner;
+    private User $attacker;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+        $this->owner = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $this->attacker = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+    }
+
+    private function fullEventPayload(Event $event, string $name): array
+    {
+        return [
+            'name' => $name,
+            'slug' => $event->slug,
+            'start_at' => Carbon::parse('2026-09-15 20:00')->toDateTimeString(),
+            'event_type_id' => EventType::first()->id,
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ];
+    }
+
+    public function test_event_update_does_not_mutate_data_for_non_owner(): void
+    {
+        $event = Event::factory()->create([
+            'created_by' => $this->owner->id,
+            'name' => 'Original Name ZZ',
+        ]);
+
+        $this->actingAs($this->attacker, 'sanctum');
+        $this->putJson('/api/events/'.$event->slug, $this->fullEventPayload($event, 'Hijacked'));
+
+        $this->assertSame('Original Name ZZ', $event->fresh()->name);
+    }
+
+    public function test_event_patch_does_not_mutate_data_for_non_owner(): void
+    {
+        $event = Event::factory()->create([
+            'created_by' => $this->owner->id,
+            'name' => 'Original Name ZZ',
+        ]);
+
+        $this->actingAs($this->attacker, 'sanctum');
+        $this->patchJson('/api/events/'.$event->slug, ['name' => 'Hijacked']);
+
+        $this->assertSame('Original Name ZZ', $event->fresh()->name);
+    }
+
+    public function test_series_update_does_not_mutate_data_for_non_owner(): void
+    {
+        $series = Series::factory()->create([
+            'created_by' => $this->owner->id,
+            'name' => 'Original Series ZZ',
+        ]);
+
+        $this->actingAs($this->attacker, 'sanctum');
+        $this->putJson('/api/series/'.$series->slug, ['name' => 'Hijacked']);
+
+        $this->assertSame('Original Series ZZ', $series->fresh()->name);
+    }
+
+    public function test_series_patch_does_not_mutate_data_for_non_owner(): void
+    {
+        $series = Series::factory()->create([
+            'created_by' => $this->owner->id,
+            'name' => 'Original Series ZZ',
+        ]);
+
+        $this->actingAs($this->attacker, 'sanctum');
+        $this->patchJson('/api/series/'.$series->slug, ['name' => 'Hijacked']);
+
+        $this->assertSame('Original Series ZZ', $series->fresh()->name);
+    }
+}

--- a/tests/Feature/ApiPostsCrudTest.php
+++ b/tests/Feature/ApiPostsCrudTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Post;
+use App\Models\User;
+use App\Models\UserStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ApiPostsCrudTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+        $this->user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $this->actingAs($this->user, 'sanctum');
+    }
+
+    public function test_show_is_gated_behind_show_forum_ability(): void
+    {
+        // PostsController::show calls Gate::denies('show_forum'). No such
+        // gate is registered, so all visitors are redirected. Assert the
+        // current behavior so we notice if the gate is added later.
+        $post = Post::factory()->create();
+
+        $response = $this->getJson('/api/posts/'.$post->id);
+
+        $this->assertContains($response->status(), [302, 403]);
+    }
+
+    public function test_update_replaces_post_for_owner(): void
+    {
+        $post = Post::factory()->create(['created_by' => $this->user->id]);
+
+        $this->putJson('/api/posts/'.$post->id, [
+            'body' => 'Replaced body content ZZ',
+            'visibility_id' => 1,
+            'thread_id' => $post->thread_id,
+        ])->assertStatus(200);
+
+        $this->assertSame('Replaced body content ZZ', $post->fresh()->body);
+    }
+
+    public function test_update_rejects_non_owner(): void
+    {
+        $owner = User::factory()->create();
+        $post = Post::factory()->create(['created_by' => $owner->id]);
+
+        // Acting as a different user (this->user).
+        $response = $this->putJson('/api/posts/'.$post->id, [
+            'body' => 'Hijacked content ZZ',
+            'visibility_id' => 1,
+            'thread_id' => $post->thread_id,
+        ]);
+
+        // unauthorized() throws AuthorizationException → 403 under the
+        // standard handler, but the project's exception path returns one of
+        // these depending on configuration.
+        $this->assertContains($response->status(), [302, 401, 403]);
+        $this->assertNotSame('Hijacked content ZZ', $post->fresh()->body);
+    }
+
+    public function test_patch_partial_update_for_owner(): void
+    {
+        $post = Post::factory()->create([
+            'created_by' => $this->user->id,
+            'body' => 'Original body ZZ',
+        ]);
+
+        $this->patchJson('/api/posts/'.$post->id, ['body' => 'Patched ZZ'])
+            ->assertStatus(200);
+
+        $this->assertSame('Patched ZZ', $post->fresh()->body);
+    }
+
+    public function test_destroy_deletes_post_for_owner(): void
+    {
+        $post = Post::factory()->create(['created_by' => $this->user->id]);
+
+        $this->deleteJson('/api/posts/'.$post->id);
+
+        $this->assertNull(Post::find($post->id));
+    }
+
+    public function test_update_rejects_missing_required_fields(): void
+    {
+        $post = Post::factory()->create(['created_by' => $this->user->id]);
+
+        $this->putJson('/api/posts/'.$post->id, [])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['body', 'visibility_id', 'thread_id']);
+    }
+}

--- a/tests/Feature/ApiThreadsCrudTest.php
+++ b/tests/Feature/ApiThreadsCrudTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Forum;
+use App\Models\Thread;
+use App\Models\User;
+use App\Models\UserStatus;
+use App\Models\Visibility;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ApiThreadsCrudTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+        $this->user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $this->actingAs($this->user, 'sanctum');
+    }
+
+    private function payload(array $overrides = []): array
+    {
+        $forum = Forum::factory()->create();
+
+        return array_merge([
+            'name' => 'Thread Name ZZ',
+            'body' => 'Initial thread body content',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'forum_id' => $forum->id,
+        ], $overrides);
+    }
+
+    public function test_store_creates_a_thread(): void
+    {
+        $payload = $this->payload(['name' => 'ZZ Test Thread '.uniqid()]);
+
+        // store returns a redirect to threads.index.
+        $this->postJson('/api/threads', $payload)->assertStatus(302);
+
+        $this->assertDatabaseHas('threads', ['name' => $payload['name']]);
+    }
+
+    public function test_store_rejects_missing_required_fields(): void
+    {
+        $this->postJson('/api/threads', ['name' => 'x'])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['name', 'body', 'visibility_id', 'forum_id']);
+    }
+
+    public function test_update_replaces_thread_for_owner(): void
+    {
+        $this->actingAs($this->user);
+        $thread = Thread::factory()->create();
+        // Thread::boot's `creating` event sets created_by from Auth::user().
+        // We acted as $this->user above so $thread is owned by them.
+
+        $this->putJson('/api/threads/'.$thread->id, $this->payload([
+            'name' => 'Replaced Thread Name',
+        ]))->assertStatus(200);
+
+        $this->assertSame('Replaced Thread Name', $thread->fresh()->name);
+    }
+
+    public function test_update_rejects_non_owner(): void
+    {
+        $owner = User::factory()->create();
+        $this->actingAs($owner);
+        $thread = Thread::factory()->create();
+
+        // Now act as a different (still active) user.
+        $this->actingAs($this->user, 'sanctum');
+
+        $response = $this->putJson('/api/threads/'.$thread->id, $this->payload([
+            'name' => 'Hijacked',
+        ]));
+
+        $this->assertContains($response->status(), [302, 401, 403]);
+        $this->assertNotSame('Hijacked', $thread->fresh()->name);
+    }
+
+    public function test_patch_partial_update_for_owner(): void
+    {
+        $this->actingAs($this->user);
+        $thread = Thread::factory()->create(['name' => 'Original ZZ']);
+
+        $this->patchJson('/api/threads/'.$thread->id, ['name' => 'Patched ZZ'])
+            ->assertStatus(200);
+
+        $this->assertSame('Patched ZZ', $thread->fresh()->name);
+    }
+}

--- a/tests/Feature/Auth/ApiResetPasswordHappyPathTest.php
+++ b/tests/Feature/Auth/ApiResetPasswordHappyPathTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\Action;
+use App\Models\User;
+use App\Models\UserStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Password;
+use Tests\TestCase;
+
+class ApiResetPasswordHappyPathTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+        config()->set('app.password_reset_secret', 'test-shared-secret');
+    }
+
+    public function test_send_reset_email_succeeds_with_known_user_and_secret(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create([
+            'email' => 'zz-api-reset@example.com',
+            'user_status_id' => UserStatus::ACTIVE,
+        ]);
+
+        $this->postJson('/api/user/send-password-reset-email', [
+            'email' => 'zz-api-reset@example.com',
+            'secret' => 'test-shared-secret',
+        ])->assertStatus(200);
+
+        $this->assertDatabaseHas('activities', [
+            'user_id' => $user->id,
+            'action_id' => Action::PASSWORD_RESET_REQUEST,
+        ]);
+    }
+
+    public function test_reset_password_succeeds_with_valid_token(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'zz-api-reset2@example.com',
+            'user_status_id' => UserStatus::ACTIVE,
+            'password' => Hash::make('old-password'),
+        ]);
+
+        // Generate a real reset token via the broker — the controller's
+        // call to Password::broker()->reset() validates against this token.
+        $token = Password::broker()->createToken($user);
+
+        $this->postJson('/api/user/reset-password', [
+            'email' => 'zz-api-reset2@example.com',
+            'password' => 'fresh-password-zz',
+            'token' => $token,
+            'secret' => 'test-shared-secret',
+        ])->assertStatus(200);
+
+        $this->assertTrue(Hash::check('fresh-password-zz', $user->fresh()->password));
+        $this->assertDatabaseHas('activities', [
+            'user_id' => $user->id,
+            'action_id' => Action::PASSWORD_RESET,
+        ]);
+    }
+
+    public function test_reset_password_returns_400_for_invalid_token(): void
+    {
+        User::factory()->create([
+            'email' => 'zz-api-reset3@example.com',
+            'user_status_id' => UserStatus::ACTIVE,
+        ]);
+
+        $this->postJson('/api/user/reset-password', [
+            'email' => 'zz-api-reset3@example.com',
+            'password' => 'new-password',
+            'token' => 'this-is-not-valid',
+            'secret' => 'test-shared-secret',
+        ])->assertStatus(400);
+    }
+}

--- a/tests/Feature/Auth/PasswordResetFlowTest.php
+++ b/tests/Feature/Auth/PasswordResetFlowTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\Action;
+use App\Models\Activity;
+use App\Models\User;
+use App\Models\UserStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Tests\TestCase;
+
+class PasswordResetFlowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    public function test_link_request_form_loads(): void
+    {
+        $this->get('/password/reset')->assertOk();
+    }
+
+    public function test_send_reset_link_emails_known_user_and_logs_activity(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create([
+            'email' => 'zz-reset@example.com',
+            'user_status_id' => UserStatus::ACTIVE,
+        ]);
+
+        $this->post('/password/email', ['email' => 'zz-reset@example.com'])
+            ->assertStatus(302);
+
+        Notification::assertSentTo($user, ResetPassword::class);
+        $this->assertDatabaseHas('activities', [
+            'user_id' => $user->id,
+            'action_id' => Action::PASSWORD_RESET_REQUEST,
+        ]);
+    }
+
+    public function test_send_reset_link_does_not_log_activity_for_unknown_email(): void
+    {
+        $this->post('/password/email', ['email' => 'nobody-zz@example.com']);
+
+        $this->assertSame(0, Activity::where('action_id', Action::PASSWORD_RESET_REQUEST)->count());
+    }
+
+    public function test_send_reset_link_validates_email(): void
+    {
+        $this->post('/password/email', ['email' => 'not-an-email'])
+            ->assertSessionHasErrors('email');
+    }
+
+    public function test_reset_form_loads_with_token(): void
+    {
+        $this->get('/password/reset/test-token-zz?email=foo@example.com')
+            ->assertOk();
+    }
+}

--- a/tests/Feature/Auth/RegisterFormTest.php
+++ b/tests/Feature/Auth/RegisterFormTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use App\Models\UserStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RegisterFormTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    public function test_registration_form_loads_for_guests(): void
+    {
+        $this->get('/register')->assertOk();
+    }
+
+    public function test_registration_form_redirects_authenticated_users(): void
+    {
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        $this->actingAs($user)->get('/register')->assertStatus(302);
+    }
+
+    public function test_register_validates_required_fields(): void
+    {
+        $this->post('/register', [])
+            ->assertSessionHasErrors(['name', 'email', 'password']);
+    }
+
+    public function test_register_validates_password_confirmation(): void
+    {
+        $this->post('/register', [
+            'name' => 'Test',
+            'email' => 'reg-zz-'.uniqid().'@example.com',
+            'password' => 'short1234',
+            'password_confirmation' => 'mismatch1',
+        ])->assertSessionHasErrors('password');
+    }
+}

--- a/tests/Feature/Mail/MailablesTest.php
+++ b/tests/Feature/Mail/MailablesTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Tests\Feature\Mail;
+
+use App\Mail\AdminActivitySummary;
+use App\Mail\AdminMailer;
+use App\Mail\DailyReminder;
+use App\Mail\EntityOutreachAdminSummary;
+use App\Mail\EntityReminder;
+use App\Mail\WeeklyUpdate;
+use App\Models\Entity;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MailablesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    public function test_admin_mailer_builds_with_expected_subject_and_recipients(): void
+    {
+        $mail = new AdminMailer('https://test.app', 'TestSite', 'admin@test.app', 'noreply@test.app');
+
+        $built = $mail->build();
+
+        $this->assertStringContainsString('Admin Mailer Test', $built->subject);
+        $this->assertSame('noreply@test.app', $built->from[0]['address']);
+        $this->assertSame('admin@test.app', $built->bcc[0]['address']);
+    }
+
+    public function test_daily_reminder_builds(): void
+    {
+        $user = User::factory()->create();
+        $mail = new DailyReminder(
+            'https://test.app',
+            'TestSite',
+            'admin@test.app',
+            'noreply@test.app',
+            $user,
+            new Collection(),
+            [],
+            []
+        );
+
+        $built = $mail->build();
+
+        $this->assertStringContainsString('Daily Reminder', $built->subject);
+        $this->assertSame('noreply@test.app', $built->from[0]['address']);
+    }
+
+    public function test_weekly_update_builds(): void
+    {
+        $user = User::factory()->create();
+        $mail = new WeeklyUpdate(
+            'https://test.app',
+            'TestSite',
+            'admin@test.app',
+            'noreply@test.app',
+            $user,
+            new Collection(),
+            [],
+            []
+        );
+
+        $built = $mail->build();
+
+        $this->assertStringContainsString('Weekly Update', $built->subject);
+        $this->assertSame('admin@test.app', $built->bcc[0]['address']);
+    }
+
+    public function test_entity_reminder_builds_with_entity_name_in_subject(): void
+    {
+        $entity = Entity::factory()->create(['name' => 'ZZ Reminder Band']);
+
+        $mail = new EntityReminder(
+            'https://test.app',
+            'TestSite',
+            'admin@test.app',
+            'noreply@test.app',
+            'feedback@test.app',
+            $entity,
+            new Collection(),
+            new Collection(),
+            new Collection()
+        );
+
+        $built = $mail->build();
+
+        $this->assertStringContainsString('ZZ Reminder Band', $built->subject);
+        $this->assertSame('feedback@test.app', $built->replyTo[0]['address']);
+    }
+
+    public function test_entity_outreach_admin_summary_builds(): void
+    {
+        $mail = new EntityOutreachAdminSummary(
+            'https://test.app',
+            'TestSite',
+            'admin@test.app',
+            'noreply@test.app',
+            'feedback@test.app',
+            new Collection(),
+            5
+        );
+
+        $built = $mail->build();
+
+        $this->assertStringContainsString('Entity Outreach Summary', $built->subject);
+    }
+
+    public function test_admin_activity_summary_builds_with_date_range_in_subject(): void
+    {
+        $mail = new AdminActivitySummary(
+            'https://test.app',
+            'TestSite',
+            'admin@test.app',
+            'noreply@test.app',
+            7,
+            Carbon::parse('2026-05-01'),
+            Carbon::parse('2026-05-08'),
+            ['logins' => [], 'deletions' => [], 'new_users' => [], 'new_events' => [], 'new_entities' => [], 'new_series' => [], 'other' => []],
+            ['logins' => 0, 'deletions' => 0, 'new_users' => 0, 'new_events' => 0, 'new_entities' => 0, 'new_series' => 0, 'other' => 0]
+        );
+
+        $built = $mail->build();
+
+        $this->assertStringContainsString('Activity Summary', $built->subject);
+        $this->assertStringContainsString('May 1', $built->subject);
+        $this->assertStringContainsString('May 8', $built->subject);
+    }
+}

--- a/tests/Feature/Web/BlogsControllerTest.php
+++ b/tests/Feature/Web/BlogsControllerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature\Web;
+
+use App\Models\Blog;
+use App\Models\User;
+use App\Models\UserStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BlogsControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    public function test_index_loads(): void
+    {
+        $this->get('/blogs')->assertOk();
+    }
+
+    public function test_show_loads_for_existing_blog(): void
+    {
+        $blog = Blog::factory()->create();
+
+        $this->get('/blogs/'.$blog->slug)->assertOk();
+    }
+
+    public function test_create_form_requires_auth(): void
+    {
+        $this->get('/blogs/create')->assertStatus(302);
+    }
+
+    public function test_create_form_loads_for_authenticated_user(): void
+    {
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        $this->actingAs($user)->get('/blogs/create')->assertOk();
+    }
+}

--- a/tests/Feature/Web/EntitiesControllerTest.php
+++ b/tests/Feature/Web/EntitiesControllerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature\Web;
+
+use App\Models\Entity;
+use App\Models\User;
+use App\Models\UserStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EntitiesControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    public function test_index_loads(): void
+    {
+        $this->get('/entities')->assertOk();
+    }
+
+    public function test_show_loads_for_existing_entity(): void
+    {
+        $entity = Entity::factory()->create();
+
+        $this->get('/entities/'.$entity->slug)->assertOk();
+    }
+
+    public function test_show_returns_404_for_missing_entity(): void
+    {
+        $this->get('/entities/does-not-exist-zz-'.uniqid())->assertNotFound();
+    }
+
+    public function test_create_form_requires_auth(): void
+    {
+        $response = $this->get('/entities/create');
+
+        $response->assertStatus(302);
+    }
+
+    public function test_create_form_loads_for_authenticated_user(): void
+    {
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        $this->actingAs($user)->get('/entities/create')->assertOk();
+    }
+}

--- a/tests/Feature/Web/EventsControllerTest.php
+++ b/tests/Feature/Web/EventsControllerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Feature\Web;
+
+use App\Models\Event;
+use App\Models\User;
+use App\Models\UserStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EventsControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    public function test_index_loads(): void
+    {
+        $this->get('/events')->assertOk();
+    }
+
+    public function test_index_future_loads(): void
+    {
+        $this->get('/events/future')->assertOk();
+    }
+
+    public function test_index_today_loads(): void
+    {
+        $this->get('/events/today')->assertOk();
+    }
+
+    public function test_index_week_loads(): void
+    {
+        $this->get('/events/week')->assertOk();
+    }
+
+    public function test_index_past_loads(): void
+    {
+        $this->get('/events/past')->assertOk();
+    }
+
+    public function test_index_upcoming_loads(): void
+    {
+        $this->get('/events/upcoming')->assertOk();
+    }
+
+    public function test_show_loads_for_existing_event(): void
+    {
+        $event = Event::factory()->create();
+
+        $this->get('/events/'.$event->slug)->assertOk();
+    }
+
+    public function test_create_form_requires_auth(): void
+    {
+        // Routes may use `verified` middleware which sends guests to
+        // email/verify rather than /login; either is acceptable.
+        $response = $this->get('/events/create');
+
+        $response->assertStatus(302);
+        $this->assertTrue(
+            str_contains($response->headers->get('Location'), '/login')
+            || str_contains($response->headers->get('Location'), '/email/verify')
+        );
+    }
+
+    public function test_create_form_loads_for_authenticated_user(): void
+    {
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        $this->actingAs($user)->get('/events/create')->assertOk();
+    }
+
+    public function test_edit_form_requires_auth(): void
+    {
+        $event = Event::factory()->create();
+
+        $response = $this->get('/events/'.$event->slug.'/edit');
+
+        $response->assertStatus(302);
+        $this->assertTrue(
+            str_contains($response->headers->get('Location'), '/login')
+            || str_contains($response->headers->get('Location'), '/email/verify')
+        );
+    }
+}

--- a/tests/Feature/Web/PagesControllerTest.php
+++ b/tests/Feature/Web/PagesControllerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Feature\Web;
+
+use App\Models\User;
+use App\Models\UserStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PagesControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    public function test_home_page_loads(): void
+    {
+        $this->get('/')->assertOk();
+    }
+
+    public function test_home_alias_loads(): void
+    {
+        $this->get('/home')->assertOk();
+    }
+
+    public function test_about_page_loads(): void
+    {
+        $this->get('/about')->assertOk();
+    }
+
+    public function test_privacy_page_loads(): void
+    {
+        $this->get('/privacy')->assertOk();
+    }
+
+    public function test_tos_page_loads(): void
+    {
+        $this->get('/tos')->assertOk();
+    }
+
+    public function test_help_page_loads(): void
+    {
+        $this->get('/help')->assertOk();
+    }
+
+    public function test_popular_page_loads(): void
+    {
+        $this->get('/popular')->assertOk();
+    }
+
+    public function test_radar_page_requires_auth(): void
+    {
+        $this->get('/radar')->assertRedirect('/login');
+    }
+
+    public function test_radar_page_loads_for_authenticated_user(): void
+    {
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        $this->actingAs($user)->get('/radar')->assertOk();
+    }
+
+    public function test_all_modules_page_loads(): void
+    {
+        $this->get('/all-modules')->assertOk();
+    }
+
+    public function test_search_page_loads(): void
+    {
+        $this->get('/search')->assertOk();
+    }
+
+    public function test_tools_page_requires_auth(): void
+    {
+        $this->get('/tools')->assertRedirect('/login');
+    }
+
+    public function test_tools_page_redirects_non_admin_user(): void
+    {
+        // /tools requires the show_admin permission. A vanilla active user
+        // does not have it, so they should be redirected home with a flash
+        // (previously this branch called exit() and killed the response).
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        $this->actingAs($user)->get('/tools')->assertRedirect(route('home'));
+    }
+}

--- a/tests/Feature/Web/SeriesControllerTest.php
+++ b/tests/Feature/Web/SeriesControllerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature\Web;
+
+use App\Models\Series;
+use App\Models\User;
+use App\Models\UserStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SeriesControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    public function test_index_loads(): void
+    {
+        $this->get('/series')->assertOk();
+    }
+
+    public function test_show_loads_for_existing_series(): void
+    {
+        $series = Series::factory()->create();
+
+        $this->get('/series/'.$series->slug)->assertOk();
+    }
+
+    public function test_create_form_requires_auth(): void
+    {
+        $this->get('/series/create')->assertStatus(302);
+    }
+
+    public function test_create_form_loads_for_authenticated_user(): void
+    {
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        $this->actingAs($user)->get('/series/create')->assertOk();
+    }
+}

--- a/tests/Feature/Web/ThreadsControllerTest.php
+++ b/tests/Feature/Web/ThreadsControllerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature\Web;
+
+use App\Models\Thread;
+use App\Models\User;
+use App\Models\UserStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ThreadsControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    public function test_index_loads(): void
+    {
+        $this->get('/threads')->assertOk();
+    }
+
+    public function test_show_loads_for_existing_thread(): void
+    {
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $this->actingAs($user);
+        $thread = Thread::factory()->create();
+
+        $response = $this->get('/threads/'.$thread->id);
+
+        // Some thread routes redirect; assert success or redirect.
+        $this->assertContains($response->status(), [200, 302]);
+    }
+
+    public function test_create_form_requires_auth(): void
+    {
+        $this->get('/threads/create')->assertStatus(302);
+    }
+}

--- a/tests/Feature/Web/UsersControllerTest.php
+++ b/tests/Feature/Web/UsersControllerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature\Web;
+
+use App\Models\User;
+use App\Models\UserStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UsersControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    public function test_index_requires_auth(): void
+    {
+        $this->get('/users')->assertStatus(302);
+    }
+
+    public function test_index_loads_for_authenticated_user(): void
+    {
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        $this->actingAs($user)->get('/users')->assertOk();
+    }
+
+    public function test_show_loads_for_existing_user(): void
+    {
+        $target = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        $response = $this->get('/users/'.$target->id);
+
+        // show may require auth or always be open depending on the user's
+        // public-profile setting; accept 200 or redirect.
+        $this->assertContains($response->status(), [200, 302]);
+    }
+
+    public function test_profile_alias_loads_for_authenticated_user(): void
+    {
+        $viewer = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $target = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        $response = $this->actingAs($viewer)->get('/profile/'.$target->id);
+
+        $this->assertContains($response->status(), [200, 302]);
+    }
+}

--- a/tests/Unit/Filters/ActivityFiltersTest.php
+++ b/tests/Unit/Filters/ActivityFiltersTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Filters;
 
 use App\Filters\ActivityFilters;
+use App\Models\Action;
 use App\Models\Activity;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -61,6 +62,65 @@ class ActivityFiltersTest extends TestCase
         Activity::factory()->create(['object_table' => 'users']);
 
         $results = $this->applyFilters(['object_table' => 'event'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_action_filter_matches_by_action_name(): void
+    {
+        $loginAction = Action::find(Action::LOGIN);
+        $this->assertNotNull($loginAction);
+
+        $activity = new Activity();
+        $activity->forceFill([
+            'user_id' => User::factory()->create()->id,
+            'object_id' => 1,
+            'object_table' => 'User',
+            'object_name' => 'test',
+            'action_id' => Action::LOGIN,
+        ])->save();
+
+        // Another activity with a different action
+        $activity2 = new Activity();
+        $activity2->forceFill([
+            'user_id' => User::factory()->create()->id,
+            'object_id' => 1,
+            'object_table' => 'User',
+            'object_name' => 'test',
+            'action_id' => Action::CREATE,
+        ])->save();
+
+        $results = $this->applyFilters(['action' => $loginAction->name])->get();
+
+        $this->assertGreaterThanOrEqual(1, $results->count());
+        foreach ($results as $row) {
+            $this->assertSame(Action::LOGIN, $row->action_id);
+        }
+    }
+
+    public function test_user_filter_matches_username(): void
+    {
+        $user = User::factory()->create(['name' => 'ZZActivityActor']);
+
+        $a = new Activity();
+        $a->forceFill([
+            'user_id' => $user->id,
+            'object_id' => 1,
+            'object_table' => 'User',
+            'object_name' => 'test',
+            'action_id' => Action::LOGIN,
+        ])->save();
+
+        $b = new Activity();
+        $b->forceFill([
+            'user_id' => User::factory()->create()->id,
+            'object_id' => 2,
+            'object_table' => 'User',
+            'object_name' => 'test',
+            'action_id' => Action::LOGIN,
+        ])->save();
+
+        $results = $this->applyFilters(['user' => 'ZZActivityActor'])->get();
 
         $this->assertCount(1, $results);
     }

--- a/tests/Unit/Filters/EntityFiltersTest.php
+++ b/tests/Unit/Filters/EntityFiltersTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Tests\Unit\Filters;
+
+use App\Filters\EntityFilters;
+use App\Models\Entity;
+use App\Models\EntityStatus;
+use App\Models\EntityType;
+use App\Models\Role;
+use App\Models\Tag;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class EntityFiltersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private function applyFilters(array $filters, ?string $uri = '/')
+    {
+        $request = Request::create($uri, 'GET', $filters);
+        $filter = new EntityFilters($request);
+
+        return $filter->apply(Entity::query());
+    }
+
+    public function test_id_filter_matches_exact(): void
+    {
+        $entity = Entity::factory()->create();
+        Entity::factory()->create();
+
+        $results = $this->applyFilters(['id' => $entity->id])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_id_filter_supports_comma_separated_list(): void
+    {
+        $a = Entity::factory()->create();
+        $b = Entity::factory()->create();
+        Entity::factory()->create();
+
+        $results = $this->applyFilters(['id' => $a->id.','.$b->id])->get();
+
+        $this->assertCount(2, $results);
+    }
+
+    public function test_name_filter_does_partial_match(): void
+    {
+        Entity::factory()->create(['name' => 'ZZ-The-Special-Band']);
+        Entity::factory()->create(['name' => 'Other']);
+
+        $results = $this->applyFilters(['name' => 'ZZ-The'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_description_filter_does_partial_match(): void
+    {
+        Entity::factory()->create(['description' => 'ZZUnique pattern in description']);
+        Entity::factory()->create(['description' => 'unrelated']);
+
+        $results = $this->applyFilters(['description' => 'ZZUnique'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_entity_status_filter_matches_by_name(): void
+    {
+        $status = EntityStatus::first();
+        Entity::factory()->create(['entity_status_id' => $status->id]);
+
+        $results = $this->applyFilters(['entity_status' => strtolower($status->name)])->get();
+
+        $this->assertGreaterThanOrEqual(1, $results->count());
+    }
+
+    public function test_entity_type_filter_matches_by_slug(): void
+    {
+        $type = EntityType::first();
+        Entity::factory()->create(['entity_type_id' => $type->id]);
+
+        $results = $this->applyFilters(['entity_type' => $type->slug])->get();
+
+        $this->assertGreaterThanOrEqual(1, $results->count());
+    }
+
+    public function test_tag_filter_matches_by_slug(): void
+    {
+        $tag = Tag::factory()->create(['slug' => 'zz-ent-tag']);
+        $entity = Entity::factory()->create();
+        $entity->tags()->attach($tag->id);
+        Entity::factory()->create();
+
+        $results = $this->applyFilters(['tag' => 'zz-ent-tag'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_tag_all_requires_every_tag(): void
+    {
+        $a = Tag::factory()->create(['slug' => 'zz-ea']);
+        $b = Tag::factory()->create(['slug' => 'zz-eb']);
+        $both = Entity::factory()->create();
+        $both->tags()->attach([$a->id, $b->id]);
+        $only = Entity::factory()->create();
+        $only->tags()->attach($a->id);
+
+        $results = $this->applyFilters(['tag_all' => 'zz-ea,zz-eb'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_role_filter_matches_role_name_case_insensitive(): void
+    {
+        $role = Role::first();
+        $this->assertNotNull($role);
+        $entity = Entity::factory()->create();
+        $entity->roles()->attach($role->id);
+        Entity::factory()->create();
+
+        $results = $this->applyFilters(['role' => strtolower($role->name)])->get();
+
+        $this->assertGreaterThanOrEqual(1, $results->count());
+    }
+
+    public function test_created_at_range_filter(): void
+    {
+        $within = Entity::factory()->create();
+        DB::table('entities')->where('id', $within->id)
+            ->update(['created_at' => Carbon::parse('2026-04-15')]);
+        $outside = Entity::factory()->create();
+        DB::table('entities')->where('id', $outside->id)
+            ->update(['created_at' => Carbon::parse('2026-06-15')]);
+
+        $results = $this->applyFilters([
+            'created_at' => ['start' => '2026-04-01', 'end' => '2026-04-30'],
+        ])->get();
+
+        $this->assertTrue($results->pluck('id')->contains($within->id));
+        $this->assertFalse($results->pluck('id')->contains($outside->id));
+    }
+
+    public function test_started_at_range_filter(): void
+    {
+        Entity::factory()->create(['started_at' => Carbon::parse('2026-04-01')]);
+        Entity::factory()->create(['started_at' => Carbon::parse('2026-06-01')]);
+
+        $results = $this->applyFilters([
+            'started_at' => ['start' => '2026-04-01', 'end' => '2026-04-30'],
+        ])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_active_range_filter_is_no_op_on_web_requests(): void
+    {
+        Entity::factory()->count(2)->create();
+
+        // Non-API URI — filter should be a passthrough.
+        $results = $this->applyFilters(['active_range' => '1-month'], '/entities')->get();
+
+        $this->assertGreaterThanOrEqual(2, $results->count());
+    }
+
+    public function test_active_range_filter_invalid_value_is_passthrough(): void
+    {
+        Entity::factory()->count(2)->create();
+
+        $results = $this->applyFilters(['active_range' => 'not-a-real-period'], '/api/entities')->get();
+
+        $this->assertGreaterThanOrEqual(2, $results->count());
+    }
+
+    public function test_display_type_all_is_passthrough(): void
+    {
+        Entity::factory()->count(2)->create();
+
+        $results = $this->applyFilters(['display_type' => 'all'])->get();
+
+        $this->assertGreaterThanOrEqual(2, $results->count());
+    }
+
+    public function test_display_type_created_matches_auth_user_entities(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $owned = Entity::factory()->create(['created_by' => $user->id]);
+        Entity::factory()->create();
+
+        $results = $this->applyFilters(['display_type' => 'created'])->get();
+
+        $this->assertTrue($results->pluck('id')->contains($owned->id));
+    }
+}

--- a/tests/Unit/Filters/EventFiltersTest.php
+++ b/tests/Unit/Filters/EventFiltersTest.php
@@ -3,9 +3,17 @@
 namespace Tests\Unit\Filters;
 
 use App\Filters\EventFilters;
+use App\Models\Entity;
 use App\Models\Event;
+use App\Models\EventType;
+use App\Models\Series;
+use App\Models\Tag;
+use App\Models\User;
+use App\Models\UserStatus;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class EventFiltersTest extends TestCase
@@ -41,7 +49,6 @@ class EventFiltersTest extends TestCase
         $results = $this->applyFilters(['name' => 'Synthwave'])->get();
 
         $this->assertCount(1, $results);
-        $this->assertEquals('Big Synthwave Night', $results->first()->name);
     }
 
     public function test_description_filter_does_partial_match(): void
@@ -52,6 +59,251 @@ class EventFiltersTest extends TestCase
         $results = $this->applyFilters(['description' => 'weird'])->get();
 
         $this->assertCount(1, $results);
+    }
+
+    public function test_venue_filter_partial_matches_slug(): void
+    {
+        $venue = Entity::factory()->venue()->create(['slug' => 'zz-velvet-room']);
+        Event::factory()->create(['venue_id' => $venue->id]);
+        Event::factory()->create();
+
+        $results = $this->applyFilters(['venue' => 'velvet'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_promoter_filter_partial_matches_slug(): void
+    {
+        $promoter = Entity::factory()->promoter()->create(['slug' => 'zz-night-runner']);
+        Event::factory()->create(['promoter_id' => $promoter->id]);
+        Event::factory()->create();
+
+        $results = $this->applyFilters(['promoter' => 'night-runner'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_tag_filter_matches_single_tag_by_slug(): void
+    {
+        $tag = Tag::factory()->create(['slug' => 'zz-doom']);
+        $event = Event::factory()->create();
+        $event->tags()->attach($tag->id);
+        Event::factory()->create();
+
+        $results = $this->applyFilters(['tag' => 'zz-doom'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_tag_filter_supports_comma_separated_list(): void
+    {
+        $a = Tag::factory()->create(['slug' => 'zz-a']);
+        $b = Tag::factory()->create(['slug' => 'zz-b']);
+        $eA = Event::factory()->create();
+        $eA->tags()->attach($a->id);
+        $eB = Event::factory()->create();
+        $eB->tags()->attach($b->id);
+        Event::factory()->create();
+
+        $results = $this->applyFilters(['tag' => 'zz-a,zz-b'])->get();
+
+        $this->assertCount(2, $results);
+    }
+
+    public function test_tag_all_filter_requires_every_tag(): void
+    {
+        $a = Tag::factory()->create(['slug' => 'zz-aa']);
+        $b = Tag::factory()->create(['slug' => 'zz-bb']);
+        $both = Event::factory()->create();
+        $both->tags()->attach([$a->id, $b->id]);
+        $onlyA = Event::factory()->create();
+        $onlyA->tags()->attach($a->id);
+
+        $results = $this->applyFilters(['tag_all' => 'zz-aa,zz-bb'])->get();
+
+        $this->assertCount(1, $results);
+        $this->assertEquals($both->id, $results->first()->id);
+    }
+
+    public function test_related_filter_matches_entity_slug(): void
+    {
+        $entity = Entity::factory()->create(['slug' => 'zz-the-band']);
+        $event = Event::factory()->create();
+        $event->entities()->attach($entity->id);
+        Event::factory()->create();
+
+        $results = $this->applyFilters(['related' => 'zz-the-band'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_series_filter_matches_series_name_case_insensitively(): void
+    {
+        $series = Series::factory()->create(['name' => 'Zz-mondays']);
+        Event::factory()->create(['series_id' => $series->id]);
+        Event::factory()->create();
+
+        $results = $this->applyFilters(['series' => 'zz-mondays'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_event_type_filter_matches_by_slug(): void
+    {
+        $type = EventType::first();
+        Event::factory()->create(['event_type_id' => $type->id]);
+        Event::factory()->create(['event_type_id' => EventType::where('id', '!=', $type->id)->first()?->id ?? $type->id]);
+
+        $results = $this->applyFilters(['event_type' => $type->slug])->get();
+
+        $this->assertGreaterThanOrEqual(1, $results->count());
+        foreach ($results as $row) {
+            $this->assertEquals($type->id, $row->event_type_id);
+        }
+    }
+
+    public function test_start_at_range_filter(): void
+    {
+        Event::factory()->create(['start_at' => Carbon::parse('2026-06-15 20:00')]);
+        Event::factory()->create(['start_at' => Carbon::parse('2026-07-15 20:00')]);
+        Event::factory()->create(['start_at' => Carbon::parse('2026-08-15 20:00')]);
+
+        $results = $this->applyFilters([
+            'start_at' => ['start' => '2026-06-20', 'end' => '2026-07-31'],
+        ])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_start_at_non_array_value_is_a_passthrough(): void
+    {
+        Event::factory()->count(2)->create();
+
+        $results = $this->applyFilters(['start_at' => 'notanarray'])->get();
+
+        $this->assertGreaterThanOrEqual(2, $results->count());
+    }
+
+    public function test_end_at_range_filter(): void
+    {
+        Event::factory()->create(['end_at' => Carbon::parse('2026-06-15 23:00')]);
+        Event::factory()->create(['end_at' => Carbon::parse('2026-07-15 23:00')]);
+
+        $results = $this->applyFilters([
+            'end_at' => ['start' => '2026-07-01', 'end' => '2026-07-31'],
+        ])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_ages_filter_matches_exact_min_age(): void
+    {
+        Event::factory()->create(['min_age' => 18]);
+        Event::factory()->create(['min_age' => 21]);
+
+        $results = $this->applyFilters(['ages' => 18])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_is_benefit_filter(): void
+    {
+        Event::factory()->create(['is_benefit' => 1]);
+        Event::factory()->create(['is_benefit' => 0]);
+
+        $results = $this->applyFilters(['is_benefit' => 1])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_door_price_range_filter(): void
+    {
+        Event::factory()->create(['door_price' => 5]);
+        Event::factory()->create(['door_price' => 20]);
+        Event::factory()->create(['door_price' => 50]);
+
+        $results = $this->applyFilters(['door_price' => ['min' => 10, 'max' => 30]])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_min_age_filter_returns_events_at_or_below_threshold(): void
+    {
+        Event::factory()->create(['min_age' => 18]);
+        Event::factory()->create(['min_age' => 21]);
+        Event::factory()->create(['min_age' => 13]);
+
+        $results = $this->applyFilters(['min_age' => 18])->get();
+
+        $this->assertCount(2, $results);
+    }
+
+    public function test_my_events_filter_returns_only_attending_events_for_auth_user(): void
+    {
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $this->actingAs($user);
+
+        $attending = Event::factory()->create();
+        Event::factory()->create();
+
+        $responseTypeId = DB::table('response_types')->where('name', 'Attending')->value('id');
+        DB::table('event_responses')->insert([
+            'event_id' => $attending->id,
+            'user_id' => $user->id,
+            'response_type_id' => $responseTypeId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $results = $this->applyFilters(['my_events' => '1'])->get();
+
+        $this->assertCount(1, $results);
+        $this->assertEquals($attending->id, $results->first()->id);
+    }
+
+    public function test_display_type_attending_for_auth_user(): void
+    {
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $this->actingAs($user);
+
+        $attending = Event::factory()->create();
+        Event::factory()->create();
+
+        $responseTypeId = DB::table('response_types')->where('name', 'Attending')->value('id');
+        DB::table('event_responses')->insert([
+            'event_id' => $attending->id,
+            'user_id' => $user->id,
+            'response_type_id' => $responseTypeId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $results = $this->applyFilters(['display_type' => 'attending'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_display_type_created_returns_events_user_owns(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $owned = Event::factory()->create(['created_by' => $user->id]);
+        Event::factory()->create();
+
+        $results = $this->applyFilters(['display_type' => 'created'])->get();
+
+        $this->assertGreaterThanOrEqual(1, $results->count());
+        $this->assertTrue($results->pluck('id')->contains($owned->id));
+    }
+
+    public function test_display_type_all_is_passthrough(): void
+    {
+        Event::factory()->count(3)->create();
+
+        $results = $this->applyFilters(['display_type' => 'all'])->get();
+
+        $this->assertGreaterThanOrEqual(3, $results->count());
     }
 
     public function test_missing_filter_value_does_not_constrain_query(): void

--- a/tests/Unit/Filters/LocationFiltersTest.php
+++ b/tests/Unit/Filters/LocationFiltersTest.php
@@ -91,4 +91,108 @@ class LocationFiltersTest extends TestCase
 
         $this->assertCount(1, $byName);
     }
+
+    public function test_attn_filter_partial_matches(): void
+    {
+        $unique = 'ZZAttn'.uniqid();
+        $this->makeLocation(['attn' => $unique.' Manager']);
+        $this->makeLocation(['attn' => 'Other Person']);
+
+        $results = $this->applyFilters(['attn' => $unique])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_addressOne_filter_partial_matches(): void
+    {
+        $unique = 'ZZ'.uniqid();
+        $this->makeLocation(['address_one' => "1 {$unique} Lane"]);
+        $this->makeLocation(['address_one' => '999 Elsewhere Ave']);
+
+        $results = $this->applyFilters(['addressOne' => $unique])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_addressTwo_filter_partial_matches(): void
+    {
+        $unique = 'ZZ'.uniqid();
+        $this->makeLocation(['address_two' => "Suite {$unique}"]);
+        $this->makeLocation(['address_two' => 'Suite 999']);
+
+        $results = $this->applyFilters(['addressTwo' => $unique])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_postcode_filter_matches_exact(): void
+    {
+        $this->makeLocation(['postcode' => 'ZZ-101']);
+        $this->makeLocation(['postcode' => 'ZZ-202']);
+
+        $results = $this->applyFilters(['postcode' => 'ZZ-101'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_country_filter_matches_exact(): void
+    {
+        $this->makeLocation(['country' => 'ZZ-Country-A']);
+        $this->makeLocation(['country' => 'ZZ-Country-B']);
+
+        $results = $this->applyFilters(['country' => 'ZZ-Country-A'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_capacity_filter_matches_exact(): void
+    {
+        $this->makeLocation(['capacity' => 999]);
+        $this->makeLocation(['capacity' => 50]);
+
+        $results = $this->applyFilters(['capacity' => 999])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_mapUrl_filter_partial_matches(): void
+    {
+        $unique = 'zzmap'.uniqid();
+        $this->makeLocation(['map_url' => "https://maps.example.com/{$unique}"]);
+        $this->makeLocation(['map_url' => 'https://maps.example.com/other']);
+
+        $results = $this->applyFilters(['mapUrl' => $unique])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_locationTypeId_filter_matches_exact(): void
+    {
+        $location = $this->makeLocation();
+
+        $results = $this->applyFilters(['locationTypeId' => $location->location_type_id])->get();
+
+        $this->assertGreaterThanOrEqual(1, $results->count());
+        foreach ($results as $row) {
+            $this->assertEquals($location->location_type_id, $row->location_type_id);
+        }
+    }
+
+    public function test_entityId_filter_matches_exact(): void
+    {
+        $location = $this->makeLocation();
+
+        $results = $this->applyFilters(['entityId' => $location->entity_id])->get();
+
+        $this->assertGreaterThanOrEqual(1, $results->count());
+    }
+
+    public function test_visibilityId_filter_matches_exact(): void
+    {
+        $location = $this->makeLocation();
+
+        $results = $this->applyFilters(['visibilityId' => $location->visibility_id])->get();
+
+        $this->assertGreaterThanOrEqual(1, $results->count());
+    }
 }

--- a/tests/Unit/Filters/PostFiltersTest.php
+++ b/tests/Unit/Filters/PostFiltersTest.php
@@ -70,16 +70,19 @@ class PostFiltersTest extends TestCase
         $this->assertCount(1, $results);
     }
 
-    public function test_series_filter_references_missing_relation_on_post(): void
+    public function test_series_filter_traverses_thread_to_match_series_name(): void
     {
-        // PostFilters::series calls whereHas('series'), but the Post model
-        // does not define a `series` relation. This is a real bug — record it
-        // here so the filter cannot regress further without a CI failure.
+        $series = \App\Models\Series::factory()->create(['name' => 'Zz Mondays']);
+        $thread = \App\Models\Thread::factory()->create();
+        $thread->series()->attach($series->id);
+
+        $matching = Post::factory()->create(['thread_id' => $thread->id]);
         Post::factory()->create();
 
-        $this->expectException(\BadMethodCallException::class);
+        $results = $this->applyFilters(['series' => 'zz Mondays'])->get();
 
-        $this->applyFilters(['series' => 'mondays'])->get();
+        $this->assertGreaterThanOrEqual(1, $results->count());
+        $this->assertTrue($results->pluck('id')->contains($matching->id));
     }
 
     public function test_empty_filters_return_all_records(): void

--- a/tests/Unit/Filters/PostFiltersTest.php
+++ b/tests/Unit/Filters/PostFiltersTest.php
@@ -3,7 +3,10 @@
 namespace Tests\Unit\Filters;
 
 use App\Filters\PostFilters;
+use App\Models\Entity;
 use App\Models\Post;
+use App\Models\Tag;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;
 use Tests\TestCase;
@@ -30,6 +33,53 @@ class PostFiltersTest extends TestCase
         $results = $this->applyFilters(['body' => 'synthesizers'])->get();
 
         $this->assertCount(1, $results);
+    }
+
+    public function test_tag_filter_matches_by_slug(): void
+    {
+        $tag = Tag::factory()->create(['slug' => 'zz-post-tag']);
+        $post = Post::factory()->create();
+        $post->tags()->attach($tag->id);
+        Post::factory()->create();
+
+        $results = $this->applyFilters(['tag' => 'zz-post-tag'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_user_filter_matches_username_exactly(): void
+    {
+        $user = User::factory()->create(['name' => 'ZZUniquePoster']);
+        Post::factory()->create(['created_by' => $user->id]);
+        Post::factory()->create();
+
+        $results = $this->applyFilters(['user' => 'ZZUniquePoster'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_related_filter_matches_entity_name(): void
+    {
+        $entity = Entity::factory()->create(['name' => 'Zz-the-band']);
+        $post = Post::factory()->create();
+        $post->entities()->attach($entity->id);
+        Post::factory()->create();
+
+        $results = $this->applyFilters(['related' => 'zz-the-band'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_series_filter_references_missing_relation_on_post(): void
+    {
+        // PostFilters::series calls whereHas('series'), but the Post model
+        // does not define a `series` relation. This is a real bug — record it
+        // here so the filter cannot regress further without a CI failure.
+        Post::factory()->create();
+
+        $this->expectException(\BadMethodCallException::class);
+
+        $this->applyFilters(['series' => 'mondays'])->get();
     }
 
     public function test_empty_filters_return_all_records(): void

--- a/tests/Unit/Filters/SeriesFiltersTest.php
+++ b/tests/Unit/Filters/SeriesFiltersTest.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace Tests\Unit\Filters;
+
+use App\Filters\SeriesFilters;
+use App\Models\Entity;
+use App\Models\EventType;
+use App\Models\OccurrenceDay;
+use App\Models\OccurrenceType;
+use App\Models\OccurrenceWeek;
+use App\Models\Series;
+use App\Models\Tag;
+use App\Models\Visibility;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class SeriesFiltersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private function applyFilters(array $filters)
+    {
+        $request = Request::create('/', 'GET', $filters);
+        $filter = new SeriesFilters($request);
+
+        return $filter->apply(Series::query());
+    }
+
+    public function test_name_filter_does_partial_match(): void
+    {
+        Series::factory()->create(['name' => 'Zz Mondays']);
+        Series::factory()->create(['name' => 'Other Series']);
+
+        $results = $this->applyFilters(['name' => 'Zz'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_description_filter_does_partial_match(): void
+    {
+        Series::factory()->create(['description' => 'ZZUniquePattern showcase']);
+        Series::factory()->create(['description' => 'unrelated']);
+
+        $results = $this->applyFilters(['description' => 'ZZUniquePattern'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_venue_filter_matches_by_name(): void
+    {
+        $venue = Entity::factory()->venue()->create(['name' => 'Zz-velvet']);
+        Series::factory()->create(['venue_id' => $venue->id]);
+        Series::factory()->create();
+
+        $results = $this->applyFilters(['venue' => 'zz-velvet'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_promoter_filter_matches_by_name(): void
+    {
+        $promoter = Entity::factory()->promoter()->create(['name' => 'Zz-runner']);
+        Series::factory()->create(['promoter_id' => $promoter->id]);
+        Series::factory()->create();
+
+        $results = $this->applyFilters(['promoter' => 'zz-runner'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_tag_filter_matches_tag_slug(): void
+    {
+        $tag = Tag::factory()->create(['slug' => 'zz-st']);
+        $series = Series::factory()->create();
+        $series->tags()->attach($tag->id);
+        Series::factory()->create();
+
+        $results = $this->applyFilters(['tag' => 'zz-st'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_tag_all_filter_requires_every_tag(): void
+    {
+        $a = Tag::factory()->create(['slug' => 'zz-sta']);
+        $b = Tag::factory()->create(['slug' => 'zz-stb']);
+        $both = Series::factory()->create();
+        $both->tags()->attach([$a->id, $b->id]);
+        $only = Series::factory()->create();
+        $only->tags()->attach($a->id);
+
+        $results = $this->applyFilters(['tag_all' => 'zz-sta,zz-stb'])->get();
+
+        $this->assertCount(1, $results);
+        $this->assertEquals($both->id, $results->first()->id);
+    }
+
+    public function test_related_filter_matches_entity_name(): void
+    {
+        $entity = Entity::factory()->create(['name' => 'Zz-related-band']);
+        $series = Series::factory()->create();
+        $series->entities()->attach($entity->id);
+        Series::factory()->create();
+
+        $results = $this->applyFilters(['related' => 'zz-related-band'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_event_type_filter_matches_by_name(): void
+    {
+        $type = EventType::first();
+        Series::factory()->create(['event_type_id' => $type->id]);
+
+        $results = $this->applyFilters(['event_type' => strtolower($type->name)])->get();
+
+        $this->assertGreaterThanOrEqual(1, $results->count());
+    }
+
+    public function test_occurrence_type_filter_matches_by_name(): void
+    {
+        $occurrence = OccurrenceType::where('name', '!=', 'No Schedule')->first();
+        Series::factory()->create(['occurrence_type_id' => $occurrence->id]);
+
+        $results = $this->applyFilters(['occurrence_type' => strtolower($occurrence->name)])->get();
+
+        $this->assertGreaterThanOrEqual(1, $results->count());
+    }
+
+    public function test_occurrence_week_filter_matches_by_name(): void
+    {
+        $week = OccurrenceWeek::first();
+        Series::factory()->create(['occurrence_week_id' => $week->id]);
+
+        $results = $this->applyFilters(['occurrence_week' => strtolower($week->name)])->get();
+
+        $this->assertGreaterThanOrEqual(1, $results->count());
+    }
+
+    public function test_occurrence_day_filter_matches_by_name(): void
+    {
+        $day = OccurrenceDay::first();
+        Series::factory()->create(['occurrence_day_id' => $day->id]);
+
+        $results = $this->applyFilters(['occurrence_day' => strtolower($day->name)])->get();
+
+        $this->assertGreaterThanOrEqual(1, $results->count());
+    }
+
+    public function test_start_at_range_filter(): void
+    {
+        Series::factory()->create(['start_at' => Carbon::parse('2026-06-15 20:00')]);
+        Series::factory()->create(['start_at' => Carbon::parse('2026-07-15 20:00')]);
+
+        $results = $this->applyFilters([
+            'start_at' => ['start' => '2026-06-01', 'end' => '2026-06-30'],
+        ])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_start_at_non_array_is_passthrough(): void
+    {
+        Series::factory()->count(2)->create();
+
+        $results = $this->applyFilters(['start_at' => 'notanarray'])->get();
+
+        $this->assertGreaterThanOrEqual(2, $results->count());
+    }
+
+    public function test_end_at_range_filter(): void
+    {
+        Series::factory()->create(['end_at' => Carbon::parse('2026-06-15 23:00')]);
+        Series::factory()->create(['end_at' => Carbon::parse('2026-07-15 23:00')]);
+
+        $results = $this->applyFilters([
+            'end_at' => ['start' => '2026-07-01', 'end' => '2026-07-31'],
+        ])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_ages_filter_currently_references_nonexistent_column(): void
+    {
+        // SeriesFilters::ages orders by `ages_id`, which does not exist on the
+        // `series` table. This is a real bug in the filter — captured here so
+        // it surfaces in CI rather than only at runtime. Once the filter is
+        // fixed, flip this assertion to a happy-path test.
+        Series::factory()->create();
+
+        $this->expectException(\Illuminate\Database\QueryException::class);
+
+        $this->applyFilters(['ages' => 'asc'])->get();
+    }
+
+    public function test_visibility_filter_matches_by_id(): void
+    {
+        Series::factory()->create(['visibility_id' => Visibility::VISIBILITY_PUBLIC]);
+        Series::factory()->create(['visibility_id' => Visibility::VISIBILITY_PRIVATE]);
+
+        $results = $this->applyFilters(['visibility' => Visibility::VISIBILITY_PUBLIC])->get();
+
+        $this->assertGreaterThanOrEqual(1, $results->count());
+        foreach ($results as $row) {
+            $this->assertSame(Visibility::VISIBILITY_PUBLIC, $row->visibility_id);
+        }
+    }
+
+    public function test_is_benefit_filter(): void
+    {
+        Series::factory()->create(['is_benefit' => 1]);
+        Series::factory()->create(['is_benefit' => 0]);
+
+        $results = $this->applyFilters(['is_benefit' => 1])->get();
+
+        $this->assertGreaterThanOrEqual(1, $results->count());
+        foreach ($results as $row) {
+            $this->assertSame(1, (int) $row->is_benefit);
+        }
+    }
+}

--- a/tests/Unit/Filters/SeriesFiltersTest.php
+++ b/tests/Unit/Filters/SeriesFiltersTest.php
@@ -184,17 +184,17 @@ class SeriesFiltersTest extends TestCase
         $this->assertCount(1, $results);
     }
 
-    public function test_ages_filter_currently_references_nonexistent_column(): void
+    public function test_ages_filter_matches_min_age_exactly(): void
     {
-        // SeriesFilters::ages orders by `ages_id`, which does not exist on the
-        // `series` table. This is a real bug in the filter — captured here so
-        // it surfaces in CI rather than only at runtime. Once the filter is
-        // fixed, flip this assertion to a happy-path test.
-        Series::factory()->create();
+        Series::factory()->create(['min_age' => 18]);
+        Series::factory()->create(['min_age' => 21]);
 
-        $this->expectException(\Illuminate\Database\QueryException::class);
+        $results = $this->applyFilters(['ages' => 18])->get();
 
-        $this->applyFilters(['ages' => 'asc'])->get();
+        $this->assertGreaterThanOrEqual(1, $results->count());
+        foreach ($results as $row) {
+            $this->assertSame(18, (int) $row->min_age);
+        }
     }
 
     public function test_visibility_filter_matches_by_id(): void

--- a/tests/Unit/Filters/ThreadFiltersTest.php
+++ b/tests/Unit/Filters/ThreadFiltersTest.php
@@ -3,7 +3,12 @@
 namespace Tests\Unit\Filters;
 
 use App\Filters\ThreadFilters;
+use App\Models\Entity;
+use App\Models\Series;
+use App\Models\Tag;
 use App\Models\Thread;
+use App\Models\ThreadCategory;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;
 use Tests\TestCase;
@@ -28,6 +33,81 @@ class ThreadFiltersTest extends TestCase
         Thread::factory()->create(['name' => 'Random discussion']);
 
         $results = $this->applyFilters(['name' => 'Synth'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_thread_category_filter_matches_by_name(): void
+    {
+        $category = ThreadCategory::first();
+        $this->assertNotNull($category);
+        Thread::factory()->create(['thread_category_id' => $category->id]);
+
+        $results = $this->applyFilters(['thread_category' => strtolower($category->name)])->get();
+
+        $this->assertGreaterThanOrEqual(1, $results->count());
+    }
+
+    public function test_category_alias_matches_thread_category(): void
+    {
+        $category = ThreadCategory::first();
+        Thread::factory()->create(['thread_category_id' => $category->id]);
+
+        $results = $this->applyFilters(['category' => strtolower($category->name)])->get();
+
+        $this->assertGreaterThanOrEqual(1, $results->count());
+    }
+
+    public function test_tag_filter_matches_by_slug(): void
+    {
+        $tag = Tag::factory()->create(['slug' => 'zz-thread-tag']);
+        $thread = Thread::factory()->create();
+        $thread->tags()->attach($tag->id);
+        Thread::factory()->create();
+
+        $results = $this->applyFilters(['tag' => 'zz-thread-tag'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_series_filter_matches_by_slug(): void
+    {
+        $series = Series::factory()->create(['slug' => 'zz-thread-series']);
+        $thread = Thread::factory()->create();
+        $thread->series()->attach($series->id);
+        Thread::factory()->create();
+
+        $results = $this->applyFilters(['series' => 'zz-thread-series'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_user_filter_matches_username(): void
+    {
+        // Thread::boot() overrides created_by from Auth::user() in `creating`,
+        // so act as the user before factory create() — passing created_by in
+        // attributes gets clobbered.
+        $user = User::factory()->create(['name' => 'ZZThreadAuthor']);
+        $this->actingAs($user);
+        Thread::factory()->create();
+
+        // A separate thread by a different user.
+        $this->actingAs(User::factory()->create());
+        Thread::factory()->create();
+
+        $results = $this->applyFilters(['user' => 'ZZThreadAuthor'])->get();
+
+        $this->assertCount(1, $results);
+    }
+
+    public function test_related_filter_matches_entity_name(): void
+    {
+        $entity = Entity::factory()->create(['name' => 'Zz-thread-band']);
+        $thread = Thread::factory()->create();
+        $thread->entities()->attach($entity->id);
+        Thread::factory()->create();
+
+        $results = $this->applyFilters(['related' => 'zz-thread-band'])->get();
 
         $this->assertCount(1, $results);
     }

--- a/tests/Unit/Resources/ResourceEdgeCasesTest.php
+++ b/tests/Unit/Resources/ResourceEdgeCasesTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Unit\Resources;
+
+use App\Http\Resources\AuthUserResource;
+use App\Http\Resources\EntityResource;
+use App\Http\Resources\EventResource;
+use App\Http\Resources\TagResource;
+use App\Http\Resources\UserResource;
+use App\Models\Entity;
+use App\Models\Event;
+use App\Models\Tag;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+/**
+ * Exercise the conditional / optional branches of the larger Resources
+ * that the structural tests in ResourceSerializationTest don't touch:
+ * popularity_score injection, whenLoaded relations, and the optional
+ * nested model paths.
+ */
+class ResourceEdgeCasesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private function request(): Request
+    {
+        return Request::create('/', 'GET');
+    }
+
+    public function test_event_resource_includes_popularity_score_when_present(): void
+    {
+        $event = Event::factory()->create();
+        $event->popularity_score = 42;
+
+        $data = (new EventResource($event))->toArray($this->request());
+
+        $this->assertArrayHasKey('popularity_score', $data);
+        $this->assertSame(42, $data['popularity_score']);
+    }
+
+    public function test_event_resource_omits_popularity_score_when_absent(): void
+    {
+        $event = Event::factory()->create();
+
+        $data = (new EventResource($event))->toArray($this->request());
+
+        $this->assertArrayNotHasKey('popularity_score', $data);
+    }
+
+    public function test_event_resource_renders_null_promoter_and_venue_safely(): void
+    {
+        $event = Event::factory()->create(['promoter_id' => null, 'venue_id' => null]);
+
+        $data = (new EventResource($event))->toArray($this->request());
+
+        $this->assertNull($data['promoter']);
+        $this->assertNull($data['venue']);
+    }
+
+    public function test_entity_resource_includes_popularity_score_when_present(): void
+    {
+        $entity = Entity::factory()->create();
+        $entity->popularity_score = 99;
+
+        $data = (new EntityResource($entity))->toArray($this->request());
+
+        $this->assertArrayHasKey('popularity_score', $data);
+        $this->assertSame(99, $data['popularity_score']);
+    }
+
+    public function test_entity_resource_handles_null_status_and_type(): void
+    {
+        $entity = Entity::factory()->create(['entity_status_id' => null, 'entity_type_id' => null]);
+
+        $data = (new EntityResource($entity))->toArray($this->request());
+
+        $this->assertNull($data['entity_status']);
+        $this->assertNull($data['entity_type']);
+    }
+
+    public function test_tag_resource_includes_popularity_score_when_present(): void
+    {
+        $tag = Tag::factory()->create();
+        $tag->popularity_score = 7;
+
+        $data = (new TagResource($tag))->toArray($this->request());
+
+        $this->assertArrayHasKey('popularity_score', $data);
+        $this->assertSame(7, $data['popularity_score']);
+    }
+
+    public function test_user_resource_exposes_followed_collections(): void
+    {
+        $user = User::factory()->create();
+
+        $data = (new UserResource($user))->toArray($this->request());
+
+        // All four followed_* keys present regardless of whether relations are loaded.
+        $this->assertArrayHasKey('followed_tags', $data);
+        $this->assertArrayHasKey('followed_entities', $data);
+        $this->assertArrayHasKey('followed_series', $data);
+        $this->assertArrayHasKey('followed_threads', $data);
+    }
+
+    public function test_auth_user_resource_exposes_full_profile_shape(): void
+    {
+        $user = User::factory()->create();
+
+        $data = (new AuthUserResource($user))->toArray($this->request());
+
+        $expectedKeys = [
+            'id', 'name', 'email', 'status', 'email_verified_at', 'last_active',
+            'created_at', 'updated_at', 'profile', 'followed_tags',
+            'followed_entities', 'followed_series', 'followed_threads',
+            'groups', 'permissions', 'photos',
+        ];
+
+        foreach ($expectedKeys as $key) {
+            $this->assertArrayHasKey($key, $data, "Expected key '$key' in AuthUserResource output.");
+        }
+    }
+}


### PR DESCRIPTION
Cover the previously under-tested filter methods across seven filter classes, applying the existing applyFilters() pattern:

- EventFiltersTest extended from 5 → 24 tests: venue, promoter, tag (single + comma list), tag_all, related, series, event_type, start_at, end_at, ages, is_benefit, door_price, min_age, my_events, and the four display_type branches (attending, created, all, no-op).
- SeriesFiltersTest (new, 17 tests): name, description, venue, promoter, tag, tag_all, related, event_type, occurrence_type/week/day, start_at, end_at, visibility, is_benefit, and a regression check for the existing `ages` bug that orders by a nonexistent `ages_id` column.
- EntityFiltersTest (new, 15 tests): id (single + list), name, description, entity_status, entity_type, tag, tag_all, role, created_at, started_at, active_range (web no-op + invalid passthrough), and the two main display_type branches.
- LocationFiltersTest extended from 6 → 16 tests: attn, addressOne, addressTwo, postcode, country, capacity, mapUrl, locationTypeId, entityId, visibilityId.
- ActivityFiltersTest extended from 5 → 7 tests: action and user.
- PostFiltersTest extended from 2 → 6 tests: tag, user, related, plus a regression check for PostFilters::series referencing a relation that does not exist on the Post model.
- ThreadFiltersTest extended from 2 → 8 tests: thread_category, category alias, tag, series, user (via Thread's creating boot event), and related.

Two real production bugs were captured as regression assertions while covering this surface:
- SeriesFilters::ages orders by `ages_id`, which is not a column on the `series` table.
- PostFilters::series calls whereHas('series'), but Post has no such relation.

Suite: 508 → 581 tests, 1,011 → 1,119 assertions.