### PR TITLE
Phase 1 search improvements: SearchService, FULLTEXT, bug fixes (#1674)

### DIFF
--- a/app/Http/Controllers/Api/SearchController.php
+++ b/app/Http/Controllers/Api/SearchController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Services\SearchService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class SearchController extends Controller
+{
+    public function __construct(private readonly SearchService $searchService)
+    {
+    }
+
+    /**
+     * Lightweight typeahead endpoint. Public — visibility scoping is applied
+     * based on the optionally-authenticated user.
+     *
+     * GET /api/search?q=keyword&types=events,entities,series,tags&limit=6
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'q'     => 'nullable|string|max:120',
+            'types' => 'nullable|string|max:120',
+            'limit' => 'nullable|integer|min:1|max:20',
+        ]);
+
+        $keyword = (string) ($validated['q'] ?? '');
+        $limit = (int) ($validated['limit'] ?? 6);
+
+        $types = null;
+        if (! empty($validated['types'])) {
+            $allowed = ['events', 'entities', 'series', 'tags'];
+            $requested = array_map('trim', explode(',', $validated['types']));
+            $types = array_values(array_intersect($allowed, $requested)) ?: null;
+        }
+
+        return response()->json($this->searchService->lite($keyword, Auth::user(), $limit, $types));
+    }
+}

--- a/app/Http/Controllers/PagesController.php
+++ b/app/Http/Controllers/PagesController.php
@@ -11,6 +11,7 @@ use App\Models\Series;
 use App\Models\Tag;
 use App\Models\Thread;
 use App\Models\User;
+use App\Services\SearchService;
 use App\Services\SessionStore\ListParameterSessionStore;
 use Carbon\Carbon;
 use Illuminate\Http\RedirectResponse;
@@ -109,96 +110,14 @@ class PagesController extends Controller
     /**
      * Primary site searchbar action.
      */
-    public function search(Request $request): View
+    public function search(Request $request, SearchService $searchService): View
     {
-        $search = $request->input('keyword');
-        $searchSlug = Str::slug($search, '-');
-
-        // override limit, while not breaking template that tries to render
+        $search = (string) $request->input('keyword', '');
         $this->limit = 20;
 
-        // find matching events by entity, tag or series or name
-        $eventQuery = Event::getByEntity(strtolower($searchSlug))
-                    ->with('visibility', 'venue','tags', 'entities','series','eventType','threads')
-                    ->orWhereHas('tags', function ($q) use ($search) {
-                        $q->where('name', '=', ucfirst($search));
-                    })
-                    ->orWhereHas('series', function ($q) use ($search) {
-                        $q->where('name', '=', ucfirst($search));
-                    })
-                    ->orWhereHas('venue', function ($q) use ($search) {
-                        $q->where('name', '=', ucfirst($search));
-                    })
-                    ->orWhereHas('promoter', function ($q) use ($search) {
-                        $q->where('name', '=', ucfirst($search));
-                    })
-                    ->orWhere('name', 'like', '%'.$search.'%')
-                    ->where(function ($query) {
-                        $query->visible($this->user);
-                    })
-                    ->orderBy('start_at', 'DESC')
-                    ->orderBy('name', 'ASC');
-        
-        $eventsCount = $eventQuery->count();
-        $events = $eventQuery->paginate($this->limit);
+        $results = $searchService->all($search, $this->user, $this->limit);
 
-        // find matching series by entity, tag or name
-        $seriesQuery = Series::getByEntity(strtolower($searchSlug))
-                    ->with('visibility', 'venue','tags', 'entities','eventType','threads','occurrenceType','occurrenceWeek','occurrenceDay')
-                    ->orWhereHas('tags', function ($q) use ($search) {
-                        $q->where('name', '=', ucfirst($search));
-                    })
-                    ->orWhere('name', 'like', '%'.$search.'%')
-                    ->where(function ($query) {
-                        $query->visible($this->user);
-                    })
-                    ->orderBy('start_at', 'DESC')
-                    ->orderBy('name', 'ASC');
-
-        $seriesCount = $seriesQuery->count();
-        $series = $seriesQuery->with('occurrenceWeek','occurrenceType','occurrenceDay')->paginate($this->limit);
-
-        // find entities by name, tags or aliases
-        $entitiesQuery = Entity::where('name', 'like', '%'.$search.'%')
-                ->with('tags', 'events','entityType','locations','entityStatus','user')
-                ->where('entity_status_id','<>',EntityStatus::UNLISTED)
-                ->orWhereHas('tags', function ($q) use ($search) {
-                    $q->where('name', '=', ucfirst($search));
-                })
-                ->orWherehas('aliases', function ($q) use ($search) {
-                    $q->where('name', '=', ucfirst($search));
-                })
-                ->orderBy('entity_type_id', 'ASC')
-                ->orderBy('name', 'ASC');
-
-        $entitiesCount = $entitiesQuery->count();
-        $entities = $entitiesQuery->paginate($this->limit);
-
-        // find tags by name
-        $tagsQuery = Tag::where('name', 'like', '%'.$search.'%')
-                ->orderBy('name', 'ASC');
-
-        $tagsCount = $tagsQuery->count();
-        $tags = $tagsQuery->simplePaginate($this->limit);
-
-        // find users by name
-        $usersQuery = User::where('name', 'like', '%'.$search.'%')
-                ->orderBy('name', 'ASC');
-
-        $usersCount = $usersQuery->count();
-        $users = $usersQuery->simplePaginate($this->limit);
-
-        // find threads by name
-        $threadsQuery = Thread::with('visibility','entities','tags','posts','event','user')->where('name', 'like', '%'.$search.'%')
-            ->orWhereHas('tags', function ($q) use ($search) {
-                $q->where('name', '=', ucfirst($search));
-            })
-            ->orderBy('name', 'ASC');
-            
-        $threadsCount = $threadsQuery->count();
-        $threads = $threadsQuery->paginate($this->limit);
-
-        return view('pages.search', compact('events', 'eventsCount', 'entities', 'entitiesCount', 'series', 'seriesCount', 'users', 'usersCount', 'threads', 'threadsCount', 'tags', 'tagsCount', 'search'));
+        return view('pages.search', array_merge($results, ['search' => $search]));
     }
 
     

--- a/app/Services/SearchService.php
+++ b/app/Services/SearchService.php
@@ -1,0 +1,269 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Entity;
+use App\Models\EntityStatus;
+use App\Models\Event;
+use App\Models\Series;
+use App\Models\Tag;
+use App\Models\Thread;
+use App\Models\User;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Contracts\Pagination\Paginator;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
+
+class SearchService
+{
+    /**
+     * Minimum keyword length for MATCH...AGAINST. Below this we fall back to LIKE
+     * because InnoDB's default ft_min_token_size is 3 (still wider than typical FULLTEXT
+     * MyISAM defaults), and BOOLEAN MODE silently ignores tokens that are too short.
+     */
+    private const FULLTEXT_MIN_LENGTH = 3;
+
+    /**
+     * Run all six section searches and return an associative array of paginators.
+     *
+     * @return array{
+     *   events: LengthAwarePaginator,
+     *   eventsCount: int,
+     *   series: LengthAwarePaginator,
+     *   seriesCount: int,
+     *   entities: LengthAwarePaginator,
+     *   entitiesCount: int,
+     *   tags: Paginator,
+     *   tagsCount: int,
+     *   users: Paginator,
+     *   usersCount: int,
+     *   threads: LengthAwarePaginator,
+     *   threadsCount: int,
+     * }
+     */
+    public function all(string $keyword, ?User $user, int $perPage = 20): array
+    {
+        $keyword = trim(preg_replace('/\s+/', ' ', $keyword) ?? '');
+        $slug = Str::slug($keyword, '-');
+
+        $events   = $this->events($keyword, $slug, $user, $perPage);
+        $series   = $this->series($keyword, $slug, $user, $perPage);
+        $entities = $this->entities($keyword, $perPage);
+        $tags     = $this->tags($keyword, $perPage);
+        $users    = $this->users($keyword, $perPage);
+        $threads  = $this->threads($keyword, $perPage);
+
+        return [
+            'events'        => $events,
+            'eventsCount'   => $events->total(),
+            'series'        => $series,
+            'seriesCount'   => $series->total(),
+            'entities'      => $entities,
+            'entitiesCount' => $entities->total(),
+            'tags'          => $tags,
+            'tagsCount'     => $this->countLike(Tag::query(), ['name'], $keyword),
+            'users'         => $users,
+            'usersCount'    => $this->countLike(User::query(), ['name'], $keyword),
+            'threads'       => $threads,
+            'threadsCount'  => $threads->total(),
+        ];
+    }
+
+    private function events(string $keyword, string $slug, ?User $user, int $perPage): LengthAwarePaginator
+    {
+        $useFulltext = $this->useFulltext($keyword);
+
+        $query = Event::query()
+            ->with('visibility', 'venue', 'tags', 'entities', 'series', 'eventType', 'threads')
+            ->where(function (Builder $q) use ($keyword, $slug, $useFulltext) {
+                // Text match on event's own columns.
+                if ($useFulltext) {
+                    $q->whereRaw(
+                        'MATCH(events.name, events.short, events.description) AGAINST (? IN BOOLEAN MODE)',
+                        [$this->booleanQuery($keyword)]
+                    );
+                } else {
+                    $q->where('events.name', 'like', '%' . $keyword . '%');
+                }
+
+                // Related-entity / tag / series matches (case-insensitive).
+                $q->orWhereHas('entities', fn ($r) => $r->where('slug', strtolower($slug)))
+                    ->orWhereHas('tags', $this->ciNameMatch($keyword))
+                    ->orWhereHas('series', $this->ciNameMatch($keyword))
+                    ->orWhereHas('venue', $this->ciNameMatch($keyword))
+                    ->orWhereHas('promoter', $this->ciNameMatch($keyword));
+            })
+            ->visible($user);
+
+        if ($useFulltext) {
+            $query->orderByRaw(
+                'MATCH(events.name, events.short, events.description) AGAINST (?) DESC',
+                [$keyword]
+            );
+        }
+        $query->orderBy('start_at', 'DESC')->orderBy('name', 'ASC');
+
+        return $query->paginate($perPage);
+    }
+
+    private function series(string $keyword, string $slug, ?User $user, int $perPage): LengthAwarePaginator
+    {
+        $useFulltext = $this->useFulltext($keyword);
+
+        $query = Series::query()
+            ->with('visibility', 'venue', 'tags', 'entities', 'eventType', 'threads', 'occurrenceType', 'occurrenceWeek', 'occurrenceDay')
+            ->where(function (Builder $q) use ($keyword, $slug, $useFulltext) {
+                if ($useFulltext) {
+                    $q->whereRaw(
+                        'MATCH(series.name, series.short, series.description) AGAINST (? IN BOOLEAN MODE)',
+                        [$this->booleanQuery($keyword)]
+                    );
+                } else {
+                    $q->where('series.name', 'like', '%' . $keyword . '%');
+                }
+
+                $q->orWhereHas('entities', fn ($r) => $r->where('slug', strtolower($slug)))
+                    ->orWhereHas('tags', $this->ciNameMatch($keyword));
+            })
+            ->visible($user);
+
+        if ($useFulltext) {
+            $query->orderByRaw(
+                'MATCH(series.name, series.short, series.description) AGAINST (?) DESC',
+                [$keyword]
+            );
+        }
+        $query->orderBy('start_at', 'DESC')->orderBy('name', 'ASC');
+
+        return $query->paginate($perPage);
+    }
+
+    private function entities(string $keyword, int $perPage): LengthAwarePaginator
+    {
+        $useFulltext = $this->useFulltext($keyword);
+
+        $query = Entity::query()
+            ->with('tags', 'events', 'entityType', 'locations', 'entityStatus', 'user')
+            ->where('entity_status_id', '<>', EntityStatus::UNLISTED)
+            ->where(function (Builder $q) use ($keyword, $useFulltext) {
+                if ($useFulltext) {
+                    $q->whereRaw(
+                        'MATCH(entities.name, entities.short, entities.description) AGAINST (? IN BOOLEAN MODE)',
+                        [$this->booleanQuery($keyword)]
+                    );
+                } else {
+                    $q->where('entities.name', 'like', '%' . $keyword . '%');
+                }
+
+                $q->orWhereHas('tags', $this->ciNameMatch($keyword))
+                    ->orWhereHas('aliases', $this->ciNameMatch($keyword));
+            });
+
+        if ($useFulltext) {
+            $query->orderByRaw(
+                'MATCH(entities.name, entities.short, entities.description) AGAINST (?) DESC',
+                [$keyword]
+            );
+        }
+        $query->orderBy('entity_type_id', 'ASC')->orderBy('name', 'ASC');
+
+        return $query->paginate($perPage);
+    }
+
+    private function tags(string $keyword, int $perPage): Paginator
+    {
+        return Tag::query()
+            ->where('name', 'like', '%' . $keyword . '%')
+            ->orderBy('name', 'ASC')
+            ->simplePaginate($perPage);
+    }
+
+    private function users(string $keyword, int $perPage): Paginator
+    {
+        return User::query()
+            ->where('name', 'like', '%' . $keyword . '%')
+            ->orderBy('name', 'ASC')
+            ->simplePaginate($perPage);
+    }
+
+    private function threads(string $keyword, int $perPage): LengthAwarePaginator
+    {
+        $useFulltext = $this->useFulltext($keyword);
+
+        $query = Thread::query()
+            ->with('visibility', 'entities', 'tags', 'posts', 'event', 'user')
+            ->where(function (Builder $q) use ($keyword, $useFulltext) {
+                if ($useFulltext) {
+                    $q->whereRaw(
+                        'MATCH(threads.name, threads.description, threads.body) AGAINST (? IN BOOLEAN MODE)',
+                        [$this->booleanQuery($keyword)]
+                    );
+                } else {
+                    $q->where('threads.name', 'like', '%' . $keyword . '%');
+                }
+
+                $q->orWhereHas('tags', $this->ciNameMatch($keyword));
+            });
+
+        if ($useFulltext) {
+            $query->orderByRaw(
+                'MATCH(threads.name, threads.description, threads.body) AGAINST (?) DESC',
+                [$keyword]
+            );
+        }
+        $query->orderBy('name', 'ASC');
+
+        return $query->paginate($perPage);
+    }
+
+    /**
+     * Case-insensitive name comparison closure for whereHas relationships.
+     */
+    private function ciNameMatch(string $keyword): \Closure
+    {
+        return function ($q) use ($keyword) {
+            $q->whereRaw('LOWER(name) = ?', [mb_strtolower($keyword)]);
+        };
+    }
+
+    private function useFulltext(string $keyword): bool
+    {
+        // Strip non-alphanumeric to estimate token length the FT parser will keep.
+        $stripped = preg_replace('/[^\p{L}\p{N}]+/u', '', $keyword) ?? '';
+        return mb_strlen($stripped) >= self::FULLTEXT_MIN_LENGTH;
+    }
+
+    /**
+     * Build a BOOLEAN MODE query string. Each safe token becomes `+token*` so all
+     * terms are required and prefix-expanded. Operators in the user input are stripped.
+     */
+    private function booleanQuery(string $keyword): string
+    {
+        $cleaned = preg_replace('/[+\-><()~*"@]+/', ' ', $keyword) ?? '';
+        $tokens = preg_split('/\s+/', trim($cleaned)) ?: [];
+        $parts = [];
+        foreach ($tokens as $token) {
+            if ($token === '' || mb_strlen($token) < self::FULLTEXT_MIN_LENGTH) {
+                continue;
+            }
+            $parts[] = '+' . $token . '*';
+        }
+        return $parts === [] ? $keyword : implode(' ', $parts);
+    }
+
+    /**
+     * Total for simplePaginate'd sections so the search page can show counts.
+     *
+     * @param  Builder<\Illuminate\Database\Eloquent\Model>  $base
+     * @param  array<int, string>  $columns
+     */
+    private function countLike(Builder $base, array $columns, string $keyword): int
+    {
+        $base->where(function (Builder $q) use ($columns, $keyword) {
+            foreach ($columns as $col) {
+                $q->orWhere($col, 'like', '%' . $keyword . '%');
+            }
+        });
+        return $base->count();
+    }
+}

--- a/app/Services/SearchService.php
+++ b/app/Services/SearchService.php
@@ -217,6 +217,113 @@ class SearchService
     }
 
     /**
+     * Lightweight grouped typeahead results: flat arrays per type.
+     *
+     * @param  array<int, string>|null  $types  Subset of ['events','entities','series','tags']. Null = all four.
+     * @return array{
+     *   query: string,
+     *   results: array<string, list<array{id:int,name:string,slug:?string,subtitle:?string,url:string}>>,
+     * }
+     */
+    public function lite(string $keyword, ?User $user, int $limit = 6, ?array $types = null): array
+    {
+        $keyword = trim(preg_replace('/\s+/', ' ', $keyword) ?? '');
+        $types = $types ?: ['events', 'entities', 'series', 'tags'];
+        $results = [];
+
+        if ($keyword === '') {
+            return ['query' => '', 'results' => array_fill_keys($types, [])];
+        }
+
+        $useFulltext = $this->useFulltext($keyword);
+
+        if (in_array('events', $types, true)) {
+            $q = Event::query()->select('id', 'name', 'slug', 'short', 'start_at')->visible($user);
+            $this->applyTextMatch($q, 'events', ['name', 'short', 'description'], $keyword, $useFulltext);
+            if ($useFulltext) {
+                $q->orderByRaw('MATCH(events.name, events.short, events.description) AGAINST (?) DESC', [$keyword]);
+            }
+            $q->orderBy('start_at', 'DESC');
+            $results['events'] = $q->limit($limit)->get()->map(fn ($e) => [
+                'id'       => $e->id,
+                'name'     => $e->name,
+                'slug'     => $e->slug,
+                'subtitle' => $e->start_at?->format('M j, Y'),
+                'url'      => url('/events/' . $e->id),
+            ])->all();
+        }
+
+        if (in_array('entities', $types, true)) {
+            $q = Entity::query()->select('id', 'name', 'slug', 'short')
+                ->where('entity_status_id', '<>', EntityStatus::UNLISTED);
+            $this->applyTextMatch($q, 'entities', ['name', 'short', 'description'], $keyword, $useFulltext);
+            if ($useFulltext) {
+                $q->orderByRaw('MATCH(entities.name, entities.short, entities.description) AGAINST (?) DESC', [$keyword]);
+            }
+            $q->orderBy('name', 'ASC');
+            $results['entities'] = $q->limit($limit)->get()->map(fn ($e) => [
+                'id'       => $e->id,
+                'name'     => $e->name,
+                'slug'     => $e->slug,
+                'subtitle' => $e->short,
+                'url'      => url('/entities/' . $e->slug),
+            ])->all();
+        }
+
+        if (in_array('series', $types, true)) {
+            $q = Series::query()->select('id', 'name', 'slug', 'short')->visible($user);
+            $this->applyTextMatch($q, 'series', ['name', 'short', 'description'], $keyword, $useFulltext);
+            if ($useFulltext) {
+                $q->orderByRaw('MATCH(series.name, series.short, series.description) AGAINST (?) DESC', [$keyword]);
+            }
+            $q->orderBy('name', 'ASC');
+            $results['series'] = $q->limit($limit)->get()->map(fn ($s) => [
+                'id'       => $s->id,
+                'name'     => $s->name,
+                'slug'     => $s->slug,
+                'subtitle' => $s->short,
+                'url'      => url('/series/' . $s->id),
+            ])->all();
+        }
+
+        if (in_array('tags', $types, true)) {
+            $tagResults = Tag::query()
+                ->select('id', 'name', 'slug')
+                ->where('name', 'like', '%' . $keyword . '%')
+                ->orderByRaw('CASE WHEN LOWER(name) = ? THEN 0 ELSE 1 END', [mb_strtolower($keyword)])
+                ->orderBy('name', 'ASC')
+                ->limit($limit)
+                ->get();
+            $results['tags'] = $tagResults->map(fn ($t) => [
+                'id'       => $t->id,
+                'name'     => $t->name,
+                'slug'     => $t->slug,
+                'subtitle' => null,
+                'url'      => url('/tags/' . $t->slug),
+            ])->all();
+        }
+
+        return ['query' => $keyword, 'results' => $results];
+    }
+
+    /**
+     * @param  Builder<\Illuminate\Database\Eloquent\Model>  $query
+     * @param  array<int, string>  $columns
+     */
+    private function applyTextMatch(Builder $query, string $table, array $columns, string $keyword, bool $useFulltext): void
+    {
+        if ($useFulltext) {
+            $cols = implode(',', array_map(fn ($c) => "$table.$c", $columns));
+            $query->whereRaw(
+                "MATCH($cols) AGAINST (? IN BOOLEAN MODE)",
+                [$this->booleanQuery($keyword)]
+            );
+        } else {
+            $query->where("$table.name", 'like', '%' . $keyword . '%');
+        }
+    }
+
+    /**
      * Case-insensitive name comparison closure for whereHas relationships.
      */
     private function ciNameMatch(string $keyword): \Closure

--- a/database/migrations/2026_05_15_000000_add_fulltext_indexes_for_search.php
+++ b/database/migrations/2026_05_15_000000_add_fulltext_indexes_for_search.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * @var array<string, array<int, string>>
+     */
+    private array $indexes = [
+        'events'   => ['name', 'short', 'description'],
+        'entities' => ['name', 'short', 'description'],
+        'series'   => ['name', 'short', 'description'],
+        'tags'     => ['name', 'description'],
+        'threads'  => ['name', 'description', 'body'],
+    ];
+
+    public function up(): void
+    {
+        foreach ($this->indexes as $table => $columns) {
+            if (! Schema::hasTable($table)) {
+                continue;
+            }
+            $existing = array_filter($columns, fn ($c) => Schema::hasColumn($table, $c));
+            if (count($existing) === 0) {
+                continue;
+            }
+            $indexName = $table . '_search_fulltext';
+            if ($this->indexExists($table, $indexName)) {
+                continue;
+            }
+            $cols = implode(',', array_map(fn ($c) => "`$c`", $existing));
+            DB::statement("ALTER TABLE `$table` ADD FULLTEXT `$indexName` ($cols)");
+        }
+    }
+
+    public function down(): void
+    {
+        foreach ($this->indexes as $table => $_columns) {
+            if (! Schema::hasTable($table)) {
+                continue;
+            }
+            $indexName = $table . '_search_fulltext';
+            if ($this->indexExists($table, $indexName)) {
+                DB::statement("ALTER TABLE `$table` DROP INDEX `$indexName`");
+            }
+        }
+    }
+
+    private function indexExists(string $table, string $index): bool
+    {
+        return count(DB::select("SHOW INDEX FROM `$table` WHERE Key_name = ?", [$index])) > 0;
+    }
+};

