### PR TITLE
Search autocomplete: 400ms debounce + 3-char minimum (#1674)

### DIFF
--- a/resources/views/partials/search-autocomplete.blade.php
+++ b/resources/views/partials/search-autocomplete.blade.php
@@ -50,7 +50,7 @@
                     role="combobox"
                     x-bind:aria-expanded="open"
                     x-model="query"
-                    x-on:input.debounce.200ms="fetch()"
+                    x-on:input.debounce.400ms="fetch()"
                     x-on:focus="onFocus()"
                     x-on:keydown.arrow-down.prevent="move(1)"
                     x-on:keydown.arrow-up.prevent="move(-1)"
@@ -72,7 +72,7 @@
                     role="combobox"
                     x-bind:aria-expanded="open || overlay"
                     x-model="query"
-                    x-on:input.debounce.200ms="fetch()"
+                    x-on:input.debounce.400ms="fetch()"
                     x-on:focus="onFocus()"
                     x-on:keydown.arrow-down.prevent="move(1)"
                     x-on:keydown.arrow-up.prevent="move(-1)"
@@ -116,7 +116,7 @@
                             role="combobox"
                             x-bind:aria-expanded="overlay"
                             x-model="query"
-                            x-on:input.debounce.200ms="fetch()"
+                            x-on:input.debounce.400ms="fetch()"
                             x-on:keydown.arrow-down.prevent="move(1)"
                             x-on:keydown.arrow-up.prevent="move(-1)"
                             x-on:keydown.enter="onEnter($event)">
@@ -206,7 +206,7 @@
 
             async fetch() {
                 const q = this.query.trim();
-                if (q.length < 2) {
+                if (q.length < 3) {
                     this.results = { events: [], entities: [], series: [], tags: [] };
                     if (!this.overlay) this.open = false;
                     return;


### PR DESCRIPTION
## Summary

- Autocomplete debounce: **200ms → 400ms**.
- Minimum trigger length: **2 → 3 characters** (also aligns with the server-side FT min-token-size).

Reduces partial-word queries hitting \`/api/search\` and \`search_logs\` without losing the live-as-you-type feel — a typical 4-character word now fires once at the end of typing instead of two or three times mid-word.

## Not included (intentionally)

We discussed also dropping API queries from \`search_logs\` (since autocomplete is exploratory mid-typing while \`/search\` page hits are intentional). Leaving them in for now to gather data on both behaviors; can revisit if the log fills with noise.

## Files

- \`resources/views/partials/search-autocomplete.blade.php\` (+4 / -4 — three \`debounce.200ms\` → \`debounce.400ms\` plus one \`q.length < 2\` → \`q.length < 3\`)

## Test plan

- [ ] Type "rock" into the search bar — should fire exactly one autocomplete request when typing pauses.
- [ ] Type a single letter — no request (was 2 letters before, now 3).
- [ ] Verify dropdown still appears responsive (400ms is below the 500ms perceptual threshold for "slow").

🤖 Generated with [Claude Code](https://claude.com/claude-code)