### PR TITLE
Add page-load smoke tests for the -tw filter pages

### DIFF
--- a/tests/Feature/TwPageRenderSmokeTest.php
+++ b/tests/Feature/TwPageRenderSmokeTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Thread;
+use App\Models\User;
+use App\Models\UserStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Page-load smoke tests for the Tailwind (-tw) index/show pages whose filter
+ * bars were migrated off the laravelcollective/html Form:: helpers to native
+ * Blade + <x-ui.select-field>. These pages had no automated coverage, so this
+ * guards against Blade-compile / missing-helper / undefined-variable
+ * regressions (e.g. removing a global helper like link_to_route) by asserting
+ * each page renders without erroring.
+ */
+class TwPageRenderSmokeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected bool $seed = true;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        // The admin group bypasses gates (show_forum/show_thread) and the
+        // auth-only pages, so every -tw page is reachable in one pass.
+        $this->user->assignGroup('admin');
+        $this->actingAs($this->user);
+    }
+
+    /**
+     * @dataProvider twPages
+     */
+    public function test_tw_page_renders(string $url): void
+    {
+        $this->get($url)->assertOk();
+    }
+
+    public static function twPages(): array
+    {
+        return [
+            'events index'    => ['/events'],
+            'events grid'     => ['/events/grid'],
+            'events calendar' => ['/calendar'],
+            'entities index'  => ['/entities'],
+            'photos index'    => ['/photos'],
+            'posts index'     => ['/posts'],
+            'reviews index'   => ['/reviews'],
+            'series index'    => ['/series'],
+            'activity index'  => ['/activity'],
+            'threads index'   => ['/threads'],
+            'users index'     => ['/users'],
+        ];
+    }
+
+    public function test_thread_show_page_renders(): void
+    {
+        $thread = Thread::factory()->create();
+
+        $this->get('/threads/' . $thread->id)->assertOk();
+    }
+}


### PR DESCRIPTION
Adds the automated coverage that was missing for the 12 Tailwind (`-tw`) index/show pages whose filter bars were migrated off `laravelcollective/html`'s `Form::` helpers (PR #1920). Those pages had **zero page-load tests**, so the migration relied on manual render-verification — and the `link_to_route` prod incident showed how a removed global helper can break pages silently.

## What it does
`TwPageRenderSmokeTest` loads each page as an admin (the admin group bypasses the `show_forum`/`show_thread` gates and the auth-only pages, so all 12 are reachable in one pass) and asserts it renders:

`/events`, `/events/grid`, `/calendar`, `/entities`, `/photos`, `/posts`, `/reviews`, `/series`, `/activity`, `/threads`, `/threads/{id}`, `/users`

Now a Blade-compile / missing-helper / undefined-variable regression on any of these is caught by CI instead of in production.

## Notes
- **12 tests, all green.** Test-only change — no `app/` code touched.
- CI's `phpstan` analyzes `app/` only (`phpstan.neon` `paths: [app]`), so the test isn't in the static-analysis gate; it follows the same model-factory/`assignGroup` patterns already used in `ApiForumsCrudTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)