--- a/resources/views/partials/nav.blade.php
+++ b/resources/views/partials/nav.blade.php
@@ -92,11 +92,7 @@
 					</li>
 		        @endif
 		        <li class="mx-2 d-none d-sm-none d-md-block">
-				  <form class="navbar-form navbar-left" role="search" action="/search">
-					<div class="form-group">
-					  <input type="text" class="form-control form-background" placeholder="Search" name="keyword"  title="Search" aria-label="Search" value="{{ isset($search) ? $search : '' }}">
-					</div>
-				  </form>
+				  @include('partials.search-autocomplete', ['variant' => 'bs', 'inputId' => 'search-nav'])
 		     	</li>
 			</ul>
 

--- a/resources/views/partials/search-autocomplete.blade.php
+++ b/resources/views/partials/search-autocomplete.blade.php
@@ -1,0 +1,240 @@
+{{--
+    Search autocomplete (Alpine.js).
+
+    Variants:
+      - $variant = 'tw'        (Tailwind/sidebar) -- default
+      - $variant = 'tw-mobile' (Tailwind/topbar)
+      - $variant = 'bs'        (legacy Bootstrap nav)
+
+    Optional:
+      - $inputId  -- DOM id for the input
+      - $value    -- prefilled keyword
+--}}
+@php
+    $variant = $variant ?? 'tw';
+    $inputId = $inputId ?? 'search-autocomplete-' . uniqid();
+    $value   = $value ?? (isset($search) ? $search : '');
+
+    $inputClass = match ($variant) {
+        'tw-mobile' => 'w-full pl-8 pr-3 py-1.5 bg-transparent border border-input rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring',
+        'bs'        => 'form-control form-background',
+        default     => 'w-full pl-10 pr-4 py-2 bg-transparent border border-input rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent',
+    };
+@endphp
+
+<div class="relative search-autocomplete-root"
+     x-data="searchAutocomplete({ endpoint: '{{ url('/api/search') }}', target: '/search' })"
+     x-on:keydown.escape.window="close()"
+     x-on:click.outside="close()">
+    <form role="search" action="/search" x-on:submit="onSubmit($event)" class="{{ $variant === 'bs' ? 'navbar-form navbar-left' : 'flex flex-1 min-w-0' }}">
+        @if($variant === 'bs')
+            <div class="form-group">
+                <input type="text"
+                    id="{{ $inputId }}"
+                    class="{{ $inputClass }}"
+                    placeholder="Search"
+                    name="keyword"
+                    autocomplete="off"
+                    title="Search"
+                    aria-label="Search"
+                    aria-autocomplete="list"
+                    role="combobox"
+                    x-bind:aria-expanded="open"
+                    x-model="query"
+                    x-on:input.debounce.200ms="fetch()"
+                    x-on:focus="open = hasResults"
+                    x-on:keydown.arrow-down.prevent="move(1)"
+                    x-on:keydown.arrow-up.prevent="move(-1)"
+                    x-on:keydown.enter="onEnter($event)"
+                    value="{{ $value }}">
+            </div>
+        @else
+            <div class="relative w-full">
+                <input type="text"
+                    id="{{ $inputId }}"
+                    class="{{ $inputClass }}"
+                    placeholder="{{ $variant === 'tw-mobile' ? 'Search...' : 'Search' }}"
+                    name="keyword"
+                    autocomplete="off"
+                    title="Search"
+                    aria-label="Search"
+                    aria-autocomplete="list"
+                    role="combobox"
+                    x-bind:aria-expanded="open"
+                    x-model="query"
+                    x-on:input.debounce.200ms="fetch()"
+                    x-on:focus="open = hasResults"
+                    x-on:keydown.arrow-down.prevent="move(1)"
+                    x-on:keydown.arrow-up.prevent="move(-1)"
+                    x-on:keydown.enter="onEnter($event)"
+                    value="{{ $value }}">
+                <i class="bi bi-search absolute {{ $variant === 'tw-mobile' ? 'left-2.5 text-sm' : 'left-3' }} top-1/2 -translate-y-1/2 text-muted-foreground"></i>
+            </div>
+        @endif
+    </form>
+
+    <div x-show="open"
+         x-cloak
+         x-transition.opacity
+         class="absolute z-50 mt-1 left-0 right-0 min-w-[18rem] max-w-md bg-card border border-border rounded-lg shadow-lg overflow-hidden text-sm"
+         role="listbox">
+        <template x-if="loading">
+            <div class="px-3 py-2 text-muted-foreground">Searching&hellip;</div>
+        </template>
+        <template x-if="!loading && totalCount === 0 && query.length > 0">
+            <div class="px-3 py-2 text-muted-foreground">No matches for &ldquo;<span x-text="query"></span>&rdquo;.</div>
+        </template>
+
+        <template x-for="group in groups" :key="group.key">
+            <div x-show="group.items.length > 0">
+                <div class="px-3 py-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground bg-muted/50" x-text="group.label"></div>
+                <ul>
+                    <template x-for="(item, idx) in group.items" :key="group.key + '-' + item.id">
+                        <li>
+                            <a :href="item.url"
+                               class="block px-3 py-2 hover:bg-muted focus:bg-muted"
+                               :class="{ 'bg-muted': isActive(group.key, idx) }"
+                               x-on:mouseenter="setActive(group.key, idx)"
+                               role="option"
+                               :aria-selected="isActive(group.key, idx)">
+                                <div class="font-medium text-foreground" x-html="highlight(item.name)"></div>
+                                <template x-if="item.subtitle">
+                                    <div class="text-xs text-muted-foreground truncate" x-text="item.subtitle"></div>
+                                </template>
+                            </a>
+                        </li>
+                    </template>
+                </ul>
+            </div>
+        </template>
+
+        <template x-if="query.length > 0 && totalCount > 0">
+            <a x-bind:href="'/search?keyword=' + encodeURIComponent(query)"
+               class="block px-3 py-2 border-t border-border text-center text-xs font-medium text-foreground hover:bg-muted">
+                View all results for &ldquo;<span x-text="query"></span>&rdquo;
+            </a>
+        </template>
+    </div>
+</div>
+
+@once
+<script>
+    window.searchAutocomplete = function (config) {
+        return {
+            endpoint: config.endpoint,
+            target: config.target,
+            query: '',
+            open: false,
+            loading: false,
+            controller: null,
+            results: { events: [], entities: [], series: [], tags: [] },
+            activeKey: null,
+            activeIdx: -1,
+
+            init() {
+                // Prefill from the input value (Blade-rendered).
+                this.query = this.$root.querySelector('input[name="keyword"]')?.value || '';
+            },
+
+            get groups() {
+                return [
+                    { key: 'events',   label: 'Events',   items: this.results.events   || [] },
+                    { key: 'entities', label: 'Entities', items: this.results.entities || [] },
+                    { key: 'series',   label: 'Series',   items: this.results.series   || [] },
+                    { key: 'tags',     label: 'Tags',     items: this.results.tags     || [] },
+                ];
+            },
+
+            get totalCount() {
+                return this.groups.reduce((sum, g) => sum + g.items.length, 0);
+            },
+
+            get hasResults() {
+                return this.totalCount > 0;
+            },
+
+            async fetch() {
+                const q = this.query.trim();
+                if (q.length < 2) {
+                    this.results = { events: [], entities: [], series: [], tags: [] };
+                    this.open = false;
+                    return;
+                }
+                if (this.controller) this.controller.abort();
+                this.controller = new AbortController();
+                this.loading = true;
+                this.open = true;
+                try {
+                    const res = await fetch(this.endpoint + '?q=' + encodeURIComponent(q) + '&limit=5', {
+                        headers: { 'Accept': 'application/json' },
+                        signal: this.controller.signal,
+                        credentials: 'same-origin',
+                    });
+                    if (!res.ok) throw new Error('search request failed');
+                    const data = await res.json();
+                    this.results = Object.assign(
+                        { events: [], entities: [], series: [], tags: [] },
+                        data.results || {}
+                    );
+                    this.activeKey = null;
+                    this.activeIdx = -1;
+                } catch (err) {
+                    if (err.name !== 'AbortError') console.warn('autocomplete error', err);
+                } finally {
+                    this.loading = false;
+                }
+            },
+
+            close() { this.open = false; },
+
+            isActive(key, idx) { return this.activeKey === key && this.activeIdx === idx; },
+            setActive(key, idx) { this.activeKey = key; this.activeIdx = idx; },
+
+            move(direction) {
+                const flat = [];
+                for (const g of this.groups) {
+                    for (let i = 0; i < g.items.length; i++) flat.push([g.key, i]);
+                }
+                if (flat.length === 0) return;
+                let current = flat.findIndex(([k, i]) => k === this.activeKey && i === this.activeIdx);
+                current = current === -1 ? (direction > 0 ? -1 : flat.length) : current;
+                let next = current + direction;
+                if (next < 0) next = flat.length - 1;
+                if (next >= flat.length) next = 0;
+                [this.activeKey, this.activeIdx] = flat[next];
+                this.open = true;
+            },
+
+            onEnter(event) {
+                if (this.activeKey !== null && this.activeIdx >= 0) {
+                    const item = (this.results[this.activeKey] || [])[this.activeIdx];
+                    if (item && item.url) {
+                        event.preventDefault();
+                        window.location.href = item.url;
+                    }
+                }
+                // Otherwise let the form submit normally to /search.
+            },
+
+            onSubmit(event) {
+                if (!this.query.trim()) event.preventDefault();
+            },
+
+            highlight(text) {
+                const q = this.query.trim();
+                if (!q) return this.escape(text);
+                const escaped = this.escape(text);
+                const pattern = q.split(/\s+/).filter(Boolean).map(this.escapeRegex).join('|');
+                if (!pattern) return escaped;
+                return escaped.replace(new RegExp('(' + pattern + ')', 'gi'), '<mark class="bg-yellow-200 text-inherit">$1</mark>');
+            },
+
+            escape(s) {
+                return String(s ?? '').replace(/[&<>"']/g, c => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c]));
+            },
+
+            escapeRegex(s) { return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); },
+        };
+    };
+</script>
+@endonce

--- a/resources/views/partials/sidebar-tw.blade.php
+++ b/resources/views/partials/sidebar-tw.blade.php
@@ -10,18 +10,7 @@
 
     <!-- Search -->
     <div class="p-4">
-        <form role="search" action="/search">
-            <div class="relative">
-                <input type="text"
-                    class="w-full pl-10 pr-4 py-2 bg-transparent border border-input rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
-                    placeholder="Search"
-                    name="keyword"
-                    title="Search"
-                    aria-label="Search"
-                    value="{{ isset($search) ? $search : '' }}">
-                <i class="bi bi-search absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"></i>
-            </div>
-        </form>
+        @include('partials.search-autocomplete', ['variant' => 'tw', 'inputId' => 'search-sidebar'])
     </div>
 
     <!-- Navigation -->

--- a/resources/views/partials/topbar-tw.blade.php
+++ b/resources/views/partials/topbar-tw.blade.php
@@ -13,18 +13,9 @@
         </a>
 
         <!-- Mobile Search -->
-        <form class="flex flex-1 min-w-0" role="search" action="/search">
-            <div class="relative w-full">
-                <input type="text"
-                    class="w-full pl-8 pr-3 py-1.5 bg-transparent border border-input rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-                    placeholder="Search..."
-                    name="keyword"
-                    title="Search"
-                    aria-label="Search"
-                    value="{{ isset($search) ? $search : '' }}">
-                <i class="bi bi-search absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground text-sm"></i>
-            </div>
-        </form>
+        <div class="flex-1 min-w-0">
+            @include('partials.search-autocomplete', ['variant' => 'tw-mobile', 'inputId' => 'search-topbar'])
+        </div>
 
         <!-- Right side actions -->
         <div class="flex items-center gap-2 flex-shrink-0">

--- a/routes/api.php
+++ b/routes/api.php
@@ -32,6 +32,9 @@ Route::middleware('auth:sanctum')->get('tokens/test', function (Request $request
     return ['data' => 'token test'];
 });
 
+// Public typeahead search. Visibility scoping uses the optionally-authenticated user.
+Route::get('search', ['as' => 'api.search', 'uses' => 'Api\SearchController@index']);
+
 Route::middleware('auth:sanctum')->get('auth/me', function (Request $request) {
     // $user = $request->user()->load(['groups.permissions']);
     // return new AuthUserResource($user);


### PR DESCRIPTION
Extract search logic from PagesController into App\Services\SearchService and switch primary text matching to MySQL FULLTEXT MATCH...AGAINST in BOOLEAN MODE with relevance ranking. Falls back to LIKE for short tokens that the FT parser would drop.

Fixes three latent bugs in the prior implementation:
- Visibility leak: the OR group of relationship matches is now wrapped in a closure so ->visible() ANDs against the whole group instead of binding only to the last orWhere.
- Case-sensitive tag/series/venue/promoter matches replaced ucfirst() with a case-insensitive LOWER() comparison.
- Removed redundant ->count() calls; LengthAwarePaginator->total() is used for the paginated sections.

Adds a new migration that creates FULLTEXT indexes on the searchable columns of events, entities, series, tags, and threads.