### PR TITLE
Re-enable JS linting + CSP report-only

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -68,6 +68,9 @@ jobs:
       - name: NPM security audit
         run: npm audit --audit-level=high
 
+      - name: Lint JS
+        run: npm run lint
+
       - name: Clear Config
         run: php artisan config:clear
 

--- a/config/secure-headers.php
+++ b/config/secure-headers.php
@@ -441,7 +441,11 @@ return [
         'enable' => true,
 
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
-        'report-only' => false,
+        // Report-only for now: violations are logged by the browser (and to
+        // report-uri/report-to if configured) but NOT enforced, so this cannot
+        // break the site. Review reports, tighten the directives below, then
+        // flip this to false to start enforcing.
+        'report-only' => true,
 
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to
         'report-to' => '',
@@ -459,6 +463,7 @@ return [
 
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/base-uri
         'base-uri' => [
+            'self' => true,
         ],
 
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/child-src
@@ -467,33 +472,69 @@ return [
 
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src
         'connect-src' => [
+            'self' => true,
+            'allow' => [
+                'https://*.pusher.com',
+                'wss://*.pusher.com',
+                'https://*.ingest.sentry.io',
+                'https://www.google-analytics.com',
+                'https://fonts.bunny.net',
+            ],
         ],
 
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src
         'default-src' => [
-//		'schemes' => [
-//			'https:'
-//		],
+            'self' => true,
         ],
 
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src
         'font-src' => [
+            'self' => true,
+            'schemes' => [
+                'data:',
+            ],
+            'allow' => [
+                'https://fonts.gstatic.com',
+                'https://fonts.bunny.net',
+                'https://cdnjs.cloudflare.com',
+            ],
         ],
 
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/form-action
         'form-action' => [
+            'self' => true,
         ],
 
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors
         'frame-ancestors' => [
+            'self' => true,
         ],
 
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-src
         'frame-src' => [
+            'self' => true,
+            'allow' => [
+                'https://www.youtube.com',
+                'https://www.youtube-nocookie.com',
+                'https://player.vimeo.com',
+                'https://w.soundcloud.com',
+                'https://open.spotify.com',
+                'https://bandcamp.com',
+                'https://www.mixcloud.com',
+                'https://www.instagram.com',
+                'https://www.facebook.com',
+                'https://platform.twitter.com',
+            ],
         ],
 
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src
         'img-src' => [
+            'self' => true,
+            'schemes' => [
+                'data:',
+                'blob:',
+                'https:',
+            ],
         ],
 
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/manifest-src
@@ -502,6 +543,10 @@ return [
 
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/media-src
         'media-src' => [
+            'self' => true,
+            'schemes' => [
+                'https:',
+            ],
         ],
 
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/navigate-to
@@ -511,6 +556,7 @@ return [
 
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/object-src
         'object-src' => [
+            'none' => true,
         ],
 
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/plugin-types
@@ -562,12 +608,15 @@ return [
         'script-src' => [
             'none' => false,
 
-            'self' => false,
+            'self' => true,
 
             'report-sample' => false,
 
             'allow' => [
-                // 'url',
+                'https://cdnjs.cloudflare.com',
+                'https://cdn.jsdelivr.net',
+                'https://www.googletagmanager.com',
+                'https://www.google-analytics.com',
             ],
 
             'schemes' => [
@@ -577,9 +626,11 @@ return [
 
             /* followings are only work for `script` and `style` related directives */
 
-            'unsafe-inline' => false,
+            // Legacy Blade views ship many inline <script> blocks and Alpine
+            // needs eval; allow them for now and tighten to nonces/hashes later.
+            'unsafe-inline' => true,
 
-            'unsafe-eval' => false,
+            'unsafe-eval' => true,
 
             // https://www.w3.org/TR/CSP3/#unsafe-hashes-usage
             'unsafe-hashes' => false,
@@ -614,6 +665,14 @@ return [
 
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src
         'style-src' => [
+            'self' => true,
+            'unsafe-inline' => true,
+            'allow' => [
+                'https://cdnjs.cloudflare.com',
+                'https://cdn.jsdelivr.net',
+                'https://fonts.googleapis.com',
+                'https://fonts.bunny.net',
+            ],
         ],
 
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src-attr

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,34 @@
+import js from '@eslint/js';
+import globals from 'globals';
+
+export default [
+    // Dead Vue code (no Vue runtime is mounted any more); these are slated for
+    // removal with the frontend modernization track, so don't lint them yet —
+    // doing so would require eslint-plugin-vue + the Vue global.
+    {
+        ignores: [
+            'resources/assets/js/**/*.vue',
+            'resources/assets/js/Collection.js',
+        ],
+    },
+
+    js.configs.recommended,
+
+    {
+        files: ['resources/assets/js/**/*.js'],
+        languageOptions: {
+            ecmaVersion: 'latest',
+            sourceType: 'module',
+            globals: {
+                ...globals.browser,
+                // Exposed on window by resources/assets/js/bootstrap.js.
+                Swal: 'readonly',
+            },
+        },
+        rules: {
+            // Surface unused symbols without failing the build on pre-existing
+            // ones; real bugs (no-undef etc.) stay as errors via recommended.
+            'no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+        },
+    },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
                 "sweetalert2": "^11.22"
             },
             "devDependencies": {
+                "@eslint/js": "^10.0.1",
                 "@tailwindcss/forms": "^0.5.7",
                 "@tailwindcss/line-clamp": "^0.4.4",
                 "@tailwindcss/postcss": "^4.1.12",
@@ -28,6 +29,7 @@
                 "axios": "^1.16.0",
                 "cross-env": "^7",
                 "eslint": "^10.0.1",
+                "globals": "^17.6.0",
                 "laravel-vite-plugin": "^3.1.0",
                 "lodash": "^4.17.23",
                 "postcss": "^8.5.13",
@@ -221,6 +223,26 @@
             },
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
+            }
+        },
+        "node_modules/@eslint/js": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+            "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+            "dev": true,
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            },
+            "funding": {
+                "url": "https://eslint.org/donate"
+            },
+            "peerDependencies": {
+                "eslint": "^10.0.0"
+            },
+            "peerDependenciesMeta": {
+                "eslint": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@eslint/object-schema": {
@@ -3340,6 +3362,18 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/globals": {
+            "version": "17.6.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+            "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/gopd": {

--- a/package.json
+++ b/package.json
@@ -9,17 +9,19 @@
         "prod": "npm run build",
         "production": "npm run build",
         "preview": "vite preview",
-        "lint": "eslint resources/assets/js --ext .js,.vue",
+        "lint": "eslint resources/assets/js",
         "format": "prettier --write 'resources/**/*.{js,vue,blade.php,css}'"
     },
     "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@tailwindcss/forms": "^0.5.7",
-        "@tailwindcss/postcss": "^4.1.12",
         "@tailwindcss/line-clamp": "^0.4.4",
+        "@tailwindcss/postcss": "^4.1.12",
         "autoprefixer": "^10.4.17",
         "axios": "^1.16.0",
         "cross-env": "^7",
         "eslint": "^10.0.1",
+        "globals": "^17.6.0",
         "laravel-vite-plugin": "^3.1.0",
         "lodash": "^4.17.23",
         "postcss": "^8.5.13",
@@ -35,9 +37,9 @@
         "js-yaml": "^4.2.0"
     },
     "dependencies": {
-        "chart.js": "^4.4.3",
         "alpinejs": "^3.13.5",
         "bootstrap-icons": "^1.5.0",
+        "chart.js": "^4.4.3",
         "dotenv": "^16.0",
         "dropzone": "^6.0.0-beta.1",
         "flatpickr": "^4.6.13",

--- a/resources/assets/js/utilities/slugify.js
+++ b/resources/assets/js/utilities/slugify.js
@@ -2,8 +2,8 @@ const Slugify = {
      text(text) {
             return text.toString().toLowerCase()
                 .replace(/\s+/g, '-')           // Replace spaces with -
-                .replace(/[^\w\-]+/g, '')       // Remove all non-word chars
-                .replace(/\-\-+/g, '-')         // Replace multiple - with single -
+                .replace(/[^\w-]+/g, '')        // Remove all non-word chars
+                .replace(/--+/g, '-')           // Replace multiple - with single -
                 .replace(/^-+/, '')             // Trim - from start of text
                 .replace(/-+$/, '');            // Trim - from end of text
      }

--- a/resources/assets/js/utilities/visibility.js
+++ b/resources/assets/js/utilities/visibility.js
@@ -26,7 +26,7 @@ const Visibility = {
         $(target).find('.toggler').on('click', (event) => { 
             const target = event.target.getAttribute("data-bs-target")
 
-            let state = '';
+            let state;
             // if the stored value is not close, then set to close
             if (localStorage.getItem(target) !== 'closed') {
                 localStorage.setItem(target, 'closed');


### PR DESCRIPTION
The two small follow-up carve-outs deferred from the security/dep quick-wins PR (#1913).

## 1. Fix & re-enable JS linting (+ CI gate)
`npm run lint` had been broken since eslint was bumped to v10 — no flat `eslint.config.js` existed and the script used the removed `--ext` flag, so it errored out instead of linting.
- Added `eslint.config.mjs` (flat config): `@eslint/js` recommended over `resources/assets/js`, browser + `Swal` globals, `no-unused-vars` as warn.
- Ignored the dead Vue SFCs + `Collection.js` (no Vue runtime is mounted — slated for removal with the frontend track; linting them would need `eslint-plugin-vue`).
- Fixed the real errors that surfaced: redundant regex escapes (`slugify.js`) and a dead initializer (`visibility.js`).
- Added `@eslint/js` + `globals` devDeps; dropped the `--ext` flag.
- **Added `npm run lint` to CI.** Currently: 0 errors, 7 warnings (unused destructured `window.location` fields in `swagger.js`) — warnings don't fail the build, so the gate is meaningful without blocking on pre-existing style.

## 2. Content-Security-Policy in report-only mode
CSP was enabled but every directive empty (ineffective). Populated a baseline (`self` + the CDNs / fonts / Pusher / Sentry / embed providers the app uses) and set **`report-only => true`**.
- Report-only **logs** violations without enforcing — cannot break the site.
- `script-src`/`style-src` allow `unsafe-inline` (legacy inline Blade scripts) + `unsafe-eval` (Alpine) for now; `object-src 'none'`, `frame-ancestors 'self'`.
- Path forward: review reported violations, tighten directives (move off `unsafe-inline` toward nonces), then flip `report-only` to `false` to enforce.

Generated header verified locally:
`Content-Security-Policy-Report-Only: base-uri 'self'; connect-src 'self' https://*.pusher.com wss://*.pusher.com ...; default-src 'self'; ... script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdnjs.cloudflare.com ...`

## Verification
- `npm run lint` exit 0 · `npm run build` succeeds · `php artisan config:cache` OK · CSP report-only header builds correctly · workflow YAML valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)