### PR TITLE
Recency-favoring search ranking + Upcoming/Past split (#1674)

### DIFF
--- a/app/Services/SearchService.php
+++ b/app/Services/SearchService.php
@@ -95,13 +95,15 @@ class SearchService
             })
             ->visible($user);
 
+        $this->applyRecencyOrder($query, 'events');
         if ($useFulltext) {
             $query->orderByRaw(
                 'MATCH(events.name, events.short, events.description) AGAINST (?) DESC',
                 [$keyword]
             );
         }
-        $query->orderBy('start_at', 'DESC')->orderBy('name', 'ASC');
+        $query->orderByRaw('ABS(TIMESTAMPDIFF(SECOND, NOW(), events.start_at)) ASC')
+            ->orderBy('events.name', 'ASC');
 
         return $query->paginate($perPage);
     }
@@ -127,13 +129,15 @@ class SearchService
             })
             ->visible($user);
 
+        $this->applyRecencyOrder($query, 'series');
         if ($useFulltext) {
             $query->orderByRaw(
                 'MATCH(series.name, series.short, series.description) AGAINST (?) DESC',
                 [$keyword]
             );
         }
-        $query->orderBy('start_at', 'DESC')->orderBy('name', 'ASC');
+        $query->orderByRaw('ABS(TIMESTAMPDIFF(SECOND, NOW(), series.start_at)) ASC')
+            ->orderBy('series.name', 'ASC');
 
         return $query->paginate($perPage);
     }
@@ -321,6 +325,27 @@ class SearchService
         } else {
             $query->where("$table.name", 'like', '%' . $keyword . '%');
         }
