### PR TITLE
Search visibility-leak regression test + query logging (#1674)

### DIFF
--- a/app/Models/SearchLog.php
+++ b/app/Models/SearchLog.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * App\Models\SearchLog
+ *
+ * @property int $id
+ * @property int|null $user_id
+ * @property string $query
+ * @property int $results_count
+ * @property string $source
+ * @property string|null $ip_address
+ * @property string|null $user_agent
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property-read \App\Models\User|null $user
+ */
+class SearchLog extends Model
+{
+    public const UPDATED_AT = null;
+
+    protected $fillable = [
+        'user_id',
+        'query',
+        'results_count',
+        'source',
+        'ip_address',
+        'user_agent',
+    ];
+
+    protected $casts = [
+        'results_count' => 'integer',
+        'created_at'    => 'datetime',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Services/SearchService.php
+++ b/app/Services/SearchService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Models\Entity;
 use App\Models\EntityStatus;
 use App\Models\Event;
+use App\Models\SearchLog;
 use App\Models\Series;
 use App\Models\Tag;
 use App\Models\Thread;
@@ -12,7 +13,9 @@ use App\Models\User;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use Throwable;
 
 class SearchService
 {
@@ -53,6 +56,11 @@ class SearchService
         $users    = $this->users($keyword, $perPage);
         $threads  = $this->threads($keyword, $perPage);
 
+        $tagsCount    = $this->countLike(Tag::query(), ['name'], $keyword);
+        $usersCount   = $this->countLike(User::query(), ['name'], $keyword);
+
+        $this->logSearch($keyword, $user, 'web', $events->total() + $series->total() + $entities->total() + $tagsCount + $usersCount + $threads->total());
+
         return [
             'events'        => $events,
             'eventsCount'   => $events->total(),
@@ -61,9 +69,9 @@ class SearchService
             'entities'      => $entities,
             'entitiesCount' => $entities->total(),
             'tags'          => $tags,
-            'tagsCount'     => $this->countLike(Tag::query(), ['name'], $keyword),
+            'tagsCount'     => $tagsCount,
             'users'         => $users,
-            'usersCount'    => $this->countLike(User::query(), ['name'], $keyword),
+            'usersCount'    => $usersCount,
             'threads'       => $threads,
             'threadsCount'  => $threads->total(),
         ];
@@ -303,7 +311,37 @@ class SearchService
             ])->all();
         }
 
+        $totalCount = array_sum(array_map('count', $results));
+        $this->logSearch($keyword, $user, 'api', $totalCount);
+
         return ['query' => $keyword, 'results' => $results];
+    }
+
+    /**
+     * Record a search to the search_logs table for later analytics.
+     *
+     * Skipped for empty queries (typeahead returns early before any query
+     * is actually run). Failures are swallowed and logged to the default
+     * channel — telemetry must never break a user-facing search.
+     */
+    private function logSearch(string $keyword, ?User $user, string $source, int $resultsCount): void
+    {
+        if ($keyword === '') {
+            return;
+        }
+        try {
+            $request = request();
+            SearchLog::create([
+                'user_id'       => $user?->id,
+                'query'         => mb_substr($keyword, 0, 191),
+                'results_count' => $resultsCount,
+                'source'        => $source,
+                'ip_address'    => $request?->ip(),
+                'user_agent'    => $request ? mb_substr((string) $request->userAgent(), 0, 512) : null,
+            ]);
+        } catch (Throwable $e) {
+            Log::warning('search log write failed', ['err' => $e->getMessage()]);
+        }
     }
 
     /**

--- a/database/migrations/2026_05_15_000001_create_search_logs_table.php
+++ b/database/migrations/2026_05_15_000001_create_search_logs_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('search_logs', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('user_id')->nullable()->index();
+            $table->string('query', 191);
+            $table->unsignedInteger('results_count')->default(0);
+            $table->string('source', 16)->default('web');   // web | api
+            $table->string('ip_address', 45)->nullable();
+            $table->string('user_agent', 512)->nullable();
+            $table->timestamp('created_at')->nullable()->index();
+            // No updated_at — log rows are write-once.
+        });
+
+        // Useful for "top queries" reports.
+        Schema::table('search_logs', function (Blueprint $table) {
+            $table->index('query');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('search_logs');
+    }
+};

--- a/tests/Feature/SearchVisibilityTest.php
+++ b/tests/Feature/SearchVisibilityTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Entity;
+use App\Models\Event;
+use App\Models\Tag;
+use App\Models\User;
+use App\Models\UserStatus;
+use App\Models\Visibility;
+use App\Services\SearchService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Regression guard for the visibility-leak bug fixed in PR #1886.
+ *
+ * Background: PagesController::search() previously chained orWhere() clauses
+ * for tag/series/venue/promoter/related-entity matches, then appended
+ * ->where(visible). Due to Eloquent boolean precedence, the visibility
+ * scope only bound to the last orWhere, so private/proposal events could
+ * leak into search results via any of the relationship matches. The fix
+ * wraps the OR group in a closure so visible() ANDs against the whole group.
+ *
+ * Each test creates a private (or proposal) event owned by user A that
+ * matches the keyword via one of the OR branches, then searches as a
+ * different user (and as a guest) to assert the event never appears in
+ * the visible result set.
+ *
+ * Note: the primary "text on the event's own name/short/description" OR
+ * branch uses MySQL FULLTEXT, which under InnoDB doesn't reflect uncommitted
+ * rows inside a transaction. Since RefreshDatabase wraps each test in a
+ * rolled-back transaction, exercising the FT branch here would always
+ * return zero rows (test would pass for the wrong reason). The relationship
+ * OR branches below use EXISTS subqueries, which DO see uncommitted data,
+ * and they exercise the exact same OR-group structure that the bug was in.
+ */
+class SearchVisibilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private SearchService $service;
+    private User $owner;
+    private User $other;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new SearchService();
+        $this->owner = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $this->other = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+    }
+
+    public function test_private_event_does_not_leak_via_tag_match(): void
+    {
+        $tag = Tag::factory()->create(['name' => 'Zorblaxcore']);
+        $event = $this->makePrivateEvent();
+        $event->tags()->attach($tag);
+
+        $this->assertNotVisibleTo($this->other, 'Zorblaxcore', $event);
+        $this->assertNotVisibleTo(null, 'Zorblaxcore', $event);
+    }
+
+    public function test_private_event_does_not_leak_via_venue_match(): void
+    {
+        $venue = Entity::factory()->venue()->create(['name' => 'Zorblax Hall']);
+        $event = $this->makePrivateEvent(['venue_id' => $venue->id]);
+
+        $this->assertNotVisibleTo($this->other, 'Zorblax Hall', $event);
+        $this->assertNotVisibleTo(null, 'Zorblax Hall', $event);
+    }
+
+    public function test_private_event_does_not_leak_via_promoter_match(): void
+    {
+        $promoter = Entity::factory()->promoter()->create(['name' => 'Zorblax Promotions']);
+        $event = $this->makePrivateEvent(['promoter_id' => $promoter->id]);
+
+        $this->assertNotVisibleTo($this->other, 'Zorblax Promotions', $event);
+        $this->assertNotVisibleTo(null, 'Zorblax Promotions', $event);
+    }
+
+    public function test_private_event_does_not_leak_via_related_entity_slug(): void
+    {
+        $entity = Entity::factory()->create(['name' => 'Zorblax Band', 'slug' => 'zorblax-band']);
+        $event = $this->makePrivateEvent();
+        $event->entities()->attach($entity);
+
+        $this->assertNotVisibleTo($this->other, 'zorblax-band', $event);
+        $this->assertNotVisibleTo(null, 'zorblax-band', $event);
+    }
+
+    public function test_proposal_event_does_not_leak_via_tag_match(): void
+    {
+        $tag = Tag::factory()->create(['name' => 'Zorblaxprop']);
+        $event = $this->makePrivateEvent(['visibility_id' => Visibility::VISIBILITY_PROPOSAL]);
+        $event->tags()->attach($tag);
+
+        $this->assertNotVisibleTo($this->other, 'Zorblaxprop', $event);
+        $this->assertNotVisibleTo(null, 'Zorblaxprop', $event);
+    }
+
+    public function test_owner_can_find_their_own_private_event_via_tag(): void
+    {
+        // The flip side: visibility filtering should ALLOW the owner to find
+        // their own private events. This catches an over-correction where
+        // the AND-wrap accidentally hides everyone's private content.
+        $tag = Tag::factory()->create(['name' => 'Zorblaxowned']);
+        $event = $this->makePrivateEvent();
+        $event->tags()->attach($tag);
+
+        $this->assertVisibleTo($this->owner, 'Zorblaxowned', $event);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function makePrivateEvent(array $overrides = []): Event
+    {
+        return Event::factory()->create(array_merge([
+            'name'          => 'Zorblax Secret Show',
+            'visibility_id' => Visibility::VISIBILITY_PRIVATE,
+            'created_by'    => $this->owner->id,
+        ], $overrides));
+    }
+
+    private function assertNotVisibleTo(?User $user, string $keyword, Event $event): void
+    {
+        $ids = $this->idsFor($keyword, $user);
+        $this->assertNotContains(
+            $event->id,
+            $ids,
+            sprintf(
+                'Expected event %d to be HIDDEN from %s searching "%s", but it appeared. Returned ids: [%s]',
+                $event->id,
+                $user ? "user {$user->id}" : 'guest',
+                $keyword,
+                implode(',', $ids)
+            )
+        );
+    }
+
+    private function assertVisibleTo(?User $user, string $keyword, Event $event): void
+    {
+        $ids = $this->idsFor($keyword, $user);
+        $this->assertContains(
+            $event->id,
+            $ids,
+            sprintf(
+                'Expected event %d to be VISIBLE to %s searching "%s", but it was missing. Returned ids: [%s]',
+                $event->id,
+                $user ? "user {$user->id}" : 'guest',
+                $keyword,
+                implode(',', $ids)
+            )
+        );
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    private function idsFor(string $keyword, ?User $user): array
+    {
+        $results = $this->service->all($keyword, $user, 50);
+        return collect($results['events']->items())->pluck('id')->all();
+    }
+}


### PR DESCRIPTION
## Summary

Two quick wins from the cross-cutting backlog in #1674.

### 1. Visibility-leak regression test

Locks in the Phase 1 bug fix where private/proposal events could leak into search results via the OR group of relationship matches. New \`tests/Feature/SearchVisibilityTest.php\`:

- Creates a private event owned by user A that matches the keyword via each OR branch (tag / venue / promoter / related-entity).
- Searches as user B and as a guest, asserts the event does **not** appear.
- Adds a proposal-visibility variant.
- Adds a complementary positive test: the owner CAN still find their own private event, so the AND-wrap isn't accidentally hiding everyone's private content.

**Why the FT branch isn't tested here:** InnoDB FULLTEXT indexes don't reflect uncommitted rows inside a transaction. \`RefreshDatabase\` wraps each test in a rolled-back transaction, so any FT-only assertion would pass for the wrong reason (returning zero rows). The relationship branches use EXISTS subqueries which DO see uncommitted data, and they exercise the exact same OR-group structure the bug was in — same code path, same boolean-precedence trap.

### 2. Search-query logging

New \`search_logs\` table:

| column | type | notes |
|---|---|---|
| id | bigint pk | |
| user_id | unsigned int nullable, indexed | guest searches allowed |
| query | varchar(191) | indexed for "top queries" reports |
| results_count | unsigned int | total across all sections |
| source | varchar(16) | \`web\` or \`api\` |
| ip_address | varchar(45) | IPv6 max |
| user_agent | varchar(512) nullable | |
| created_at | timestamp, indexed | no \`updated_at\` — write-once |

\`SearchService::all()\` (web) and \`lite()\` (api typeahead) both call a private \`logSearch()\` helper after running. Empty queries are skipped (typeahead returns early before any work happens). The write is wrapped in try/catch with warnings-only on failure — telemetry must never break a user-facing search.

## Unblocks

- Data-driven decisions on Phase 3 (do users actually search "this weekend" enough to justify the date parser?)
- Phase 4 gate (capture p50/p95 latency before committing to Meilisearch).
- "Did you mean…" suggestions corpus.
- Saved / recent searches per user.

## Files

- \`tests/Feature/SearchVisibilityTest.php\` — new (6 tests, 11 assertions)
- \`app/Services/SearchService.php\` — \`logSearch()\` helper + calls from \`all()\` and \`lite()\`
- \`app/Models/SearchLog.php\` — new
- \`database/migrations/2026_05_15_000001_create_search_logs_table.php\` — new

## Test plan

- [ ] Run a real search; confirm a row appears in \`search_logs\` with \`source='web'\`.
- [ ] Hit \`/api/search?q=…\` from autocomplete; confirm a row appears with \`source='api'\`.
- [ ] Confirm empty-keyword searches don't create rows.
- [ ] Confirm the new visibility test file runs green: \`vendor/bin/phpunit tests/Feature/SearchVisibilityTest.php\`.
- [ ] Run the migration in deploy; verify the table exists and is indexed (\`query\`, \`created_at\`, \`user_id\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)