### PR TITLE
Fix "Undefined array key scheme" on click-tracking redirects

### DIFF
--- a/app/Http/Controllers/ClickTrackController.php
+++ b/app/Http/Controllers/ClickTrackController.php
@@ -113,21 +113,37 @@ class ClickTrackController extends Controller
      */
     private function attachReferralParams(string $ticketUrl): string
     {
+        $ticketUrl = trim($ticketUrl);
+
         // Parse URL to add referral parameters
         $parsedUrl = parse_url($ticketUrl);
+
+        // Ticket links are sometimes stored without a scheme (e.g. "example.com/tickets"),
+        // which makes parse_url() omit 'scheme'/'host'. Normalize to https:// and re-parse
+        // so the redirect target is well-formed.
+        if ($parsedUrl === false || !isset($parsedUrl['scheme'])) {
+            $parsedUrl = parse_url('https://' . ltrim($ticketUrl, '/'));
+        }
+
+        // If the link is still unparseable / has no host, return it untouched rather than
+        // throwing on a missing array key.
+        if (!is_array($parsedUrl) || !isset($parsedUrl['host'])) {
+            return $ticketUrl;
+        }
+
         $query = [];
-        
+
         if (isset($parsedUrl['query'])) {
             parse_str($parsedUrl['query'], $query);
         }
-        
+
         // Add referral parameter
         $query['ref'] = config('app.name', 'events-tracker');
-        
+
         // Rebuild URL with parameters
         $newQuery = http_build_query($query);
-        $redirectUrl = $parsedUrl['scheme'] . '://' . $parsedUrl['host'];
-        
+        $redirectUrl = ($parsedUrl['scheme'] ?? 'https') . '://' . $parsedUrl['host'];
+
         if (isset($parsedUrl['port'])) {
             $redirectUrl .= ':' . $parsedUrl['port'];
         }

--- a/tests/Feature/ClickTrackingTest.php
+++ b/tests/Feature/ClickTrackingTest.php
@@ -309,4 +309,43 @@ class ClickTrackingTest extends TestCase
         // Assert no click was tracked
         $this->assertEquals(0, ClickTrack::count());
     }
+
+    /** @test */
+    public function event_with_schemeless_ticket_link_redirects_with_https_and_does_not_error()
+    {
+        // Regression: ticket links stored without a scheme (e.g. "example.com/...")
+        // previously raised "Undefined array key 'scheme'" instead of redirecting.
+        $event = Event::factory()->create([
+            'ticket_link' => 'example.com/tickets?utm=x',
+        ]);
+
+        $response = $this->get('/go/evt-' . $event->id);
+
+        $response->assertRedirect();
+        $redirectUrl = $response->headers->get('Location');
+
+        $this->assertStringStartsWith('https://example.com/tickets', $redirectUrl);
+        $this->assertStringContainsString('utm=x', $redirectUrl);
+        $this->assertStringContainsString('ref=', $redirectUrl);
+
+        $this->assertDatabaseHas('click_tracks', [
+            'event_id' => $event->id,
+        ]);
+    }
+
+    /** @test */
+    public function event_with_protocol_relative_ticket_link_redirects_with_https()
+    {
+        $event = Event::factory()->create([
+            'ticket_link' => '//tickets.example.com/buy',
+        ]);
+
+        $response = $this->get('/go/evt-' . $event->id);
+
+        $response->assertRedirect();
+        $this->assertStringStartsWith(
+            'https://tickets.example.com/buy',
+            $response->headers->get('Location')
+        );
+    }
 }


### PR DESCRIPTION
## Problem
Sentry reports ~3.8K `ErrorException: Undefined array key "scheme"` at `ClickTrackController.php:129` (`/go/evt-{id}`).

`attachReferralParams()` does:
```php
$parsedUrl = parse_url($ticketUrl);
...
$redirectUrl = $parsedUrl['scheme'] . '://' . $parsedUrl['host'];
```
When an event/series `ticket_link` is stored **without a scheme** (e.g. `example.com/tickets`, `www.venue.com`), `parse_url()` returns no `scheme`/`host` keys. PHP emits an "Undefined array key" warning, which Laravel converts to an `ErrorException`. The click row is inserted first, so the user gets a **500 instead of being redirected** to the ticket link.

## Fix
- If `parse_url()` yields no `scheme`, normalize the link to `https://…` and re-parse, so the redirect target is well-formed (covers schemeless and protocol-relative `//host` links).
- If it's still unparseable / has no host, return the original link untouched rather than throwing.
- Default `scheme` to `https` when building the URL as a belt-and-suspenders.

Confirmed this was the only unguarded `parse_url()['scheme'/'host']` usage in `app/`.

## Tests
Added two regression tests to `ClickTrackingTest` (schemeless host preserves the original query + adds `ref=`; protocol-relative link redirects with `https`). Full class green: **17 tests / 34 assertions**. PHPStan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)