### PR TITLE
Security/dependency quick-wins + Mail/Jobs/Notification test coverage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,11 @@ SESSION_DRIVER=file
 QUEUE_DRIVER=database
 QUEUE_NOTIFY_EMAIL=false
 
+# Sanctum personal access token lifetime, in minutes (default: 30 days). Leave blank for non-expiring tokens.
+SANCTUM_TOKEN_EXPIRATION=43200
+# Comma-separated extra CORS origins for non-production environments (optional).
+CORS_EXTRA_ORIGINS=
+
 MAIL_DRIVER=smtp
 MAIL_HOST=smtp.mailgun.org
 MAIL_PORT=587

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           php-version: 8.4
           extensions: intl #optional
+          coverage: pcov
           ini-values: "post_max_size=256M" #optional
 
       - name: Check PHP Version
@@ -51,6 +52,10 @@ jobs:
       - name: Install dependencies
         run: composer install --quiet --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
 
+      # Fails the build on any unignored advisory; known-abandoned packages are reported, not gated.
+      - name: Composer security audit
+        run: composer audit --abandoned=report
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -59,6 +64,9 @@ jobs:
 
       - name: Install NPM Dependencies
         run: npm install
+
+      - name: NPM security audit
+        run: npm audit --audit-level=high
 
       - name: Clear Config
         run: php artisan config:clear
@@ -73,7 +81,7 @@ jobs:
         run: php artisan storage:link
 
       - name: Output the phpstan config
-        run: more phpstan.neon.dist
+        run: more phpstan.neon
 
       - name: Run php stan static analysis
         run: composer run-script phpstan
@@ -90,4 +98,8 @@ jobs:
           DB_PORT: 33306
           DB_USER: root
           DB_PASSWORD: db-password
-        run: composer run-script tests
+        # Equivalent to `composer run-script tests`, with coverage reporting added (pcov).
+        run: |
+          php artisan migrate --verbose
+          php artisan db:seed
+          ./vendor/bin/phpunit tests --coverage-text --coverage-clover=coverage.xml

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -81,7 +81,7 @@ jobs:
         run: php artisan storage:link
 
       - name: Output the phpstan config
-        run: more phpstan.neon
+        run: more phpstan.neon.dist
 
       - name: Run php stan static analysis
         run: composer run-script phpstan

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
 		"mockery/mockery": "^1.0",
 		"symfony/dom-crawler": "^6.0",
 		"barryvdh/laravel-ide-helper": "^2.8",
-		"nunomaduro/larastan": "^2.11",
+		"larastan/larastan": "^2.11",
 		"laravel/dusk": "^7.7",
 		"phpunit/phpunit": "^10.0",
 		"barryvdh/laravel-debugbar": "^3.8"
@@ -96,6 +96,11 @@
 		"preferred-install": "dist",
 		"allow-plugins": {
 			"php-http/discovery": true
+		},
+		"audit": {
+			"ignore": {
+				"PKSA-mdq4-51ck-6kdq": "Laravel CRLF injection in default email validation rule. Patched only in Laravel 12.60+/13.10+ (all 10.x AND 11.x are affected), so it cannot be resolved without the deferred framework-upgrade track. Accepted/known risk; revisit when upgrading the framework."
+			}
 		}
 	},
 	"minimum-stability": "stable"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8fd9598e2da04c59737a97f018f4b1ea",