+    }
+
+    /**
+     * Order results into three time buckets so upcoming events always come
+     * before recent-past, which come before older — keeping discovery of
+     * upcoming events as the primary use case for the site.
+     *
+     * @param  Builder<\Illuminate\Database\Eloquent\Model>  $query
+     */
+    private function applyRecencyOrder(Builder $query, string $table): void
+    {
+        // start_at NULL is treated as "older" so undated rows don't outrank
+        // real upcoming events.
+        $query->orderByRaw(
+            "CASE
+                WHEN {$table}.start_at IS NULL                      THEN 2
+                WHEN {$table}.start_at >= NOW()                     THEN 0
+                WHEN {$table}.start_at >= NOW() - INTERVAL 60 DAY   THEN 1
+                ELSE                                                     2
+            END ASC"
+        );
     }
 
     /**

--- a/resources/views/pages/search.blade.php
+++ b/resources/views/pages/search.blade.php
@@ -94,12 +94,46 @@
 			</button>
 		</div>
 		<div id="search-events" class="p-4">
-			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-				@foreach($events as $event)
-				@include('events.card-tw', ['event' => $event])
-				@php unset($event); @endphp
-				@endforeach
+			@php
+				$now = \Carbon\Carbon::now();
+				$upcomingEvents = $events->getCollection()->filter(fn ($e) => $e->start_at && $e->start_at >= $now);
+				$pastEvents     = $events->getCollection()->reject(fn ($e) => $e->start_at && $e->start_at >= $now);
+			@endphp
+
+			@if ($upcomingEvents->isNotEmpty())
+			<div class="mb-5">
+				<h3 class="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3 flex items-center gap-2">
+					<i class="bi bi-calendar-event"></i>
+					Upcoming
+					<span class="badge-tw bg-muted text-foreground text-xs">{{ $upcomingEvents->count() }}</span>
+				</h3>
+				<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+					@foreach($upcomingEvents as $event)
+					@include('events.card-tw', ['event' => $event])
+					@php unset($event); @endphp
+					@endforeach
+				</div>
 			</div>
+			@endif
+
+			@if ($pastEvents->isNotEmpty())
+			<div>
+				@if ($upcomingEvents->isNotEmpty())
+				<h3 class="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3 flex items-center gap-2">
+					<i class="bi bi-clock-history"></i>
+					Past
+					<span class="badge-tw bg-muted text-foreground text-xs">{{ $pastEvents->count() }}</span>
+				</h3>
+				@endif
+				<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+					@foreach($pastEvents as $event)
+					@include('events.card-tw', ['event' => $event])
+					@php unset($event); @endphp
+					@endforeach
+				</div>
+			</div>
+			@endif
+
 			<div class="mt-4">
 				{!! $events->appends(['keyword' => $search])->links('vendor.pagination.tailwind') !!}
 			</div>
@@ -125,12 +159,46 @@
 			</button>
 		</div>
 		<div id="search-series" class="p-4">
-			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-				@foreach($series as $s)
-				@include('series.card-tw', ['series' => $s])
-				@php unset($s); @endphp
-				@endforeach
+			@php
+				$now = $now ?? \Carbon\Carbon::now();
+				$upcomingSeries = $series->getCollection()->filter(fn ($s) => $s->start_at && $s->start_at >= $now);
+				$pastSeries     = $series->getCollection()->reject(fn ($s) => $s->start_at && $s->start_at >= $now);
+			@endphp
+
+			@if ($upcomingSeries->isNotEmpty())
+			<div class="mb-5">
+				<h3 class="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3 flex items-center gap-2">
+					<i class="bi bi-calendar-event"></i>
+					Upcoming
+					<span class="badge-tw bg-muted text-foreground text-xs">{{ $upcomingSeries->count() }}</span>
+				</h3>
+				<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+					@foreach($upcomingSeries as $s)
+					@include('series.card-tw', ['series' => $s])
+					@php unset($s); @endphp
+					@endforeach
+				</div>
 			</div>
+			@endif
+
+			@if ($pastSeries->isNotEmpty())
+			<div>
+				@if ($upcomingSeries->isNotEmpty())
+				<h3 class="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3 flex items-center gap-2">
+					<i class="bi bi-clock-history"></i>
+					Past
+					<span class="badge-tw bg-muted text-foreground text-xs">{{ $pastSeries->count() }}</span>
+				</h3>
+				@endif
+				<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+					@foreach($pastSeries as $s)
+					@include('series.card-tw', ['series' => $s])
+					@php unset($s); @endphp
+					@endforeach
+				</div>
+			</div>
+			@endif
+
 			<div class="mt-4">
 				{!! $series->appends(['keyword' => $search])->links('vendor.pagination.tailwind') !!}
 			</div>


### PR DESCRIPTION
## Summary

Phase 1's switch to FULLTEXT ranking surfaced a regression for an events-discovery site: a strong text match on a years-old event could outrank a same-topic event next week. This PR restores the upcoming-first bias the old `LIKE`-ordered-by-date search had, **without throwing away relevance**.

Implements options **A + E** from the discussion in #1674.

## A. Time-bucketed ranking (SearchService)

For `events()` and `series()`, the new primary `ORDER BY` is a three-tier bucket:

| Bucket | Condition |
|---|---|
| 0 | \`start_at >= NOW()\` (upcoming) |
| 1 | \`start_at >= NOW() - INTERVAL 60 DAY\` (recent past) |
| 2 | everything else, plus \`NULL start_at\` |

Then `MATCH(...) AGAINST(...)` relevance, then `ABS(TIMESTAMPDIFF(SECOND, NOW(), start_at))` (closest-to-now first within bucket — soonest in upcoming, most-recent in past), then name.

`NULL start_at` is treated as "older" so undated rows don't outrank real upcoming events.

## E. Upcoming / Past visual split (search results page)

The Events and Series cards now split internally into **Upcoming** and **Past** subsections, each with a small header and count. If there are no upcoming results, the "Past" header is suppressed and past results render unlabeled — so searches that match only past content look identical to before.

## Files

- `app/Services/SearchService.php` — new `applyRecencyOrder()` helper; `events()` and `series()` use it.
- `resources/views/pages/search.blade.php` — Events and Series sections split into Upcoming/Past subsections.

## What's unchanged

- Entities, tags, threads — no date concept.
- The autocomplete (`/api/search` / `lite()`) — keeps its existing per-type sort. Considered worthwhile to add later if needed, but the dropdown is short and the visual cost isn't there.

## Alternatives kept on the shelf

Not implemented; documented in #1674 as fallbacks if A+E proves insufficient once query logging gives evidence:

- **B.** Continuous time decay (smooth sigmoid added to FT score).
- **C.** Asymmetric future-favoring decay (multiplicative future boost + small past penalty).
- **D.** Two-pass rerank in PHP combining additional signals (attendance, photos, comments).

## Test plan

- [ ] Search a broad term (e.g. \`rock\`, \`music\`) — upcoming events should appear first, followed by past, with relevance ordering within each bucket.
- [ ] Confirm an obscure word that only matches old events still returns those results (just below any upcoming matches).
- [ ] Confirm a future event whose name barely matches still appears above a perfect-match event from 3 years ago.
- [ ] Verify the Events section card shows two subsection headers ("Upcoming" + "Past") when both are non-empty.
- [ ] Verify the Events section card shows no subsection headers (just one grid) when only past results exist — preserves the old appearance.
- [ ] Same checks for the Series section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)