### PR TITLE
Fix N+1 on entity show page (past events grid)

### DIFF
--- a/app/Http/Controllers/EntitiesController.php
+++ b/app/Http/Controllers/EntitiesController.php
@@ -903,7 +903,10 @@ class EntitiesController extends Controller
         $relatedEvents = $relatedEventsQuery->limit(16)->get();
 
         // get past events (prior to today, most recent first); fetch 21 to detect overflow past the 20 shown
+        // Eager-load the relations the past-events grid card reads per event
+        // (primary photo, venue, event type, tags) to avoid an N+1.
         $pastEvents = $entity->events()
+            ->with(['eventType', 'tags', 'venue', 'photos'])
             ->where('start_at', '<', Carbon::today()->startOfDay())
             ->orderBy('start_at', 'desc')
             ->limit(21)

--- a/tests/Feature/Web/EntitiesControllerTest.php
+++ b/tests/Feature/Web/EntitiesControllerTest.php
@@ -3,9 +3,14 @@
 namespace Tests\Feature\Web;
 
 use App\Models\Entity;
+use App\Models\Event;
+use App\Models\Photo;
+use App\Models\Tag;
 use App\Models\User;
 use App\Models\UserStatus;
+use App\Models\Visibility;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class EntitiesControllerTest extends TestCase
@@ -49,5 +54,36 @@ class EntitiesControllerTest extends TestCase
         $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
 
         $this->actingAs($user)->get('/entities/create')->assertOk();
+    }
+
+    public function test_show_eager_loads_past_event_relations_without_n_plus_one(): void
+    {
+        $entity = Entity::factory()->create();
+
+        // Several past events for the grid card, each with a primary photo, type and tags.
+        for ($i = 1; $i <= 3; $i++) {
+            $event = Event::factory()->create([
+                'start_at' => now()->subMonths($i),
+                'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            ]);
+            $event->tags()->attach(Tag::factory()->create());
+            $event->photos()->attach(Photo::factory()->create(['is_primary' => 1]));
+            $entity->events()->attach($event);
+        }
+
+        DB::enableQueryLog();
+        $this->get('/entities/'.$entity->slug)->assertOk();
+        $queries = collect(DB::getQueryLog())->pluck('query');
+
+        // The per-event primary-photo lookup must be eager-loaded, not run once per event.
+        $perEventPhotoQueries = $queries->filter(fn ($q) => str_contains($q, 'event_photo')
+            && str_contains($q, 'is_primary')
+            && str_contains($q, 'limit 1'));
+
+        $this->assertLessThanOrEqual(
+            1,
+            $perEventPhotoQueries->count(),
+            'Past-event primary photos should be eager-loaded, not queried per event (N+1).'
+        );
     }
 }


### PR DESCRIPTION
Fixes the Sentry N+1 on `/entities/{entity}` (`entities.show-tw`). The past-events grid card (`events.past-events-grid-card-tw`) reads `getPrimaryPhoto()`, `eventType`, and `tags` per event, but `$pastEvents` was fetched with no eager loading → a query per event (covers Sentry **EVENTREPO-TN/TE** photos and **EVENTREPO-TC** event_types).

Eager-load `['eventType', 'tags', 'venue', 'photos']` on the `$pastEvents` query. `Event::getPrimaryPhoto()` already uses the loaded `photos` relation when present, so the per-event `photos … is_primary … limit 1` lookup is eliminated too. (`venue` is already loaded by the `Entity::events()` relation default; included for clarity.)

Adds an N+1 regression test that creates an entity with 3 past events and asserts the per-event primary-photo query doesn't repeat — verified it **fails before the fix** (3 queries) and passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)