+    "content-hash": "238b4384bf40090a80b075cddbf3018f",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -1374,25 +1374,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "version": "7.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
+                "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.3",
-                "guzzlehttp/psr7": "^2.8",
+                "guzzlehttp/promises": "^2.5",
+                "guzzlehttp/psr7": "^2.11",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -1401,8 +1402,9 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
+                "guzzlehttp/test-server": "^0.5",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -1480,7 +1482,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.11.1"
             },
             "funding": [
                 {
@@ -1496,28 +1498,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-06-07T22:54:06+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.0",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0"
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -1563,7 +1566,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.0"
             },
             "funding": [
                 {
@@ -1579,27 +1582,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-06-02T12:23:43+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.9.0",
+            "version": "2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
+                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/bbb5e61349fa5cb822b3e87842b951088b76b81f",
+                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -1607,9 +1612,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
+                "http-interop/http-factory-tests": "1.1.0",
                 "jshttp/mime-db": "1.54.0.1",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -1680,7 +1685,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.11.0"
             },
             "funding": [
                 {
@@ -1696,20 +1701,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-10T16:41:02+00:00"
+            "time": "2026-06-02T12:30:48+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
-            "version": "v1.0.5",
+            "version": "v1.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/uri-template.git",
-                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1"
+                "reference": "7fe811c23a9e3cd712b4389eaeb50b5456d8c529"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/4f4bbd4e7172148801e76e3decc1e559bdee34e1",
-                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1",
+                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/7fe811c23a9e3cd712b4389eaeb50b5456d8c529",
+                "reference": "7fe811c23a9e3cd712b4389eaeb50b5456d8c529",
                 "shasum": ""
             },
             "require": {
@@ -1718,7 +1723,7 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "uri-template/tests": "1.0.0"
             },
             "type": "library",
@@ -1766,7 +1771,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/uri-template/issues",
-                "source": "https://github.com/guzzle/uri-template/tree/v1.0.5"
+                "source": "https://github.com/guzzle/uri-template/tree/v1.0.7"
             },
             "funding": [
                 {
@@ -1782,7 +1787,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:27:06+00:00"
+            "time": "2026-06-12T21:33:43+00:00"
         },
         {
             "name": "http-interop/http-factory-guzzle",
@@ -2142,16 +2147,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v10.50.0",
+            "version": "10.50.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "fc41c8ceb4d4a55b23d4030ef4ed86383e4b2bc3"
+                "reference": "3ff39b7a9b83e633383ec9b019827ed54b6d38bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/fc41c8ceb4d4a55b23d4030ef4ed86383e4b2bc3",
-                "reference": "fc41c8ceb4d4a55b23d4030ef4ed86383e4b2bc3",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/3ff39b7a9b83e633383ec9b019827ed54b6d38bc",
+                "reference": "3ff39b7a9b83e633383ec9b019827ed54b6d38bc",
                 "shasum": ""
             },
             "require": {
@@ -2346,7 +2351,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-11-28T18:20:42+00:00"
+            "time": "2026-02-15T14:12:07+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -2926,16 +2931,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "3.31.0",
+            "version": "3.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "1717e0b3642b0df65ecb0cc89cdd99fa840672ff"
+                "reference": "2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/1717e0b3642b0df65ecb0cc89cdd99fa840672ff",
-                "reference": "1717e0b3642b0df65ecb0cc89cdd99fa840672ff",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e",
+                "reference": "2daaac3b0d4c83ea7ed5d8586e786f5d00f3540e",
                 "shasum": ""
             },
             "require": {
@@ -3003,9 +3008,9 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.31.0"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.34.0"
             },
-            "time": "2026-01-23T15:38:47+00:00"
+            "time": "2026-05-14T10:28:08+00:00"
         },
         {
             "name": "league/flysystem-aws-s3-v3",
@@ -3579,16 +3584,16 @@
         },
         {
             "name": "nette/utils",
-            "version": "v4.1.3",
+            "version": "v4.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe"
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/bb3ea637e3d131d72acc033cfc2746ee893349fe",
-                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe",
+                "url": "https://api.github.com/repos/nette/utils/zipball/7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
                 "shasum": ""
             },
             "require": {
@@ -3664,9 +3669,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.1.3"
+                "source": "https://github.com/nette/utils/tree/v4.1.4"
             },
-            "time": "2026-02-13T03:05:33+00:00"
+            "time": "2026-05-11T20:49:54+00:00"
         },
         {
             "name": "nicmart/tree",
@@ -6477,16 +6482,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.32",
+            "version": "v6.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "0bc2199c6c1f05276b05956f1ddc63f6d7eb5fc3"
+                "reference": "d21b17ed158e79180fac3895ff751707970eeb57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/0bc2199c6c1f05276b05956f1ddc63f6d7eb5fc3",
-                "reference": "0bc2199c6c1f05276b05956f1ddc63f6d7eb5fc3",
+                "url": "https://api.github.com/repos/symfony/console/zipball/d21b17ed158e79180fac3895ff751707970eeb57",
+                "reference": "d21b17ed158e79180fac3895ff751707970eeb57",
                 "shasum": ""
             },
             "require": {
@@ -6551,7 +6556,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.32"
+                "source": "https://github.com/symfony/console/tree/v6.4.41"
             },
             "funding": [
                 {
@@ -6571,24 +6576,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-13T08:45:59+00:00"
+            "time": "2026-05-24T08:48:41+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v8.0.0",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "6225bd458c53ecdee056214cb4a2ffaf58bd592b"
+                "reference": "dc0e2be45c9b5588c82414f02ac574b4b986abcd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/6225bd458c53ecdee056214cb4a2ffaf58bd592b",
-                "reference": "6225bd458c53ecdee056214cb4a2ffaf58bd592b",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/dc0e2be45c9b5588c82414f02ac574b4b986abcd",
+                "reference": "dc0e2be45c9b5588c82414f02ac574b4b986abcd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4"
+                "php": ">=8.4.1"
             },
             "type": "library",
             "autoload": {
@@ -6620,7 +6625,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v8.0.0"
+                "source": "https://github.com/symfony/css-selector/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -6640,7 +6645,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-30T14:17:19+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -6786,16 +6791,16 @@
         },
         {
             "name": "symfony/error-handler",
-            "version": "v6.4.32",
+            "version": "v6.4.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "8c18400784fcb014dc73c8d5601a9576af7f8ad4"
+                "reference": "2ea68f0e1835ad6a126f93bbc14cd236c10ab361"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/8c18400784fcb014dc73c8d5601a9576af7f8ad4",
-                "reference": "8c18400784fcb014dc73c8d5601a9576af7f8ad4",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/2ea68f0e1835ad6a126f93bbc14cd236c10ab361",
+                "reference": "2ea68f0e1835ad6a126f93bbc14cd236c10ab361",
                 "shasum": ""
             },
             "require": {
@@ -6841,7 +6846,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v6.4.32"
+                "source": "https://github.com/symfony/error-handler/tree/v6.4.36"
             },
             "funding": [
                 {
@@ -6861,7 +6866,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-19T19:28:19+00:00"
+            "time": "2026-03-10T15:56:14+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -7030,20 +7035,21 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v8.0.6",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "7bf9162d7a0dff98d079b72948508fa48018a770"
+                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/7bf9162d7a0dff98d079b72948508fa48018a770",
-                "reference": "7bf9162d7a0dff98d079b72948508fa48018a770",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/99aec13b82b4967ec5088222c4a3ecca955949c2",
+                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8"
             },
@@ -7076,7 +7082,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v8.0.6"
+                "source": "https://github.com/symfony/filesystem/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -7096,20 +7102,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-25T16:59:43+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v6.4.33",
+            "version": "v6.4.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "24965ca011dac87431729640feef8bcf7b5523e0"
+                "reference": "9590e86be1d1c57bfbb16d0dd040345378c20896"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/24965ca011dac87431729640feef8bcf7b5523e0",
-                "reference": "24965ca011dac87431729640feef8bcf7b5523e0",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/9590e86be1d1c57bfbb16d0dd040345378c20896",
+                "reference": "9590e86be1d1c57bfbb16d0dd040345378c20896",
                 "shasum": ""
             },
             "require": {
@@ -7144,7 +7150,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v6.4.33"
+                "source": "https://github.com/symfony/finder/tree/v6.4.34"
             },
             "funding": [
                 {
@@ -7164,20 +7170,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-26T13:03:48+00:00"
+            "time": "2026-01-28T15:16:37+00:00"
         },
         {
             "name": "symfony/http-client",
-            "version": "v6.4.33",
+            "version": "v6.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "50e5386dbef6361b6c2d9a2eb22954f8525b8921"
+                "reference": "dd697006ca7f0fa40fa8575f331dabdba7473180"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/50e5386dbef6361b6c2d9a2eb22954f8525b8921",
-                "reference": "50e5386dbef6361b6c2d9a2eb22954f8525b8921",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/dd697006ca7f0fa40fa8575f331dabdba7473180",
+                "reference": "dd697006ca7f0fa40fa8575f331dabdba7473180",
                 "shasum": ""
             },
             "require": {
@@ -7242,7 +7248,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v6.4.33"
+                "source": "https://github.com/symfony/http-client/tree/v6.4.41"
             },
             "funding": [
                 {
@@ -7262,20 +7268,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-27T15:43:08+00:00"
+            "time": "2026-05-24T09:51:05+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "75d7043853a42837e68111812f4d964b01e5101c"
+                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/75d7043853a42837e68111812f4d964b01e5101c",
-                "reference": "75d7043853a42837e68111812f4d964b01e5101c",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
+                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
                 "shasum": ""
             },
             "require": {
@@ -7288,7 +7294,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -7324,7 +7330,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -7336,24 +7342,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-29T11:18:49+00:00"
+            "time": "2026-03-06T13:17:50+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v6.4.33",
+            "version": "v6.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "f1a490cc9d595ba7ebe684220e625d1e472ad278"
+                "reference": "48d76c29a67a301e0f7779a512bf76417395ffef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/f1a490cc9d595ba7ebe684220e625d1e472ad278",
-                "reference": "f1a490cc9d595ba7ebe684220e625d1e472ad278",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/48d76c29a67a301e0f7779a512bf76417395ffef",
+                "reference": "48d76c29a67a301e0f7779a512bf76417395ffef",
                 "shasum": ""
             },
             "require": {
@@ -7401,7 +7411,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v6.4.33"
+                "source": "https://github.com/symfony/http-foundation/tree/v6.4.41"
             },
             "funding": [
                 {
@@ -7421,20 +7431,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-27T15:04:55+00:00"
+            "time": "2026-05-24T10:54:17+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v6.4.33",
+            "version": "v6.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "73fa5c999d7f741ca544a97d3c791cc97890ae4d"
+                "reference": "155f6c1fa29720e8c947591da3be4014951fba6f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/73fa5c999d7f741ca544a97d3c791cc97890ae4d",
-                "reference": "73fa5c999d7f741ca544a97d3c791cc97890ae4d",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/155f6c1fa29720e8c947591da3be4014951fba6f",
+                "reference": "155f6c1fa29720e8c947591da3be4014951fba6f",
                 "shasum": ""
             },
             "require": {
@@ -7475,7 +7485,7 @@
                 "symfony/config": "^6.1|^7.0",
                 "symfony/console": "^5.4|^6.0|^7.0",
                 "symfony/css-selector": "^5.4|^6.0|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4.1|^7.0.1",
                 "symfony/dom-crawler": "^5.4|^6.0|^7.0",
                 "symfony/expression-language": "^5.4|^6.0|^7.0",
                 "symfony/finder": "^5.4|^6.0|^7.0",
@@ -7519,7 +7529,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v6.4.33"
+                "source": "https://github.com/symfony/http-kernel/tree/v6.4.41"
             },
             "funding": [
                 {
@@ -7539,7 +7549,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-28T10:02:13+00:00"
+            "time": "2026-05-27T08:22:22+00:00"
         },
         {
             "name": "symfony/mailer",
@@ -7789,16 +7799,16 @@
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v7.4.0",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "b38026df55197f9e39a44f3215788edf83187b80"
+                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/b38026df55197f9e39a44f3215788edf83187b80",
-                "reference": "b38026df55197f9e39a44f3215788edf83187b80",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
+                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
                 "shasum": ""
             },
             "require": {
@@ -7836,7 +7846,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v7.4.0"
+                "source": "https://github.com/symfony/options-resolver/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -7856,7 +7866,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-12T15:39:26+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -7943,16 +7953,16 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70"
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
                 "shasum": ""
             },
             "require": {
@@ -8001,7 +8011,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -8021,7 +8031,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T09:58:17+00:00"
+            "time": "2026-05-26T05:58:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
@@ -8197,16 +8207,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.38.1",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
-                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -8258,7 +8268,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -8278,7 +8288,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-26T12:51:13+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
@@ -8366,16 +8376,16 @@
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.33.0",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5"
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/17f6f9a6b1735c0f163024d959f700cfbc5155e5",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/796a26abb75ce49f3a84433cd81bf1009d73d5f8",
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8",
                 "shasum": ""
             },
             "require": {
@@ -8422,7 +8432,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -8442,20 +8452,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-08T02:45:35+00:00"
+            "time": "2026-05-27T06:51:48+00:00"
         },
         {
             "name": "symfony/polyfill-uuid",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-uuid.git",
-                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2"
+                "reference": "26dfec253c4cf3e51b541b52ddf7e42cb0908e94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
-                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
+                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/26dfec253c4cf3e51b541b52ddf7e42cb0908e94",
+                "reference": "26dfec253c4cf3e51b541b52ddf7e42cb0908e94",
                 "shasum": ""
             },
             "require": {
@@ -8505,7 +8515,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -8525,20 +8535,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v6.4.33",
+            "version": "v6.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "c46e854e79b52d07666e43924a20cb6dc546644e"
+                "reference": "c8fc09bdfe9fde9aaa89b415a4477feaccec16a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/c46e854e79b52d07666e43924a20cb6dc546644e",
-                "reference": "c46e854e79b52d07666e43924a20cb6dc546644e",
+                "url": "https://api.github.com/repos/symfony/process/zipball/c8fc09bdfe9fde9aaa89b415a4477feaccec16a7",
+                "reference": "c8fc09bdfe9fde9aaa89b415a4477feaccec16a7",
                 "shasum": ""
             },
             "require": {
@@ -8570,7 +8580,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.4.33"
+                "source": "https://github.com/symfony/process/tree/v6.4.41"
             },
             "funding": [
                 {
@@ -8590,7 +8600,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-23T16:02:12+00:00"
+            "time": "2026-05-23T13:47:21+00:00"
         },
         {
             "name": "symfony/psr-http-message-bridge",
@@ -8857,16 +8867,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.4.4",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "1c4b10461bf2ec27537b5f36105337262f5f5d6f"
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/1c4b10461bf2ec27537b5f36105337262f5f5d6f",
-                "reference": "1c4b10461bf2ec27537b5f36105337262f5f5d6f",
+                "url": "https://api.github.com/repos/symfony/string/zipball/961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
                 "shasum": ""
             },
             "require": {
@@ -8924,7 +8934,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.4.4"
+                "source": "https://github.com/symfony/string/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -8944,20 +8954,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-12T10:54:30+00:00"
+            "time": "2026-05-23T15:23:29+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v6.4.32",
+            "version": "v6.4.38",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "d6cc8e2fdd484f2f41d25938b0e8e3915de3cfbc"
+                "reference": "afaa31b0c12d9a659eed1ea97f268a614cc1299c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/d6cc8e2fdd484f2f41d25938b0e8e3915de3cfbc",
-                "reference": "d6cc8e2fdd484f2f41d25938b0e8e3915de3cfbc",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/afaa31b0c12d9a659eed1ea97f268a614cc1299c",
+                "reference": "afaa31b0c12d9a659eed1ea97f268a614cc1299c",
                 "shasum": ""
             },
             "require": {
@@ -9023,7 +9033,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v6.4.32"
+                "source": "https://github.com/symfony/translation/tree/v6.4.38"
             },
             "funding": [
                 {
@@ -9043,20 +9053,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-12T19:15:33+00:00"
+            "time": "2026-05-06T08:55:54+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "65a8bc82080447fae78373aa10f8d13b38338977"
+                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/65a8bc82080447fae78373aa10f8d13b38338977",
-                "reference": "65a8bc82080447fae78373aa10f8d13b38338977",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/0ab302977a952b42fd51475c4ebac81f8da0a95d",
+                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d",
                 "shasum": ""
             },
             "require": {
@@ -9069,7 +9079,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -9105,7 +9115,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -9125,7 +9135,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T13:41:35+00:00"
+            "time": "2026-01-05T13:30:16+00:00"
         },
         {
             "name": "symfony/uid",
@@ -9207,16 +9217,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v6.4.32",
+            "version": "v6.4.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "131fc9915e0343052af5ed5040401b481ca192aa"
+                "reference": "7c8ad9ce4faf6c8a99948e70ce02b601a0439782"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/131fc9915e0343052af5ed5040401b481ca192aa",
-                "reference": "131fc9915e0343052af5ed5040401b481ca192aa",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/7c8ad9ce4faf6c8a99948e70ce02b601a0439782",
+                "reference": "7c8ad9ce4faf6c8a99948e70ce02b601a0439782",
                 "shasum": ""
             },
             "require": {
@@ -9271,7 +9281,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v6.4.32"
+                "source": "https://github.com/symfony/var-dumper/tree/v6.4.36"
             },
             "funding": [
                 {
@@ -9291,7 +9301,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-01T13:34:06+00:00"
+            "time": "2026-03-30T15:36:00+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -9499,23 +9509,23 @@
         },
         {
             "name": "voku/portable-ascii",
-            "version": "2.0.3",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voku/portable-ascii.git",
-                "reference": "b1d923f88091c6bf09699efcd7c8a1b1bfd7351d"
+                "reference": "8e1051fe39379367aecf014f41744ce7539a856f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/b1d923f88091c6bf09699efcd7c8a1b1bfd7351d",
-                "reference": "b1d923f88091c6bf09699efcd7c8a1b1bfd7351d",
+                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/8e1051fe39379367aecf014f41744ce7539a856f",
+                "reference": "8e1051fe39379367aecf014f41744ce7539a856f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0.0"
+                "php": ">=7.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~6.0 || ~7.0 || ~9.0"
+                "phpunit/phpunit": "~8.5 || ~9.6 || ~10.5 || ~11.5"
             },
             "suggest": {
                 "ext-intl": "Use Intl for transliterator_transliterate() support"
@@ -9545,7 +9555,7 @@
             ],
             "support": {
                 "issues": "https://github.com/voku/portable-ascii/issues",
-                "source": "https://github.com/voku/portable-ascii/tree/2.0.3"
+                "source": "https://github.com/voku/portable-ascii/tree/2.1.1"
             },
             "funding": [
                 {
@@ -9569,7 +9579,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-21T01:49:47+00:00"
+            "time": "2026-04-26T05:33:54+00:00"
         }
     ],
     "packages-dev": [
@@ -10298,6 +10308,95 @@
             "time": "2024-03-22T22:46:32+00:00"
         },
         {
+            "name": "larastan/larastan",
+            "version": "v2.11.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/larastan/larastan.git",
+                "reference": "1aae902a5851c03dc1a58cbd9010a0c3ef8def63"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/larastan/larastan/zipball/1aae902a5851c03dc1a58cbd9010a0c3ef8def63",
+                "reference": "1aae902a5851c03dc1a58cbd9010a0c3ef8def63",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "iamcal/sql-parser": "^0.5.0",
+                "illuminate/console": "^9.52.20 || ^10.48.28 || ^11.41.3",
+                "illuminate/container": "^9.52.20 || ^10.48.28 || ^11.41.3",
+                "illuminate/contracts": "^9.52.20 || ^10.48.28 || ^11.41.3",
+                "illuminate/database": "^9.52.20 || ^10.48.28 || ^11.41.3",
+                "illuminate/http": "^9.52.20 || ^10.48.28 || ^11.41.3",
+                "illuminate/pipeline": "^9.52.20 || ^10.48.28 || ^11.41.3",
+                "illuminate/support": "^9.52.20 || ^10.48.28 || ^11.41.3",
+                "php": "^8.0.2",
+                "phpstan/phpstan": "^1.12.17"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^13",
+                "laravel/framework": "^9.52.20 || ^10.48.28 || ^11.41.3",
+                "mockery/mockery": "^1.5.1",
+                "nikic/php-parser": "^4.19.1",
+                "orchestra/canvas": "^7.11.1 || ^8.11.0 || ^9.0.2",
+                "orchestra/testbench-core": "^7.33.0 || ^8.13.0 || ^9.0.9",
+                "phpstan/phpstan-deprecation-rules": "^1.2",
+                "phpunit/phpunit": "^9.6.13 || ^10.5.16"
+            },
+            "suggest": {
+                "orchestra/testbench": "Using Larastan for analysing a package needs Testbench"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Larastan\\Larastan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Can Vural",
+                    "email": "can9119@gmail.com"
+                }
+            ],
+            "description": "Larastan - Discover bugs in your code without running it. A phpstan/phpstan extension for Laravel",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "larastan",
+                "laravel",
+                "package",
+                "php",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/larastan/larastan/issues",
+                "source": "https://github.com/larastan/larastan/tree/v2.11.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/canvural",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-06-10T22:06:33+00:00"
+        },
+        {
             "name": "laravel/dusk",
             "version": "v7.13.0",
             "source": {
@@ -10515,96 +10614,6 @@
                 }
             ],
             "time": "2025-08-01T08:46:24+00:00"
-        },
-        {
-            "name": "nunomaduro/larastan",
-            "version": "v2.11.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/larastan/larastan.git",
-                "reference": "1aae902a5851c03dc1a58cbd9010a0c3ef8def63"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/larastan/larastan/zipball/1aae902a5851c03dc1a58cbd9010a0c3ef8def63",
-                "reference": "1aae902a5851c03dc1a58cbd9010a0c3ef8def63",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "iamcal/sql-parser": "^0.5.0",
-                "illuminate/console": "^9.52.20 || ^10.48.28 || ^11.41.3",
-                "illuminate/container": "^9.52.20 || ^10.48.28 || ^11.41.3",
-                "illuminate/contracts": "^9.52.20 || ^10.48.28 || ^11.41.3",
-                "illuminate/database": "^9.52.20 || ^10.48.28 || ^11.41.3",
-                "illuminate/http": "^9.52.20 || ^10.48.28 || ^11.41.3",
-                "illuminate/pipeline": "^9.52.20 || ^10.48.28 || ^11.41.3",
-                "illuminate/support": "^9.52.20 || ^10.48.28 || ^11.41.3",
-                "php": "^8.0.2",
-                "phpstan/phpstan": "^1.12.17"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^13",
-                "laravel/framework": "^9.52.20 || ^10.48.28 || ^11.41.3",
-                "mockery/mockery": "^1.5.1",
-                "nikic/php-parser": "^4.19.1",
-                "orchestra/canvas": "^7.11.1 || ^8.11.0 || ^9.0.2",
-                "orchestra/testbench-core": "^7.33.0 || ^8.13.0 || ^9.0.9",
-                "phpstan/phpstan-deprecation-rules": "^1.2",
-                "phpunit/phpunit": "^9.6.13 || ^10.5.16"
-            },
-            "suggest": {
-                "orchestra/testbench": "Using Larastan for analysing a package needs Testbench"
-            },
-            "type": "phpstan-extension",
-            "extra": {
-                "phpstan": {
-                    "includes": [
-                        "extension.neon"
-                    ]
-                },
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Larastan\\Larastan\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Can Vural",
-                    "email": "can9119@gmail.com"
-                }
-            ],
-            "description": "Larastan - Discover bugs in your code without running it. A phpstan/phpstan extension for Laravel",
-            "keywords": [
-                "PHPStan",
-                "code analyse",
-                "code analysis",
-                "larastan",
-                "laravel",
-                "package",
-                "php",
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/larastan/larastan/issues",
-                "source": "https://github.com/larastan/larastan/tree/v2.11.2"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/canvural",
-                    "type": "github"
-                }
-            ],
-            "abandoned": "larastan/larastan",
-            "time": "2025-06-10T22:06:33+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -11024,11 +11033,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.32",
+            "version": "1.12.33",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/2770dcdf5078d0b0d53f94317e06affe88419aa8",
-                "reference": "2770dcdf5078d0b0d53f94317e06affe88419aa8",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/37982d6fc7cbb746dda7773530cda557cdf119e1",
+                "reference": "37982d6fc7cbb746dda7773530cda557cdf119e1",
                 "shasum": ""
             },
             "require": {
@@ -11073,7 +11082,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-30T10:16:31+00:00"
+            "time": "2026-02-28T20:30:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/config/cors.php
+++ b/config/cors.php
@@ -1,7 +1,49 @@
 <?php
+
+/*
+ | CORS origins.
+ |
+ | Production origins are always allowed. Development / preview origins
+ | (localhost, plain-http, and Vercel preview deployments) are only added
+ | outside production, so a permissive policy never ships to prod. Additional
+ | origins can be supplied per-environment via CORS_EXTRA_ORIGINS
+ | (comma-separated). supports_credentials stays false, so these origins
+ | cannot be used to ride a session cookie.
+ */
+
+$prodOrigins = [
+    env('APP_URL', 'https://arcane.city'),
+    'https://dev.arcane.city',
+    'https://beta.arcane.city',
+    'https://arcane-city-frontend.vercel.app',
+    'https://api.arcane.city',
+];
+
+$devOrigins = [
+    'http://beta.arcane.city',
+    'http://api.arcane.city',
+    'http://localhost:3000',
+    'http://localhost:5173',
+];
+
+// Note: a literal '*' in allowed_origins is matched verbatim and never fires;
+// wildcards must be regexes in allowed_origins_patterns.
+$devOriginPatterns = [
+    '#^https://.*geoffmaddocks-projects\.vercel\.app$#',
+];
+
+$extraOrigins = array_values(array_filter(array_map('trim', explode(',', (string) env('CORS_EXTRA_ORIGINS', '')))));
+
+$isProduction = env('APP_ENV', 'production') === 'production';
+
 return [
     'paths' => ['api/*'],
-    'allowed_origins' => [env('APP_URL', 'https://arcane.city'),'https://dev.arcane.city','http://beta.arcane.city','https://beta.arcane.city','http://localhost:3000','http://localhost:5173','https://arcane-city-frontend.vercel.app','https://*geoffmaddocks-projects.vercel.app', 'http://api.arcane.city', 'https://api.arcane.city'],
+    'allowed_origins' => array_values(array_unique(array_merge(
+        $prodOrigins,
+        $isProduction ? [] : $devOrigins,
+        $extraOrigins,
+    ))),
+    'allowed_origins_patterns' => $isProduction ? [] : $devOriginPatterns,
     'allowed_methods' => ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
     'allowed_headers' => ['Content-Type', 'Authorization'],
     'exposed_headers' => [],

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -46,7 +46,7 @@ return [
     |
     */
 
-    'expiration' => null,
+    'expiration' => env('SANCTUM_TOKEN_EXPIRATION', 60 * 24 * 30),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/secure-headers.php
+++ b/config/secure-headers.php
@@ -39,7 +39,7 @@ return [
      * Available Value: 'deny', 'sameorigin', 'allow-from <uri>'
      */
 
-    //    'x-frame-options' => 'sameorigin',
+    'x-frame-options' => 'sameorigin',
 
     /*
      * X-Permitted-Cross-Domain-Policies

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,11 @@
                 "dotenv": "^16.0",
                 "dropzone": "^6.0.0-beta.1",
                 "flatpickr": "^4.6.13",
-                "fs": "0.0.1-security",
                 "fullcalendar": "^6.1.11",
                 "jquery": "^3.5.1",
                 "laravel-echo": "^1.6.1",
                 "lightbox2": "^2.11.1",
                 "moment": "^2.29.4",
-                "save-dev": "0.0.1-security",
                 "select2": "^4.1.0-rc.0",
                 "swagger-ui": "^5.32.1",
                 "sweetalert2": "^11.22"
@@ -30,7 +28,7 @@
                 "axios": "^1.16.0",
                 "cross-env": "^7",
                 "eslint": "^10.0.1",
-                "laravel-vite-plugin": "^2.1.0",
+                "laravel-vite-plugin": "^3.1.0",
                 "lodash": "^4.17.23",
                 "postcss": "^8.5.13",
                 "prettier": "^3.2.0",
@@ -38,7 +36,7 @@
                 "pusher-js": "^8.4.0-rc2",
                 "sass": "^1.56.1",
                 "tailwindcss": "^4.1.12",
-                "vite": "^7.3.2",
+                "vite": "^8.0.0",
                 "vue": "^3.2"
             },
             "engines": {
@@ -102,10 +100,9 @@
             }
         },
         "node_modules/@babel/runtime-corejs3": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz",
-            "integrity": "sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==",
-            "license": "MIT",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.7.tgz",
+            "integrity": "sha512-ppj9ouYku+RX0ljtgZd+KMO5mkM2bCqg8H2PYAFWnLsHEIKIdRojqbJ2i3eVHrisuxy7nOFCmngTDdWtUCdXUQ==",
             "dependencies": {
                 "core-js-pure": "^3.48.0"
             },
@@ -127,446 +124,35 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-            "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
-            "cpu": [
-                "ppc64"
-            ],
+        "node_modules/@emnapi/core": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
             "dev": true,
-            "license": "MIT",
             "optional": true,
-            "os": [
-                "aix"
-            ],
-            "engines": {
-                "node": ">=18"
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.1",
+                "tslib": "^2.4.0"
             }
         },
-        "node_modules/@esbuild/android-arm": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-            "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
-            "cpu": [
-                "arm"
-            ],
+        "node_modules/@emnapi/runtime": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
             "dev": true,
-            "license": "MIT",
             "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
+            "dependencies": {
+                "tslib": "^2.4.0"
             }
         },
-        "node_modules/@esbuild/android-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-            "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
-            "cpu": [
-                "arm64"
-            ],
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
             "dev": true,
-            "license": "MIT",
             "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/android-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-            "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-            "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/darwin-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-            "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-            "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-            "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-arm": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-            "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-            "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-ia32": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-            "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-loong64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-            "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
-            "cpu": [
-                "loong64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-            "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
-            "cpu": [
-                "mips64el"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-            "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-            "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-s390x": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-            "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
-            "cpu": [
-                "s390x"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-            "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-            "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-            "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-            "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-            "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-            "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openharmony"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/sunos-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-            "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "sunos"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/win32-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-            "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/win32-ia32": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-            "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/win32-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-            "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
+            "dependencies": {
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -828,6 +414,33 @@
             "version": "0.3.4",
             "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
             "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="
+        },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+            "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@tybys/wasm-util": "^0.10.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
+            }
+        },
+        "node_modules/@oxc-project/types": {
+            "version": "0.133.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+            "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
         },
         "node_modules/@parcel/watcher": {
             "version": "2.5.0",
@@ -1125,371 +738,267 @@
                 "url": "https://opencollective.com/parcel"
             }
         },
-        "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-            "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ]
-        },
-        "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-            "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+            "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-            "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+            "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-            "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+            "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
-            ]
-        },
-        "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-            "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
-            "cpu": [
-                "arm64"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-            "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+            "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-            "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+            "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-            "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
-            "cpu": [
-                "arm"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-            "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+            "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-            "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+            "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-            "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
-            "cpu": [
-                "loong64"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-loong64-musl": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-            "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
-            "cpu": [
-                "loong64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-            "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+            "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-            "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
-            "cpu": [
-                "ppc64"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-            "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-            "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-            "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+            "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-            "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+            "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-            "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+            "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-openbsd-x64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-            "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
-            "cpu": [
-                "x64"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-            "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+            "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "openharmony"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-            "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+            "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "1.10.0",
+                "@emnapi/runtime": "1.10.0",
+                "@napi-rs/wasm-runtime": "^1.1.4"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+            "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
-            ]
-        },
-        "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-            "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
-            "cpu": [
-                "ia32"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-            "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+            "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
-            ]
-        },
-        "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-            "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
-            "cpu": [
-                "x64"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+            "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+            "dev": true
         },
         "node_modules/@scarf/scarf": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
             "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
-            "hasInstallScript": true,
-            "license": "Apache-2.0"
+            "hasInstallScript": true
         },
         "node_modules/@swagger-api/apidom-ast": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.8.0.tgz",
-            "integrity": "sha512-cpYLFeXusH9kN1ekaTbb9rG8HYFYtqZeiAAB4WaA1YmMkzf5bHSKqsrMFVKwupwdKTxxkmmlsLqGjy1HOIxFlQ==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.11.2.tgz",
+            "integrity": "sha512-keG5q/AR0zIizKCcfcUKiDXDQscw27SyILFb0kFmVWlgv3JTP+8pdXjzCEFW+C8RKg/etap270jv2s8B6ghuXA==",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-error": "^1.8.0",
+                "@swagger-api/apidom-error": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1497,14 +1006,13 @@
             }
         },
         "node_modules/@swagger-api/apidom-core": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.8.0.tgz",
-            "integrity": "sha512-iJavkTVvf5iRMYG0W5XPM33A6BypWvEVrnXfl0hiUL7AEV1ZcDLjyxvmS4CqYdaB4oiSVpClMlJZZqUI1yt0rg==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.11.2.tgz",
+            "integrity": "sha512-ZXxaL1MxE1JWq7HDrifPI89migiy0clYpXMzSc+3FIOPfOaKrdfbF5DKG6r3aQOByfd3jrsFVwMpoL7rRjFkHg==",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-ast": "^1.8.0",
-                "@swagger-api/apidom-error": "^1.8.0",
+                "@swagger-api/apidom-ast": "^1.11.2",
+                "@swagger-api/apidom-error": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "minim": "~0.23.8",
                 "ramda": "~0.30.0",
@@ -1514,37 +1022,34 @@
             }
         },
         "node_modules/@swagger-api/apidom-error": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.8.0.tgz",
-            "integrity": "sha512-Bbqr15CpSbexdQYr4Z7sI6UGQw650nDrynQkGXu7NEWO/kGM43RexvkrIGHfOLlf4gA71qRO630KYe+/+b62/Q==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.11.2.tgz",
+            "integrity": "sha512-U96v+tAad0rshqFX22A8ILfWEHz/z3aAtff/HrZk6dCDuoW98kKRySBDbXq2KCa9uMaJQt9C0bxx9DC/1yPYVA==",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.20.7"
             }
         },
         "node_modules/@swagger-api/apidom-json-pointer": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.8.0.tgz",
-            "integrity": "sha512-r00Tl0MDdiKowH6xSzVAdwGnNIQ7uFPfxFJHcDnA/lZ8S1mUTHToaoq3ZiEtErdkM4Qvb6r2kUo7gjuX4cyZvA==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.11.2.tgz",
+            "integrity": "sha512-Udx0F052IFVXVFLB7q6uLdqn7HV0obFGRoHMWglQXdK3587Ln/0Ct6A+7Q1QEeuMlKmLCTa9YrcC/ButsF3F/g==",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-error": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-error": "^1.11.2",
                 "@swaggerexpert/json-pointer": "^2.10.1"
             }
         },
         "node_modules/@swagger-api/apidom-ns-api-design-systems": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.8.0.tgz",
-            "integrity": "sha512-3jFySxvBDnsPg7B4hPGqWmlRm2o6mOViyKWKXT2cHixjPP7ZxvCaj8bdSQhmOaZrdgMM+9JUXpY8yZz6UdNrig==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.11.2.tgz",
+            "integrity": "sha512-vKWtEn/XLABDUrRL8zajmQdqHMRO7pC7QowhuZr7abiH1NIolQqKixEi88MQLKeh+QJ7QQLq4YJlsQ543IHt+Q==",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-error": "^1.8.0",
-                "@swagger-api/apidom-ns-openapi-3-1": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-error": "^1.11.2",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1552,15 +1057,14 @@
             }
         },
         "node_modules/@swagger-api/apidom-ns-arazzo-1": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-1.8.0.tgz",
-            "integrity": "sha512-CQ2+FbsZgcBcEY9PSfqvG1vRDSUjj+wfILGbhd9/EitF6E1hdur+ahUNPObW8qBHN/nOvo+cRtoGMTP1ZB8i3Q==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-1.11.2.tgz",
+            "integrity": "sha512-2ojvpWrlMgG0/hNMQMWEQ9cZP07ZvUQ2vez7Pws8plxQQY9DklQfmZpgElLfiup2ckYGqJ3VTxb5x36CaGJ07w==",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-ns-json-schema-2020-12": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1568,15 +1072,14 @@
             }
         },
         "node_modules/@swagger-api/apidom-ns-asyncapi-2": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.8.0.tgz",
-            "integrity": "sha512-COFbS2FoUOIUEz7+Sq9NHwsidBPZ0aqQu3/TXID2O+kx4MfZmnGrpuJliwYeB73gkI4o2JhT28fB1Jb+pmul7Q==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.11.2.tgz",
+            "integrity": "sha512-hIgphPTfETYe582dJhy8bTU+EPcXhdATnniynYkmKQ0mmMC/im77cBjoOyFRUzAyAeOWD1WpWEoQBStxa1YYzQ==",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-ns-json-schema-draft-7": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-ns-json-schema-draft-7": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1584,15 +1087,14 @@
             }
         },
         "node_modules/@swagger-api/apidom-ns-asyncapi-3": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-3/-/apidom-ns-asyncapi-3-1.8.0.tgz",
-            "integrity": "sha512-kC6mxmh+x+qpyZvxAA2C0BURUtnCVpNRvcjrnzMEShA4mderW+e6uD6rtmr3DxbBt+BGIQE9eXtCOW1q+aPOUQ==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-3/-/apidom-ns-asyncapi-3-1.11.2.tgz",
+            "integrity": "sha512-p4K/tsnIAVa7Z4ey4MmSR639SlwHbRH/zWWfZ2PyyMkpTUHNTcPK9kVTck7s3n10amHWn09SKWgVa506W269SQ==",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-ns-asyncapi-2": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-ns-asyncapi-2": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1600,15 +1102,14 @@
             }
         },
         "node_modules/@swagger-api/apidom-ns-json-schema-2019-09": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-1.8.0.tgz",
-            "integrity": "sha512-ipyiN63PpMccMpC6K95yl0MZOjFGMlCGtphKE9j1W2Hj8Poxirdlo8NpYOioqC2uJlEwb+fm0Ue2ysFdFkG0Ng==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-1.11.2.tgz",
+            "integrity": "sha512-QFxx47skbBLDtbKeBj5Sa1p3cMbN1xspPIQs5EaTcPcx4SxzMtJlWqfMRtwgkxh1nlCrPwMHZBNq+oJ1ZFWB6A==",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-error": "^1.8.0",
-                "@swagger-api/apidom-ns-json-schema-draft-7": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-error": "^1.11.2",
+                "@swagger-api/apidom-ns-json-schema-draft-7": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1616,15 +1117,14 @@
             }
         },
         "node_modules/@swagger-api/apidom-ns-json-schema-2020-12": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-1.8.0.tgz",
-            "integrity": "sha512-v1RdzxUcGv6RtXYLKd5qh8asPWzSrbDkEwHgV0JitzwQd8sd0Vu3ey8JaIuG3ZTsndS7qHOQG9Xdu+rqtjEXxQ==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-1.11.2.tgz",
+            "integrity": "sha512-twf6oMAv7bM6CAz8giSw2YcYgsy5niSlrCwLQfeKg1MxaRhDL1d/Ym8EWFCNwHuV/hI/vJn/HBHRuCKwK9XkUA==",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-error": "^1.8.0",
-                "@swagger-api/apidom-ns-json-schema-2019-09": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-error": "^1.11.2",
+                "@swagger-api/apidom-ns-json-schema-2019-09": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1632,14 +1132,13 @@
             }
         },
         "node_modules/@swagger-api/apidom-ns-json-schema-draft-4": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.8.0.tgz",
-            "integrity": "sha512-UOvfkK2Dl158IZ2wCYcE1z2YcPZDPKMe6U0OdwBoftM8sWd19GU6a6jyUw2AKSofCdmPWEIRvZNYHvDcue1cbA==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.11.2.tgz",
+            "integrity": "sha512-OMbpfkaoot7yDMGgpIULYZdo4gNZIf84KXvgpJDk2Y/etEMLozV2JWktAq6niV1VwKis1Zwovuk0L4lOCucWIg==",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-ast": "^1.8.0",
-                "@swagger-api/apidom-core": "^1.8.0",
+                "@swagger-api/apidom-ast": "^1.11.2",
+                "@swagger-api/apidom-core": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1647,15 +1146,14 @@
             }
         },
         "node_modules/@swagger-api/apidom-ns-json-schema-draft-6": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.8.0.tgz",
-            "integrity": "sha512-RlO/P8VpQ55hhrP4MMf9wyiBWBbrEnEhN1MtTIyF/P04+WxRBPCOVmAFiCJ9DAI6ppJIU+PBn/5wF7mpUCmA6Q==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.11.2.tgz",
+            "integrity": "sha512-zoUaG+bNBbrzYNv/2K0ijJTwe0g5ljKlXTqC9Fqrobeau/COrYD5Z2ZPTOUASba6Kn3QapICzNDUGnJVyrE6EA==",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-error": "^1.8.0",
-                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-error": "^1.11.2",
+                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1663,15 +1161,14 @@
             }
         },
         "node_modules/@swagger-api/apidom-ns-json-schema-draft-7": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.8.0.tgz",
-            "integrity": "sha512-RDY2TxaJ/wCUBDq9ZqLM8E9Ub4kSyJ5USqjp5HsgRkYOkXKZzXKnEDwtTz2ZO4s+9ocjQMMEtWNvpCHYTR/JFA==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.11.2.tgz",
+            "integrity": "sha512-fmfqYuoxpWxEIHYTZuMUCOeb/ilihc5lFMRBLB3wwZiZe+srTPoqAsm9qiSF6FKsDMUysiWKl6NYWLQ09K7Qvw==",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-error": "^1.8.0",
-                "@swagger-api/apidom-ns-json-schema-draft-6": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-error": "^1.11.2",
+                "@swagger-api/apidom-ns-json-schema-draft-6": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1679,16 +1176,15 @@
             }
         },
         "node_modules/@swagger-api/apidom-ns-openapi-2": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.8.0.tgz",
-            "integrity": "sha512-9GZDWZc28RcpuinZjSnK7L6TVKtBYKb3n0SGqITKfNp2CRKcEwIeyenQjiES4/lwcT3VYIROByG89+6KHX6p2w==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.11.2.tgz",
+            "integrity": "sha512-Lq23xu8HXf1M0Z4raw/6d0y4UwjpaBh5bPhhoiRfOAuRIsyDUO4rCDDiT+np/r5jtkM7haexmaLHMkEdknsepA==",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-error": "^1.8.0",
-                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-error": "^1.11.2",
+                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1696,15 +1192,14 @@
             }
         },
         "node_modules/@swagger-api/apidom-ns-openapi-3-0": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.8.0.tgz",
-            "integrity": "sha512-c1OcjKo/WDd13b08WW1ENm2tArYJunO2SsRnqhg//Z6UOJl+5q4ykIWi96zx/yxh6+kPFVCylU5Mxl+eNW35ng==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.11.2.tgz",
+            "integrity": "sha512-XNBJzeSTQvKvuCeC2XCXL7ix4qGXQY6fPddsPSLaEW0XnFddjuASymqivaUbekPgLXs65/OdPqX5jFo/6W6t/A==",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-error": "^1.8.0",
-                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-error": "^1.11.2",
+                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1712,17 +1207,16 @@
             }
         },
         "node_modules/@swagger-api/apidom-ns-openapi-3-1": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.8.0.tgz",
-            "integrity": "sha512-l19IeQG8I2i3510jNd7OO99f1hqV6zlVkHNKgLSsjufMjIP30p8iJ1tz6QPoVxC5S8ZRCijEUCo0rsyVpITV0g==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.11.2.tgz",
+            "integrity": "sha512-me2giRgbYEryanIBQa6sZiQ2XPVRvrC4KI4J8dZfy/uEALB60CwPAQKMLMhhlIxrXb3AYrHgbSO33hVA6Z3Oxg==",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-ast": "^1.8.0",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-json-pointer": "^1.8.0",
-                "@swagger-api/apidom-ns-json-schema-2020-12": "^1.8.0",
-                "@swagger-api/apidom-ns-openapi-3-0": "^1.8.0",
+                "@swagger-api/apidom-ast": "^1.11.2",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-json-pointer": "^1.11.2",
+                "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.2",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1730,18 +1224,17 @@
             }
         },
         "node_modules/@swagger-api/apidom-ns-openapi-3-2": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-2/-/apidom-ns-openapi-3-2-1.8.0.tgz",
-            "integrity": "sha512-RJqLKqXV1x9N358PXzD5tIS3fhGVP1axIZBXFfV3pI/1QFprUq0qjxU0yyW26BRsP81ZXHY/41WIwBPmeDLJXA==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-2/-/apidom-ns-openapi-3-2-1.11.2.tgz",
+            "integrity": "sha512-JjJhddUc+4Uaj+scL0WCjmYiKrnjxKF0hI1wvfVHDqIBJCXJPsuKG5g/EQYHd1Xi9b5ruX0O/PH9PCR7/lvThA==",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-ast": "^1.8.0",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-json-pointer": "^1.8.0",
-                "@swagger-api/apidom-ns-json-schema-2020-12": "^1.8.0",
-                "@swagger-api/apidom-ns-openapi-3-0": "^1.8.0",
-                "@swagger-api/apidom-ns-openapi-3-1": "^1.8.0",
+                "@swagger-api/apidom-ast": "^1.11.2",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-json-pointer": "^1.11.2",
+                "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.2",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.11.2",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1749,144 +1242,135 @@
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.8.0.tgz",
-            "integrity": "sha512-gFvwDoMOLHsWGCQk+zuA9bBR76jNhNaUlhElnvAARllYosmwuYNh0AnLfXCs2+r8j6Oy0WxZs/cIsRmspiDtTQ==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.11.2.tgz",
+            "integrity": "sha512-HvANhGWUTQqRuY4+2BhQ3QzkhaguXe/+VO3as1Ybqy7lr3DFDNimpDhzPOZqx2e5i5ADLmwfWUmMbMJ/mE2xng==",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-ns-api-design-systems": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-json": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-ns-api-design-systems": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.8.0.tgz",
-            "integrity": "sha512-DgeQibnf0j9A22XsaMDl+JNrrP3TJYODh4+YNkKPds6m7rBYv89wloC7cNs2fFZphY87sfhF3B2Bckp3CeR7IQ==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.11.2.tgz",
+            "integrity": "sha512-liebkLeHDjXIybPher1Z1uMq8ZxCln+fFcVcLZSXkBXEPrPUueAd08K4Xpv5lVRh/p/cPg12b8dZH3F/HuoOfQ==",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-ns-api-design-systems": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-ns-api-design-systems": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-arazzo-json-1": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-1.8.0.tgz",
-            "integrity": "sha512-a10UIWrV3GTOqugX83qvWZR/UjwQJffrVQ6OdD27GkhwXk0+58As551Hu5NW1W/BIgHHKlhsAmgndgE/jlz4Jg==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-1.11.2.tgz",
+            "integrity": "sha512-Q8nQobgCzlgkxjA+ICwPS/SbW/3T/PMhV8UjDBqdiSPU3zKDOsOPKFQViGddRWBhAG5LJmV9GlhMPlmc6KLzSA==",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-ns-arazzo-1": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-json": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-ns-arazzo-1": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-arazzo-yaml-1": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-1.8.0.tgz",
-            "integrity": "sha512-eK7XRuGMxQKI3R13IWki1IRzoJ6kYTkOrg9bRGaw2JmsgHHFeXVBbYTABRDsYRLe0kG7LU4Kk8OaKSqmq/IuZw==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-1.11.2.tgz",
+            "integrity": "sha512-cnJggQWPUSdUZ0qsIaMVEKlVT7U3+u/bdqFRDio5+cdslaoRhO7VG8jCCWCacdCHVr/jFleJ3RkT8C6VWJ+CRg==",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-ns-arazzo-1": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-ns-arazzo-1": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.8.0.tgz",
-            "integrity": "sha512-YqcrODYnlsPBghJL6hlCMVhqdjHhCresL6SpO55eoYvFJGABtl+wgYjVN5Ddug9PAw/25c9vLpth4sYb0m9+oQ==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.11.2.tgz",
+            "integrity": "sha512-Ts2c6XVgzJ5x30Y+RzOeQZ0+XlIBX/YWqxg2D8bIoQPaLmfSFDaZskb0FfxSCpox4OjyOXxbLPYib2IEPf9ZXg==",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-ns-asyncapi-2": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-json": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-ns-asyncapi-2": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-3": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-3/-/apidom-parser-adapter-asyncapi-json-3-1.8.0.tgz",
-            "integrity": "sha512-3oKgsXR/UmFwSXDsmM6eNObLy93VJZethhzp3bCC/Br83w8V/tkBNIXcWZs0xx2crqYDnROr20jy4Qtq6SqoCw==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-3/-/apidom-parser-adapter-asyncapi-json-3-1.11.2.tgz",
+            "integrity": "sha512-43W+ncs8VwFO3U45qxvrCWjUN1nuup9i1DJCj75x3AG1XCqyFMRcUhzMUWdEs2KykvKws/DvyaTMmy555bMflA==",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-ns-asyncapi-3": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-json": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-ns-asyncapi-3": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.8.0.tgz",
-            "integrity": "sha512-HvK2+6dlD2Q7SMHbgsFXGpDL5uiCxu4N8oOXVuy1OeapoQRxzB0LZae/rKrXj/YDITc1xQ9cbQyTsEM+Hfa2bA==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.11.2.tgz",
+            "integrity": "sha512-kTV7VhOrPrqe/wwNcmEzP1J49iyAJybrIwHswpr0e5mDExREb9U9BNkOS7SbVjQhP9KHLYhXSHhn0bBAet22CQ==",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-ns-asyncapi-2": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-ns-asyncapi-2": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3/-/apidom-parser-adapter-asyncapi-yaml-3-1.8.0.tgz",
-            "integrity": "sha512-ekIRVp20kntmCabQKmsEoXp6LVAqCf1MJRU94tx+n9NfAL68OVYF/47qxP5IXRyPSapa18oAAUDm09qfAg/8Uw==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3/-/apidom-parser-adapter-asyncapi-yaml-3-1.11.2.tgz",
+            "integrity": "sha512-LdTRYIYLlS4U2fp8bt8BFBo4HQrXXIN7z0MuH5Vv853l06oBg2brvToCmGsfIjdwVHjvS0MXKxriSc1dvl93qg==",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-ns-asyncapi-3": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-ns-asyncapi-3": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-json": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.8.0.tgz",
-            "integrity": "sha512-hlbtGgsnLumr5LHTxuJrc6d2uDGtbhEikVQGF7UHL2rMMmPBGCIASC1HbdmkFohXFf5I80s7TuMEnelvvGwxIQ==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.11.2.tgz",
+            "integrity": "sha512-OPirA1EczgSDtkXz+HU5YPl6gIDf4FdamcNPd96/H/9I4aDBkNF5XviPPuh8yCgYdXNElvR4FC1OB67X2JslgA==",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-ast": "^1.8.0",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-error": "^1.8.0",
+                "@swagger-api/apidom-ast": "^1.11.2",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-error": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1896,144 +1380,135 @@
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-2": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.8.0.tgz",
-            "integrity": "sha512-MnuhZKGzQC/MnLADuLyWZnpAcc5Vw9UoUctEkVovADSMfuHKDHg3sCNc2cB1cOB+BjWrWU4L/Vys8TUfS4866g==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.11.2.tgz",
+            "integrity": "sha512-zl6XA49VcG3EEJYWk2PZqsWzAx7BrxwMZCR+8j7S2yaILqEJp+sfkMrzbfmYznXz8tQdoR7XtLjpVT+M/qzNaA==",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-ns-openapi-2": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-json": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-ns-openapi-2": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.8.0.tgz",
-            "integrity": "sha512-mjhDbnW2MkgZ5C2iJgMPZvvOL3MLYkwwwwjGekiCo0IjcWMBUdJ6ArOS3zOjQ5NMbKu1XbYmt4/D53fFLIFcwA==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.11.2.tgz",
+            "integrity": "sha512-+jGp8T+mP0jtqZ9iOUrcS/7o5InGG+dBVTdLmOOtbxgdF4LoXlxKGj8SBFpQrHuAuVb8R7d9SOza5mSvhSeSjg==",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-ns-openapi-3-0": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-json": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.8.0.tgz",
-            "integrity": "sha512-nA9AQuGsd1YqZ9QG8CRW0f4YHU9ryY+uU8nevprSiRuAi1FQJPrS30eUgnEs7x1Em7QKU43QmSZmWYpyJCdQZA==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.11.2.tgz",
+            "integrity": "sha512-+dxJNNDUwAjapijVk/S8X6lbi+wtpdbAit84V8En6HK7D2hvZtebTO8/8saSi57utpJ04hm244EZtMlmIy6G0A==",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-ns-openapi-3-1": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-json": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-2": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-2/-/apidom-parser-adapter-openapi-json-3-2-1.8.0.tgz",
-            "integrity": "sha512-FC/Ktls4mNKY2MtHNmpPHXk5c6sD21dcaHmGGQH+wdovBlei3/xCiWOjYeT+Pr6A1mvMIG5cRhBjra3l5Jdhgw==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-2/-/apidom-parser-adapter-openapi-json-3-2-1.11.2.tgz",
+            "integrity": "sha512-rY7wBmD0Tfg5M1PVRTysCveFM721YbXkE0ZsU9zAVurSqBIn2UOX8KbqtMEjNJaz0nw0ekcDITwUIYSzObE2gg==",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-ns-openapi-3-2": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-json": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-ns-openapi-3-2": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-2": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.8.0.tgz",
-            "integrity": "sha512-GAc2Ckr5FXvNm8Deh/NnUdQzcqhns/hxysYI9tikhxc14y1rytzmX81ATpVnKouHkZqXXNgDYhoFVG5+QFJYdg==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.11.2.tgz",
+            "integrity": "sha512-DLgvZp0hxW67/0LQ69ulKvfQPkxONIdO/Gg1Dz7iYLWKy7RD/pPdfPBrEShujWksPd7yP2DURWb1YKy4yHfyBw==",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-ns-openapi-2": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-ns-openapi-2": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.8.0.tgz",
-            "integrity": "sha512-f9AFCXgdqA1xbUrTCcQ0NqarQqBhpw79M5rmhu5R51pHtaVx9N+FxlHMqGYsdL9/Opq3eKtsd0in0JBC77qZEQ==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.11.2.tgz",
+            "integrity": "sha512-ExQpftF3fjGvFKMn5fpyEOsFJXpuUy5YngguR/3IS/jY1oXc9HD6kDCYtcbkFLOO0x0qGdarQ4nxFzAWTitcUQ==",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-ns-openapi-3-0": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.8.0.tgz",
-            "integrity": "sha512-zmWJAspilTYZm6ZtpQJ65U1S+d+wOk6Wwi3TJkRmNDIygmY3jrBEpS65Lrc6D/Mk1bwsKyZN095cXAxCPajt8g==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.11.2.tgz",
+            "integrity": "sha512-GDMMN30Iv8ckWpz/jWjRb7jpkbCdg2/K2a0O7OkyrbsA7XC10WexRp6FehhBBrVPVbZdxQeLIo4wWOHMY3n6yA==",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-ns-openapi-3-1": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2/-/apidom-parser-adapter-openapi-yaml-3-2-1.8.0.tgz",
-            "integrity": "sha512-V6Q48ihqpX/IJ98MF9DUpwhGUzN+ZKLQEQm8M7He51geAsKillxDSHOFltdH38BCGW+CpbkEWnWRmzgV4ehjIA==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2/-/apidom-parser-adapter-openapi-yaml-3-2-1.11.2.tgz",
+            "integrity": "sha512-UQwIUXctN7cF1yvEzhqMP64w5ykOcUkD/ndVks+J9lYCgcdBnWRJ46V6nQhs6crFnSQIYzppDHF0uyd2mJAprA==",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-ns-openapi-3-2": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-ns-openapi-3-2": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.2",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.8.0.tgz",
-            "integrity": "sha512-uUhXEXwK4G3cVO52cTzoJG6Sbke8pgEFXHK+LMIXTZ0zb3gVfGD4N9bDyGB8Uibr41fK3DjUycIx5x9ZsR8l+Q==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.11.2.tgz",
+            "integrity": "sha512-wzrCB+GKkuhN0T7YcNfbI81HfB3yVBT1RUD+W0huOB6zIOaXQMaQKT+fcZ/BPNCTyuvzeevzwdtoYUYKP/H6Ow==",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-ast": "^1.8.0",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-error": "^1.8.0",
+                "@swagger-api/apidom-ast": "^1.11.2",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-error": "^1.11.2",
                 "@tree-sitter-grammars/tree-sitter-yaml": "=0.7.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
@@ -2047,7 +1522,6 @@
             "resolved": "https://registry.npmjs.org/@tree-sitter-grammars/tree-sitter-yaml/-/tree-sitter-yaml-0.7.1.tgz",
             "integrity": "sha512-AynBwkIoQCTgjDR33bDUp9Mqq+YTco0is3n5hRApMqG9of/6A4eQsfC1/uSEeHSUyMQSYawcAWamsexnVpIP4Q==",
             "hasInstallScript": true,
-            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "node-addon-api": "^8.3.1",
@@ -2063,10 +1537,9 @@
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/node-addon-api": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
-            "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
-            "license": "MIT",
+            "version": "8.8.0",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
+            "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
             "optional": true,
             "engines": {
                 "node": "^18 || ^20 || >= 21"
@@ -2077,7 +1550,6 @@
             "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
             "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
             "hasInstallScript": true,
-            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "node-addon-api": "^8.3.0",
@@ -2085,53 +1557,51 @@
             }
         },
         "node_modules/@swagger-api/apidom-reference": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.8.0.tgz",
-            "integrity": "sha512-TnNqXiWMXgzS3uDm8KYdgJ+O+w2TAcGrQpmdQot2XlDw5pxxzmH22A0xgdmvv/XYB9BBMBPzmxaI/MPiF9i8kg==",
-            "license": "Apache-2.0",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.11.2.tgz",
+            "integrity": "sha512-Xr7mYPG3vmbBUVNaRWn/R+6lJTvfuIkbXkAAcii+qYbnBweUQGSDNE9aRPj7q8kbRJRTMX8lzg97CW41S4JLyg==",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.8.0",
-                "@swagger-api/apidom-error": "^1.8.0",
+                "@swagger-api/apidom-core": "^1.11.2",
+                "@swagger-api/apidom-error": "^1.11.2",
                 "@types/ramda": "~0.30.0",
-                "axios": "^1.12.2",
+                "axios": "^1.16.0",
                 "minimatch": "^10.2.1",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             },
             "optionalDependencies": {
-                "@swagger-api/apidom-json-pointer": "^1.8.0",
-                "@swagger-api/apidom-ns-arazzo-1": "^1.8.0",
-                "@swagger-api/apidom-ns-asyncapi-2": "^1.8.0",
-                "@swagger-api/apidom-ns-openapi-2": "^1.8.0",
-                "@swagger-api/apidom-ns-openapi-3-0": "^1.8.0",
-                "@swagger-api/apidom-ns-openapi-3-1": "^1.8.0",
-                "@swagger-api/apidom-ns-openapi-3-2": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-json": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.8.0",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.8.0"
+                "@swagger-api/apidom-json-pointer": "^1.11.2",
+                "@swagger-api/apidom-ns-arazzo-1": "^1.11.2",
+                "@swagger-api/apidom-ns-asyncapi-2": "^1.11.2",
+                "@swagger-api/apidom-ns-openapi-2": "^1.11.2",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.11.2",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.11.2",
+                "@swagger-api/apidom-ns-openapi-3-2": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.11.2",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.2"
             }
         },
         "node_modules/@swaggerexpert/cookie": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@swaggerexpert/cookie/-/cookie-2.0.2.tgz",
             "integrity": "sha512-DPI8YJ0Vznk4CT+ekn3rcFNq1uQwvUHZhH6WvTSPD0YKBIlMS9ur2RYKghXuxxOiqOam/i4lHJH4xTIiTgs3Mg==",
-            "license": "Apache-2.0",
             "dependencies": {
                 "apg-lite": "^1.0.3"
             },
@@ -2143,7 +1613,6 @@
             "version": "2.10.2",
             "resolved": "https://registry.npmjs.org/@swaggerexpert/json-pointer/-/json-pointer-2.10.2.tgz",
             "integrity": "sha512-qMx1nOrzoB+PF+pzb26Q4Tc2sOlrx9Ba2UBNX9hB31Omrq+QoZ2Gly0KLrQWw4Of1AQ4J9lnD+XOdwOdcdXqqw==",
-            "license": "Apache-2.0",
             "dependencies": {
                 "apg-lite": "^1.0.4"
             },
@@ -2503,6 +1972,16 @@
                 "tailwindcss": "4.1.18"
             }
         },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+            "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@types/esrecurse": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -2542,7 +2021,6 @@
             "version": "0.30.2",
             "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.30.2.tgz",
             "integrity": "sha512-PyzHvjCalm2BRYjAU6nIB3TprYwMNOUY/7P/N8bSzp9W/yM2YrtGtAnnVtaCNSeOZ8DzKyFDvaqQs7LnWwwmBA==",
-            "license": "MIT",
             "dependencies": {
                 "types-ramda": "^0.30.1"
             }
@@ -2741,14 +2219,12 @@
         "node_modules/apg-lite": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/apg-lite/-/apg-lite-1.0.5.tgz",
-            "integrity": "sha512-SlI+nLMQDzCZfS39ihzjGp3JNBQfJXyMi6cg9tkLOCPVErgFsUIAEdO9IezR7kbP5Xd0ozcPNQBkf9TO5cHgWw==",
-            "license": "BSD-2-Clause"
+            "integrity": "sha512-SlI+nLMQDzCZfS39ihzjGp3JNBQfJXyMi6cg9tkLOCPVErgFsUIAEdO9IezR7kbP5Xd0ozcPNQBkf9TO5cHgWw=="
         },
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "license": "Python-2.0"
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
@@ -3088,7 +2564,6 @@
             "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
             "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
             "hasInstallScript": true,
-            "license": "MIT",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/core-js"
@@ -3186,7 +2661,6 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
             "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3341,48 +2815,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/esbuild": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-            "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "bin": {
-                "esbuild": "bin/esbuild"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.27.3",
-                "@esbuild/android-arm": "0.27.3",
-                "@esbuild/android-arm64": "0.27.3",
-                "@esbuild/android-x64": "0.27.3",
-                "@esbuild/darwin-arm64": "0.27.3",
-                "@esbuild/darwin-x64": "0.27.3",
-                "@esbuild/freebsd-arm64": "0.27.3",
-                "@esbuild/freebsd-x64": "0.27.3",
-                "@esbuild/linux-arm": "0.27.3",
-                "@esbuild/linux-arm64": "0.27.3",
-                "@esbuild/linux-ia32": "0.27.3",
-                "@esbuild/linux-loong64": "0.27.3",
-                "@esbuild/linux-mips64el": "0.27.3",
-                "@esbuild/linux-ppc64": "0.27.3",
-                "@esbuild/linux-riscv64": "0.27.3",
-                "@esbuild/linux-s390x": "0.27.3",
-                "@esbuild/linux-x64": "0.27.3",
-                "@esbuild/netbsd-arm64": "0.27.3",
-                "@esbuild/netbsd-x64": "0.27.3",
-                "@esbuild/openbsd-arm64": "0.27.3",
-                "@esbuild/openbsd-x64": "0.27.3",
-                "@esbuild/openharmony-arm64": "0.27.3",
-                "@esbuild/sunos-x64": "0.27.3",
-                "@esbuild/win32-arm64": "0.27.3",
-                "@esbuild/win32-ia32": "0.27.3",
-                "@esbuild/win32-x64": "0.27.3"
             }
         },
         "node_modules/escalade": {
@@ -3687,8 +3119,7 @@
         "node_modules/fast-json-patch": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
-            "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
-            "license": "MIT"
+            "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
@@ -3804,16 +3235,15 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-            "license": "MIT",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -3839,11 +3269,6 @@
                 "type": "patreon",
                 "url": "https://github.com/sponsors/rawify"
             }
-        },
-        "node_modules/fs": {
-            "version": "0.0.1-security",
-            "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-            "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
         },
         "node_modules/fsevents": {
             "version": "2.3.3",
@@ -3972,9 +3397,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -4207,10 +3632,19 @@
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-            "license": "MIT",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -4262,12 +3696,13 @@
             }
         },
         "node_modules/laravel-vite-plugin": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-2.1.0.tgz",
-            "integrity": "sha512-z+ck2BSV6KWtYcoIzk9Y5+p4NEjqM+Y4i8/H+VZRLq0OgNjW2DqyADquwYu5j8qRvaXwzNmfCWl1KrMlV1zpsg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-3.1.0.tgz",
+            "integrity": "sha512-Fzocl+X4eQ9jOi0RwdphYRGkUbPJ3ky1pTAST5Ot18cS2gw6d2vldK2eCrlKDVjtibCjCx5qptYDlA0373n7qg==",
             "dev": true,
             "dependencies": {
                 "picocolors": "^1.0.0",
+                "tinyglobby": "^0.2.12",
                 "vite-plugin-full-reload": "^1.1.0"
             },
             "bin": {
@@ -4277,7 +3712,13 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "peerDependencies": {
-                "vite": "^7.0.0"
+                "fontaine": "^0.5.0",
+                "vite": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "fontaine": {
+                    "optional": true
+                }
             }
         },
         "node_modules/levn": {
@@ -4654,7 +4095,6 @@
             "version": "0.23.8",
             "resolved": "https://registry.npmjs.org/minim/-/minim-0.23.8.tgz",
             "integrity": "sha512-bjdr2xW1dBCMsMGGsUeqM4eFI60m94+szhxWys+B1ztIt6gWSfeGBdSVCIawezeHYLYn0j6zrsXdQS/JllBzww==",
-            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.15.0"
             },
@@ -4693,9 +4133,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.12",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
             "dev": true,
             "funding": [
                 {
@@ -4703,7 +4143,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -4721,7 +4160,6 @@
             "version": "0.6.18",
             "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
             "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
-            "license": "MIT",
             "engines": {
                 "node": ">= 10"
             }
@@ -4729,8 +4167,7 @@
         "node_modules/node-abort-controller": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
-            "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
-            "license": "MIT"
+            "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
         },
         "node_modules/node-addon-api": {
             "version": "7.1.1",
@@ -4739,48 +4176,10 @@
             "dev": true,
             "optional": true
         },
-        "node_modules/node-domexception": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-            "deprecated": "Use your platform's native DOMException instead",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/jimmywarting"
-                },
-                {
-                    "type": "github",
-                    "url": "https://paypal.me/jimmywarting"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.5.0"
-            }
-        },
-        "node_modules/node-fetch-commonjs": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/node-fetch-commonjs/-/node-fetch-commonjs-3.3.2.tgz",
-            "integrity": "sha512-VBlAiynj3VMLrotgwOS3OyECFxas5y7ltLcK4t41lMUZeaK15Ym4QRkqN0EQKAFL42q9i21EPKjzLUPfltR72A==",
-            "license": "MIT",
-            "dependencies": {
-                "node-domexception": "^1.0.0",
-                "web-streams-polyfill": "^3.0.3"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/node-fetch"
-            }
-        },
         "node_modules/node-gyp-build": {
             "version": "4.8.4",
             "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
             "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-            "license": "MIT",
             "optional": true,
             "bin": {
                 "node-gyp-build": "bin.js",
@@ -4816,7 +4215,6 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/openapi-path-templating/-/openapi-path-templating-2.2.1.tgz",
             "integrity": "sha512-eN14VrDvl/YyGxxrkGOHkVkWEoPyhyeydOUrbvjoz8K5eIGgELASwN1eqFOJ2CTQMGCy2EntOK1KdtJ8ZMekcg==",
-            "license": "Apache-2.0",
             "dependencies": {
                 "apg-lite": "^1.0.4"
             },
@@ -4828,7 +4226,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/openapi-server-url-templating/-/openapi-server-url-templating-1.3.0.tgz",
             "integrity": "sha512-DPlCms3KKEbjVQb0spV6Awfn6UWNheuG/+folQPzh/wUaKwuqvj8zt5gagD7qoyxtE03cIiKPgLFS3Q8Bz00uQ==",
-            "license": "Apache-2.0",
             "dependencies": {
                 "apg-lite": "^1.0.4"
             },
@@ -4925,9 +4322,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.13",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-            "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+            "version": "8.5.15",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
             "dev": true,
             "funding": [
                 {
@@ -4943,9 +4340,8 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.12",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -5070,7 +4466,6 @@
             "version": "0.30.1",
             "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
             "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-            "license": "MIT",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/ramda"
@@ -5080,7 +4475,6 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-5.1.0.tgz",
             "integrity": "sha512-8qCpl2vZBXEJyNbi4zqcgdfHtcdsWjOGbiNSEnEBrM6Y0OKOT8UxJbIVGm1TIcjaSu2MxaWcgtsNlKlCk7o7qg==",
-            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.3"
             },
@@ -5305,49 +4699,37 @@
                 "node": ">=4"
             }
         },
-        "node_modules/rollup": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-            "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+        "node_modules/rolldown": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+            "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@types/estree": "1.0.8"
+                "@oxc-project/types": "=0.133.0",
+                "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
-                "rollup": "dist/bin/rollup"
+                "rolldown": "bin/cli.mjs"
             },
             "engines": {
-                "node": ">=18.0.0",
-                "npm": ">=8.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.59.0",
-                "@rollup/rollup-android-arm64": "4.59.0",
-                "@rollup/rollup-darwin-arm64": "4.59.0",
-                "@rollup/rollup-darwin-x64": "4.59.0",
-                "@rollup/rollup-freebsd-arm64": "4.59.0",
-                "@rollup/rollup-freebsd-x64": "4.59.0",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
-                "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
-                "@rollup/rollup-linux-arm64-gnu": "4.59.0",
-                "@rollup/rollup-linux-arm64-musl": "4.59.0",
-                "@rollup/rollup-linux-loong64-gnu": "4.59.0",
-                "@rollup/rollup-linux-loong64-musl": "4.59.0",
-                "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
-                "@rollup/rollup-linux-ppc64-musl": "4.59.0",
-                "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
-                "@rollup/rollup-linux-riscv64-musl": "4.59.0",
-                "@rollup/rollup-linux-s390x-gnu": "4.59.0",
-                "@rollup/rollup-linux-x64-gnu": "4.59.0",
-                "@rollup/rollup-linux-x64-musl": "4.59.0",
-                "@rollup/rollup-openbsd-x64": "4.59.0",
-                "@rollup/rollup-openharmony-arm64": "4.59.0",
-                "@rollup/rollup-win32-arm64-msvc": "4.59.0",
-                "@rollup/rollup-win32-ia32-msvc": "4.59.0",
-                "@rollup/rollup-win32-x64-gnu": "4.59.0",
-                "@rollup/rollup-win32-x64-msvc": "4.59.0",
-                "fsevents": "~2.3.2"
+                "@rolldown/binding-android-arm64": "1.0.3",
+                "@rolldown/binding-darwin-arm64": "1.0.3",
+                "@rolldown/binding-darwin-x64": "1.0.3",
+                "@rolldown/binding-freebsd-x64": "1.0.3",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+                "@rolldown/binding-linux-arm64-musl": "1.0.3",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+                "@rolldown/binding-linux-x64-gnu": "1.0.3",
+                "@rolldown/binding-linux-x64-musl": "1.0.3",
+                "@rolldown/binding-openharmony-arm64": "1.0.3",
+                "@rolldown/binding-wasm32-wasi": "1.0.3",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+                "@rolldown/binding-win32-x64-msvc": "1.0.3"
             }
         },
         "node_modules/safe-buffer": {
@@ -5416,11 +4798,6 @@
                 "type": "individual",
                 "url": "https://paulmillr.com/funding/"
             }
-        },
-        "node_modules/save-dev": {
-            "version": "0.0.1-security",
-            "resolved": "https://registry.npmjs.org/save-dev/-/save-dev-0.0.1-security.tgz",
-            "integrity": "sha512-k6knZTDNK8PKKbIqnvxiOveJinuw2LcQjqDoaorZWP9M5AR2EPsnpDeSbeoZZ0pHr5ze1uoaKdK8NBGQrJ34Uw=="
         },
         "node_modules/scheduler": {
             "version": "0.23.2",
@@ -5510,7 +4887,6 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/short-unique-id/-/short-unique-id-5.3.2.tgz",
             "integrity": "sha512-KRT/hufMSxXKEDSQujfVE0Faa/kZ51ihUcZQAcmP04t00DvPj7Ox5anHke1sJYUtzSuiT/Y5uyzg/W7bBEGhCg==",
-            "license": "Apache-2.0",
             "bin": {
                 "short-unique-id": "bin/short-unique-id",
                 "suid": "bin/short-unique-id"
@@ -5541,37 +4917,37 @@
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
         },
         "node_modules/swagger-client": {
-            "version": "3.37.1",
-            "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.37.1.tgz",
-            "integrity": "sha512-WCRU7wfyqTyB0vOpVK1vHFm4aCqnmqcXycDcWVmHa784Nd4cABaQeSITtjWMOnjJoIkTqG8TLArYn4SAv+wj2w==",
-            "license": "Apache-2.0",
+            "version": "3.37.4",
+            "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.37.4.tgz",
+            "integrity": "sha512-3xxqc9s99Vsf47ket2j7D4Tw6b6T7ObNvTqSP009yBeoAo0fy0yprqOVxFISTrvRxN7jgfrEi8GXMhsjzb1M0g==",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.22.15",
                 "@scarf/scarf": "=1.4.0",
-                "@swagger-api/apidom-core": "^1.7.0",
-                "@swagger-api/apidom-error": "^1.7.0",
-                "@swagger-api/apidom-json-pointer": "^1.7.0",
-                "@swagger-api/apidom-ns-openapi-3-1": "^1.7.0",
-                "@swagger-api/apidom-ns-openapi-3-2": "^1.7.0",
-                "@swagger-api/apidom-reference": "^1.7.0",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@swagger-api/apidom-json-pointer": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-2": "^1.11.0",
+                "@swagger-api/apidom-reference": "^1.11.0",
                 "@swaggerexpert/cookie": "^2.0.2",
                 "deepmerge": "~4.3.0",
                 "fast-json-patch": "^3.0.0-1",
                 "js-yaml": "^4.1.0",
                 "neotraverse": "=0.6.18",
                 "node-abort-controller": "^3.1.1",
-                "node-fetch-commonjs": "^3.3.2",
                 "openapi-path-templating": "^2.2.1",
                 "openapi-server-url-templating": "^1.3.0",
                 "ramda": "^0.30.1",
                 "ramda-adjunct": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=22"
             }
         },
         "node_modules/swagger-ui": {
-            "version": "5.32.1",
-            "resolved": "https://registry.npmjs.org/swagger-ui/-/swagger-ui-5.32.1.tgz",
-            "integrity": "sha512-qQSRe0wNmlM/oCGacmZFc5/2y1o7N23EuxXCrBLRlZyLzsAvdIFqEAORW783TMYPGqmISFMAUtvCiS0KQImlbw==",
-            "license": "Apache-2.0",
+            "version": "5.32.6",
+            "resolved": "https://registry.npmjs.org/swagger-ui/-/swagger-ui-5.32.6.tgz",
+            "integrity": "sha512-Kju+1XSjjnzm6X9JBW4eRXX8+5NIxELDagrzRh5BnvnWu91+6aA7IpAlVqLVfJrKYkY7w4+NIfD+ad18tGqyGQ==",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.27.1",
                 "@scarf/scarf": "=1.4.0",
@@ -5580,12 +4956,12 @@
                 "classnames": "^2.5.1",
                 "css.escape": "1.5.1",
                 "deep-extend": "0.6.0",
-                "dompurify": "^3.3.2",
+                "dompurify": "^3.4.0",
                 "ieee754": "^1.2.1",
                 "immutable": "^3.x.x",
                 "js-file-download": "^0.4.12",
                 "js-yaml": "=4.1.1",
-                "lodash": "^4.17.21",
+                "lodash": "^4.18.1",
                 "prop-types": "^15.8.1",
                 "randexp": "^0.5.3",
                 "randombytes": "^2.1.0",
@@ -5604,7 +4980,7 @@
                 "reselect": "^5.1.1",
                 "serialize-error": "^8.1.0",
                 "sha.js": "^2.4.12",
-                "swagger-client": "^3.37.1",
+                "swagger-client": "^3.37.4",
                 "url-parse": "^1.5.10",
                 "xml": "=1.0.1",
                 "xml-but-prettier": "^1.0.1",
@@ -5682,14 +5058,13 @@
             }
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.15",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
-                "picomatch": "^4.0.3"
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -5703,7 +5078,6 @@
             "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
             "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=12.0.0"
             },
@@ -5721,7 +5095,6 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -5772,7 +5145,6 @@
             "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
             "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
             "hasInstallScript": true,
-            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "node-addon-api": "^8.0.0",
@@ -5784,7 +5156,6 @@
             "resolved": "https://registry.npmjs.org/tree-sitter-json/-/tree-sitter-json-0.24.8.tgz",
             "integrity": "sha512-Tc9ZZYwHyWZ3Tt1VEw7Pa2scu1YO7/d2BCBbKTx5hXwig3UfdQjsOPkPyLpDJOn/m1UBEWYAtSdGAwCSyagBqQ==",
             "hasInstallScript": true,
-            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "node-addon-api": "^8.2.2",
@@ -5800,20 +5171,18 @@
             }
         },
         "node_modules/tree-sitter-json/node_modules/node-addon-api": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
-            "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
-            "license": "MIT",
+            "version": "8.8.0",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
+            "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
             "optional": true,
             "engines": {
                 "node": "^18 || ^20 || >= 21"
             }
         },
         "node_modules/tree-sitter/node_modules/node-addon-api": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
-            "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
-            "license": "MIT",
+            "version": "8.8.0",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
+            "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
             "optional": true,
             "engines": {
                 "node": "^18 || ^20 || >= 21"
@@ -5822,14 +5191,12 @@
         "node_modules/ts-mixer": {
             "version": "6.0.4",
             "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
-            "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
-            "license": "MIT"
+            "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="
         },
         "node_modules/ts-toolbelt": {
             "version": "9.6.0",
             "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
-            "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
-            "license": "Apache-2.0"
+            "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="
         },
         "node_modules/tslib": {
             "version": "2.8.1",
@@ -5883,7 +5250,6 @@
             "version": "0.30.1",
             "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.30.1.tgz",
             "integrity": "sha512-1HTsf5/QVRmLzcGfldPFvkVsAdi1db1BBKzi7iW3KBUlOICg/nKnFS+jGqDJS3YD8VsWbAh7JiHeBvbsw8RPxA==",
-            "license": "MIT",
             "dependencies": {
                 "ts-toolbelt": "^9.6.0"
             }
@@ -5891,8 +5257,7 @@
         "node_modules/unraw": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/unraw/-/unraw-3.0.0.tgz",
-            "integrity": "sha512-08/DA66UF65OlpUDIQtbJyrqTR0jTAlJ+jsnkQ4jxR7+K5g5YG1APZKQSMCE1vqqmD+2pv6+IdEjmopFatacvg==",
-            "license": "MIT"
+            "integrity": "sha512-08/DA66UF65OlpUDIQtbJyrqTR0jTAlJ+jsnkQ4jxR7+K5g5YG1APZKQSMCE1vqqmD+2pv6+IdEjmopFatacvg=="
         },
         "node_modules/update-browserslist-db": {
             "version": "1.2.3",
@@ -5953,18 +5318,16 @@
             }
         },
         "node_modules/vite": {
-            "version": "7.3.2",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-            "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+            "version": "8.0.16",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+            "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "esbuild": "^0.27.0",
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.3",
-                "postcss": "^8.5.6",
-                "rollup": "^4.43.0",
-                "tinyglobby": "^0.2.15"
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.4",
+                "postcss": "^8.5.15",
+                "rolldown": "1.0.3",
+                "tinyglobby": "^0.2.17"
             },
             "bin": {
                 "vite": "bin/vite.js"
@@ -5980,9 +5343,10 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.1.18",
+                "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
-                "lightningcss": "^1.21.0",
                 "sass": "^1.70.0",
                 "sass-embedded": "^1.70.0",
                 "stylus": ">=0.54.8",
@@ -5995,13 +5359,16 @@
                 "@types/node": {
                     "optional": true
                 },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
                 "jiti": {
                     "optional": true
                 },
                 "less": {
-                    "optional": true
-                },
-                "lightningcss": {
                     "optional": true
                 },
                 "sass": {
@@ -6037,22 +5404,262 @@
                 "picomatch": "^2.3.1"
             }
         },
-        "node_modules/vite/node_modules/fdir": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+        "node_modules/vite/node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=8"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "dev": true,
+            "dependencies": {
+                "detect-libc": "^2.0.3"
             },
-            "peerDependencies": {
-                "picomatch": "^3 || ^4"
+            "engines": {
+                "node": ">= 12.0.0"
             },
-            "peerDependenciesMeta": {
-                "picomatch": {
-                    "optional": true
-                }
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-android-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-darwin-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
             }
         },
         "node_modules/vite/node_modules/picomatch": {
@@ -6060,7 +5667,6 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -6089,20 +5695,10 @@
                 }
             }
         },
-        "node_modules/web-streams-polyfill": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-            "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 8"
-            }
-        },
         "node_modules/web-tree-sitter": {
             "version": "0.24.5",
             "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.24.5.tgz",
             "integrity": "sha512-+J/2VSHN8J47gQUAvF8KDadrfz6uFYVjxoxbKWDoXVsH2u7yLdarCnIURnrMA6uSRkgX3SdmqM5BOoQjPdSh5w==",
-            "license": "MIT",
             "optional": true
         },
         "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "axios": "^1.16.0",
         "cross-env": "^7",
         "eslint": "^10.0.1",
-        "laravel-vite-plugin": "^2.1.0",
+        "laravel-vite-plugin": "^3.1.0",
         "lodash": "^4.17.23",
         "postcss": "^8.5.13",
         "prettier": "^3.2.0",
@@ -28,8 +28,11 @@
         "pusher-js": "^8.4.0-rc2",
         "sass": "^1.56.1",
         "tailwindcss": "^4.1.12",
-        "vite": "^7.3.2",
+        "vite": "^8.0.0",
         "vue": "^3.2"
+    },
+    "overrides": {
+        "js-yaml": "^4.2.0"
     },
     "dependencies": {
         "chart.js": "^4.4.3",
@@ -38,13 +41,11 @@
         "dotenv": "^16.0",
         "dropzone": "^6.0.0-beta.1",
         "flatpickr": "^4.6.13",
-        "fs": "0.0.1-security",
         "fullcalendar": "^6.1.11",
         "jquery": "^3.5.1",
         "laravel-echo": "^1.6.1",
         "lightbox2": "^2.11.1",
         "moment": "^2.29.4",
-        "save-dev": "0.0.1-security",
         "select2": "^4.1.0-rc.0",
         "swagger-ui": "^5.32.1",
         "sweetalert2": "^11.22"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,5 +10,5 @@ parameters:
   checkMissingIterableValueType: false
 
 includes:
-  - ./vendor/nunomaduro/larastan/extension.neon
+  - ./vendor/larastan/larastan/extension.neon
   - phpstan-baseline.neon

--- a/tests/Feature/Jobs/ExportUserDataJobTest.php
+++ b/tests/Feature/Jobs/ExportUserDataJobTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Jobs\ExportUserDataJob;
+use App\Mail\UserDataExportReady;
+use App\Models\JobStatus;
+use App\Models\User;
+use App\Notifications\JobCompleted;
+use App\Services\DataExportService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Notification;
+use Mockery;
+use RuntimeException;
+use Tests\TestCase;
+
+/**
+ * Covers ExportUserDataJob — the user-triggered data export job. (The Instagram
+ * jobs and the shared TracksJobStatus concern are already covered by
+ * QueuedInstagramPostTest.)
+ */
+class ExportUserDataJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected bool $seed = true;
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_constructing_the_job_creates_a_queued_job_status(): void
+    {
+        $user = User::factory()->create();
+
+        $job = new ExportUserDataJob($user);
+
+        $this->assertNotNull($job->jobStatusId);
+        $this->assertDatabaseHas('job_statuses', [
+            'id' => $job->jobStatusId,
+            'user_id' => $user->id,
+            'type' => 'data_export',
+            'status' => JobStatus::STATUS_QUEUED,
+        ]);
+    }
+
+    public function test_handle_generates_export_emails_user_and_marks_succeeded(): void
+    {
+        Mail::fake();
+        Notification::fake();
+
+        $user = User::factory()->create();
+
+        $service = Mockery::mock(DataExportService::class);
+        $service->shouldReceive('generateExport')
+            ->once()
+            ->with(Mockery::on(fn ($u) => $u instanceof User && $u->id === $user->id))
+            ->andReturn(['filename' => 'user-export.zip']);
+        $service->shouldReceive('getDownloadUrl')
+            ->once()
+            ->with('user-export.zip')
+            ->andReturn('https://example.test/download/user-export.zip');
+
+        $job = new ExportUserDataJob($user);
+        $job->handle($service);
+
+        $this->assertDatabaseHas('job_statuses', [
+            'id' => $job->jobStatusId,
+            'status' => JobStatus::STATUS_SUCCEEDED,
+        ]);
+
+        Mail::assertSent(UserDataExportReady::class, function ($mail) use ($user) {
+            return $mail->hasTo($user->email) && $mail->filename === 'user-export.zip';
+        });
+
+        Notification::assertSentTo($user, JobCompleted::class);
+    }
+
+    public function test_handle_rethrows_when_export_fails(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+
+        $service = Mockery::mock(DataExportService::class);
+        $service->shouldReceive('generateExport')
+            ->once()
+            ->andThrow(new RuntimeException('disk full'));
+
+        $job = new ExportUserDataJob($user);
+
+        $this->expectException(RuntimeException::class);
+        $job->handle($service);
+    }
+
+    public function test_failed_marks_status_failed_and_notifies_user(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+
+        $job = new ExportUserDataJob($user);
+        $job->failed(new RuntimeException('boom'));
+
+        $this->assertDatabaseHas('job_statuses', [
+            'id' => $job->jobStatusId,
+            'status' => JobStatus::STATUS_FAILED,
+        ]);
+
+        Notification::assertSentTo($user, JobCompleted::class);
+    }
+}

--- a/tests/Feature/Mail/MailableBuildTest.php
+++ b/tests/Feature/Mail/MailableBuildTest.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Tests\Feature\Mail;
+
+use App\Mail\AdminActivitySummary;
+use App\Mail\AdminMailer;
+use App\Mail\DailyReminder;
+use App\Mail\EntityOutreachAdminSummary;
+use App\Mail\EntityReminder;
+use App\Mail\EntityUpdateSummary;
+use App\Mail\FollowingPostUpdate;
+use App\Mail\FollowingThreadUpdate;
+use App\Mail\FollowingUpdate;
+use App\Mail\InstagramPostFailure;
+use App\Mail\LoginFailure;
+use App\Mail\UserActivation;
+use App\Mail\UserDataExportReady;
+use App\Mail\UserRegistration;
+use App\Mail\UserSuspended;
+use App\Mail\UserUpdate;
+use App\Mail\WeeklyUpdate;
+use App\Models\Entity;
+use App\Models\Event;
+use App\Models\Post;
+use App\Models\Tag;
+use App\Models\Thread;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Mail\Mailable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Dedicated coverage for the app/Mail mailables. The existing suite exercises
+ * mail through the flows that dispatch it; these tests assert the mailable
+ * classes themselves build correctly — view selection, sender, and subject —
+ * without coupling to the rendered Blade output.
+ */
+class MailableBuildTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected bool $seed = true;
+
+    private const URL = 'https://example.test';
+    private const SITE = 'TestSite';
+    private const ADMIN = 'admin@example.test';
+    private const REPLY = 'noreply@example.test';
+    private const FEEDBACK = 'feedback@example.test';
+
+    /**
+     * Build the mailable and assert it points at the expected (existing) markdown
+     * view, sends from the reply address, and has a non-empty subject prefixed
+     * with the site name (the convention every mailable in this app follows).
+     */
+    private function assertBuilt(Mailable $mailable, string $view): void
+    {
+        $mailable->build();
+
+        $this->assertSame($view, $mailable->markdown, "Mailable should use the {$view} markdown view");
+        $this->assertTrue(view()->exists($view), "Markdown view {$view} should exist");
+        $this->assertNotEmpty($mailable->subject, 'Mailable subject should be set');
+        $this->assertStringStartsWith(self::SITE, $mailable->subject, 'Subject should be prefixed with the site name');
+        $this->assertNotEmpty($mailable->from, 'Mailable should have a from address');
+        $this->assertSame(self::REPLY, $mailable->from[0]['address'], 'Mailable should send from the reply address');
+        $this->assertSame(self::SITE, $mailable->from[0]['name'], 'From name should be the site name');
+    }
+
+    private function assertBccsAdmin(Mailable $mailable): void
+    {
+        $this->assertNotEmpty($mailable->bcc, 'Mailable should bcc the admin address');
+        $this->assertSame(self::ADMIN, $mailable->bcc[0]['address'], 'Mailable should bcc the admin address');
+    }
+
+    public function test_user_registration_builds(): void
+    {
+        $user = User::factory()->create();
+        $mailable = new UserRegistration(self::URL, self::SITE, self::ADMIN, self::REPLY, $user);
+
+        $this->assertBuilt($mailable, 'emails.user-registration-markdown');
+        $this->assertStringContainsString($user->name, $mailable->subject);
+        $this->assertBccsAdmin($mailable);
+    }
+
+    public function test_user_activation_builds(): void
+    {
+        $user = User::factory()->create();
+        $mailable = new UserActivation(self::URL, self::SITE, self::ADMIN, self::REPLY, $user);
+
+        $this->assertBuilt($mailable, 'emails.user-activation-markdown');
+        $this->assertStringContainsString($user->name, $mailable->subject);
+    }
+
+    public function test_user_suspended_builds(): void
+    {
+        $user = User::factory()->create();
+        $mailable = new UserSuspended(self::URL, self::SITE, self::ADMIN, self::REPLY, $user);
+
+        $this->assertBuilt($mailable, 'emails.user-suspended-markdown');
+        $this->assertStringContainsString($user->name, $mailable->subject);
+    }
+
+    public function test_login_failure_builds(): void
+    {
+        $user = User::factory()->create();
+        $mailable = new LoginFailure(self::URL, self::SITE, self::ADMIN, self::REPLY, $user, 3);
+
+        $this->assertBuilt($mailable, 'emails.user-login-failed-markdown');
+        $this->assertStringContainsString($user->name, $mailable->subject);
+    }
+
+    public function test_user_data_export_ready_builds(): void
+    {
+        $user = User::factory()->create();
+        $mailable = new UserDataExportReady(
+            self::URL,
+            self::SITE,
+            self::ADMIN,
+            self::REPLY,
+            $user,
+            'https://example.test/download/export.zip',
+            'export.zip'
+        );
+
+        $this->assertBuilt($mailable, 'emails.user-data-export-ready');
+        $this->assertSame(self::SITE . ': Your Data Export is Ready', $mailable->subject);
+        $this->assertBccsAdmin($mailable);
+    }
+
+    public function test_user_update_builds(): void
+    {
+        $user = User::factory()->create();
+        $mailable = new UserUpdate(self::URL, self::SITE, self::ADMIN, self::REPLY, $user, new EloquentCollection(), [], []);
+
+        $this->assertBuilt($mailable, 'emails.user-update-markdown');
+        $this->assertStringContainsString($user->name, $mailable->subject);
+    }
+
+    public function test_weekly_update_builds(): void
+    {
+        $user = User::factory()->create();
+        $mailable = new WeeklyUpdate(self::URL, self::SITE, self::ADMIN, self::REPLY, $user, new EloquentCollection(), [], []);
+
+        $this->assertBuilt($mailable, 'emails.weekly-update-markdown');
+    }
+
+    public function test_daily_reminder_builds(): void
+    {
+        $user = User::factory()->create();
+        $mailable = new DailyReminder(self::URL, self::SITE, self::ADMIN, self::REPLY, $user, new EloquentCollection(), [], []);
+
+        $this->assertBuilt($mailable, 'emails.daily-reminder-markdown');
+    }
+
+    public function test_following_update_builds(): void
+    {
+        $user = User::factory()->create();
+        $event = Event::factory()->create(['start_at' => Carbon::parse('2026-01-15 20:00:00')]);
+        $tag = Tag::factory()->create();
+
+        $mailable = new FollowingUpdate(self::URL, self::SITE, self::ADMIN, self::REPLY, $user, $event, $tag);
+
+        $this->assertBuilt($mailable, 'emails.following-update-markdown');
+        $this->assertStringContainsString($tag->name, $mailable->subject);
+    }
+
+    public function test_following_thread_update_builds(): void
+    {
+        $user = User::factory()->create();
+        $thread = Thread::factory()->create();
+        $tag = Tag::factory()->create();
+
+        $mailable = new FollowingThreadUpdate(self::URL, self::SITE, self::ADMIN, self::REPLY, $user, $thread, $tag);
+
+        $this->assertBuilt($mailable, 'emails.following-thread-update-markdown');
+        $this->assertStringContainsString($tag->name, $mailable->subject);
+    }
+
+    public function test_following_post_update_builds(): void
+    {
+        $user = User::factory()->create();
+        $thread = Thread::factory()->create();
+        $post = Post::factory()->create();
+        $tag = Tag::factory()->create();
+
+        $mailable = new FollowingPostUpdate(self::URL, self::SITE, self::ADMIN, self::REPLY, $user, $thread, $post, $tag);
+
+        $this->assertBuilt($mailable, 'emails.following-post-update-markdown');
+        $this->assertStringContainsString($thread->name, $mailable->subject);
+    }
+
+    public function test_admin_activity_summary_builds(): void
+    {
+        $mailable = new AdminActivitySummary(
+            self::URL,
+            self::SITE,
+            self::ADMIN,
+            self::REPLY,
+            7,
+            Carbon::parse('2026-01-01'),
+            Carbon::parse('2026-01-07'),
+            [],
+            [],
+            []
+        );
+
+        $this->assertBuilt($mailable, 'emails.admin-activity-summary');
+    }
+
+    public function test_admin_mailer_builds(): void
+    {
+        $mailable = new AdminMailer(self::URL, self::SITE, self::ADMIN, self::REPLY);
+
+        $this->assertBuilt($mailable, 'emails.admin-test-markdown');
+    }
+
+    public function test_entity_reminder_builds(): void
+    {
+        $entity = Entity::factory()->create();
+        $mailable = new EntityReminder(
+            self::URL,
+            self::SITE,
+            self::ADMIN,
+            self::REPLY,
+            self::FEEDBACK,
+            $entity,
+            new EloquentCollection(),
+            new EloquentCollection(),
+            new EloquentCollection()
+        );
+
+        $this->assertBuilt($mailable, 'emails.entity-reminder-markdown');
+        $this->assertStringContainsString($entity->name, $mailable->subject);
+    }
+
+    public function test_entity_outreach_admin_summary_builds(): void
+    {
+        $mailable = new EntityOutreachAdminSummary(
+            self::URL,
+            self::SITE,
+            self::ADMIN,
+            self::REPLY,
+            self::FEEDBACK,
+            new EloquentCollection(),
+            0
+        );
+
+        $this->assertBuilt($mailable, 'emails.entity-outreach-admin-markdown');
+    }
+
+    public function test_entity_update_summary_builds(): void
+    {
+        $entity = Entity::factory()->create();
+        $mailable = new EntityUpdateSummary(
+            self::URL,
+            self::SITE,
+            self::ADMIN,
+            self::REPLY,
+            $entity,
+            new EloquentCollection(),
+            new EloquentCollection(),
+            new EloquentCollection(),
+            new EloquentCollection()
+        );
+
+        $this->assertBuilt($mailable, 'emails.entity-update-summary-markdown');
+        $this->assertStringContainsString($entity->name, $mailable->subject);
+    }
+
+    public function test_instagram_post_failure_builds(): void
+    {
+        $mailable = new InstagramPostFailure(
+            42,
+            'some-event-slug',
+            'Some Event',
+            'API timeout',
+            self::SITE,
+            self::ADMIN,
+            self::REPLY
+        );
+
+        $this->assertBuilt($mailable, 'emails.instagram-post-failure');
+    }
+}

--- a/tests/Feature/Notifications/NotificationContentTest.php
+++ b/tests/Feature/Notifications/NotificationContentTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature\Notifications;
+
+use App\Models\JobStatus;
+use App\Models\User;
+use App\Notifications\EventPublished;
+use App\Notifications\JobCompleted;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Notifications\Messages\MailMessage;
+use NotificationChannels\Twitter\TwitterChannel;
+use stdClass;
+use Tests\TestCase;
+
+/**
+ * Dedicated coverage for the notification classes themselves — channels,
+ * mail content, and array payload. (Dispatch of JobCompleted is exercised by
+ * QueuedInstagramPostTest; this asserts what the notification actually contains.)
+ */
+class NotificationContentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected bool $seed = true;
+
+    private function jobStatus(User $user, string $label = 'Account data export'): JobStatus
+    {
+        return JobStatus::create([
+            'user_id' => $user->id,
+            'type' => 'data_export',
+            'label' => $label,
+            'status' => JobStatus::STATUS_SUCCEEDED,
+        ]);
+    }
+
+    public function test_event_published_uses_twitter_channel(): void
+    {
+        $notification = new EventPublished();
+
+        $this->assertSame([TwitterChannel::class], $notification->via(new stdClass()));
+        $this->assertSame([], $notification->toArray(new stdClass()));
+    }
+
+    public function test_event_published_mail_has_intro_lines(): void
+    {
+        $mail = (new EventPublished())->toMail(new stdClass());
+
+        $this->assertInstanceOf(MailMessage::class, $mail);
+        $this->assertContains('The introduction to the notification.', $mail->introLines);
+        $this->assertSame('Notification Action', $mail->actionText);
+    }
+
+    public function test_job_completed_sends_via_database_only_by_default(): void
+    {
+        config()->set('app.queue_notify_email', false);
+
+        $user = User::factory()->create();
+        $notification = new JobCompleted($this->jobStatus($user), true, 'done');
+
+        $this->assertSame(['database'], $notification->via(new stdClass()));
+    }
+
+    public function test_job_completed_adds_mail_channel_when_enabled(): void
+    {
+        config()->set('app.queue_notify_email', true);
+
+        $user = User::factory()->create();
+        $notification = new JobCompleted($this->jobStatus($user), true, 'done');
+
+        $this->assertSame(['database', 'mail'], $notification->via(new stdClass()));
+    }
+
+    public function test_job_completed_mail_subject_reflects_outcome(): void
+    {
+        $user = User::factory()->create();
+        $status = $this->jobStatus($user, 'Account data export');
+
+        $success = (new JobCompleted($status, true, 'all good'))->toMail(new stdClass());
+        $this->assertSame('Completed: Account data export', $success->subject);
+
+        $failure = (new JobCompleted($status, false, 'it broke'))->toMail(new stdClass());
+        $this->assertSame('Failed: Account data export', $failure->subject);
+    }
+
+    public function test_job_completed_to_array_payload(): void
+    {
+        $user = User::factory()->create();
+        $status = $this->jobStatus($user);
+
+        $payload = (new JobCompleted($status, true, 'done'))->toArray(new stdClass());
+
+        $this->assertSame($status->id, $payload['job_status_id']);
+        $this->assertSame('data_export', $payload['type']);
+        $this->assertTrue($payload['succeeded']);
+        $this->assertSame('done', $payload['message']);
+    }
+}


### PR DESCRIPTION
Implements two tracks from a project health review: security/dependency hygiene and test-coverage gaps. Deferred (not in this PR): backend refactors, frontend modernization, and the framework major upgrade.

## Track A — Security & dependency quick-wins
- **Composer:** patched 10 of 11 advisories in-range (`guzzlehttp/psr7` 2.11.0, `symfony/*` 6.4.40/41, `symfony/polyfill-intl-idn` 1.38.1). The remaining `laravel/framework` CRLF-email-rule advisory is patched **only in Laravel 12.60+/13.10+** (all 10.x **and** 11.x affected), so it's recorded as a documented, accepted exception in `config.audit.ignore` pending the deferred framework upgrade.
- **npm:** cleared all advisories (`vite` 7→8.0.16, `laravel-vite-plugin` 3.1.0, `js-yaml`→4.2.0 via `overrides`, `form-data` via axios). Production build verified under Vite 8.
- **Abandoned package:** `nunomaduro/larastan` → `larastan/larastan` (`^2.x` for Laravel-10 compat); updated `phpstan.neon` extension path. PHPStan still clean.
- **Removed junk deps:** `fs`, `save-dev` placeholders.
- **Config hardening:** Sanctum token expiry (30d, env-overridable), restored `X-Frame-Options: sameorigin`, env-gated CORS so production no longer ships `localhost`/plain-HTTP/Vercel-preview origins. (Full CSP left as a deliberate report-only follow-up.)
- **CI (`php.yml`):** added `composer audit`, `npm audit --audit-level=high`, and pcov coverage reporting; fixed a stale `phpstan.neon.dist` reference.

## Track B — Test coverage gaps (27 new tests)
- **Mail:** all 17 mailables — view selection, sender, subject, bcc.
- **Jobs:** `ExportUserDataJob` (the only uncovered job; Instagram jobs + `TracksJobStatus` already covered by `QueuedInstagramPostTest`).
- **Notifications:** `EventPublished` + `JobCompleted` — channels, mail content, array payload.

## Notes / follow-ups
- `npm run lint` is **broken independent of this PR** (eslint v10 needs a flat `eslint.config.js`; none exists, and the script uses the removed `--ext` flag). Fixing it is an eslint-flat-config migration that belongs to the deferred frontend track, so the lint CI gate was intentionally **not** added.
- When the framework is eventually upgraded, target **Laravel 12.60+** (or 13.10+) to clear the deferred CRLF advisory — Laravel 11 does not fix it.

## Verification
- Full suite: **850 tests / 1710 assertions — OK** (no regressions).
- PHPStan clean · `composer audit` exit 0 (1 documented ignore) · `npm audit --audit-level=high` clean · Vite 8 build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)