### PR TITLE
Harden list sorting + fix /calendar/tag N+1 (Sentry)

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -334,6 +334,7 @@ class CalendarController extends Controller
         $eventList = [];
 
         $events = Event::getByTag($tag->name)
+            ->with('visibility')
             ->orderBy('start_at', 'ASC')
             ->orderBy('name', 'ASC')
             ->get();
@@ -343,7 +344,7 @@ class CalendarController extends Controller
         });
 
         // get all the upcoming series events
-        $series = Series::getByTag($tag->name)->active()->get();
+        $series = Series::getByTag($tag->name)->active()->with('visibility', 'occurrenceType')->get();
 
         // filter for only events that are public or that were created by the current user and are not "no schedule"
         $series = $series->filter(function ($e) {

--- a/app/Http/ResultBuilder/ListEntityResultBuilder.php
+++ b/app/Http/ResultBuilder/ListEntityResultBuilder.php
@@ -164,6 +164,20 @@ class ListEntityResultBuilder implements ListResultBuilderInterface
             $this->appliedSortDirection = $this->defaultSort[$this->appliedSortField];
         }
 
+        // Guard against malformed / injected sort input reaching orderBy (e.g. a
+        // stray quote -> SQLSTATE error). Fall back to the default sort column and
+        // normalize the direction to a known-safe value.
+        if (!$this->isValidSortField($this->appliedSortField)) {
+            $this->appliedSortField = 1 === count($this->defaultSort)
+                ? array_keys($this->defaultSort)[0]
+                : null;
+        }
+        $this->appliedSortDirection = strtolower((string) $this->appliedSortDirection) === 'asc' ? 'asc' : 'desc';
+
+        if (is_null($this->appliedSortField)) {
+            return;
+        }
+
         // If sorting by a relationship count column (e.g. follows_count), add withCount
         if (str_ends_with($this->appliedSortField, '_count')) {
             $relationship = str_replace('_count', '', $this->appliedSortField);
@@ -171,6 +185,16 @@ class ListEntityResultBuilder implements ListResultBuilderInterface
         }
 
         $this->queryBuilder->orderBy($this->appliedSortField, $this->appliedSortDirection);
+    }
+
+    /**
+     * A sort field is only safe to pass to orderBy() if it's a plain SQL
+     * identifier ("column" or "table.column") — no quotes, spaces, etc.
+     */
+    private function isValidSortField(?string $field): bool
+    {
+        return is_string($field)
+            && preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)?$/', $field) === 1;
     }
 
     public function setMultiSort(array $multiSort): void

--- a/tests/Feature/ListSortHardeningTest.php
+++ b/tests/Feature/ListSortHardeningTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Filters\PhotoFilters;
+use App\Http\Requests\ListQueryParameters;
+use App\Http\ResultBuilder\ListEntityResultBuilder;
+use App\Models\Photo;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * The list pages take a sort field that flows into orderBy() via
+ * ListEntityResultBuilder. A malformed value (e.g. a stray quote from a fuzz
+ * probe or a broken link) previously reached the query and produced a SQLSTATE
+ * 500; it must now fall back to the default sort column.
+ */
+class ListSortHardeningTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function buildList(?string $sortField)
+    {
+        $params = Mockery::mock(ListQueryParameters::class);
+        $params->shouldReceive('getFilters')->andReturn([]);
+        $params->shouldReceive('getIsEmptyFilter')->andReturn(false);
+        $params->shouldReceive('getSortFieldName')->andReturn($sortField);
+        $params->shouldReceive('getSortDirection')->andReturn('desc');
+        $params->shouldReceive('getLimit')->andReturn(25);
+        $params->shouldReceive('getPage')->andReturn(1);
+
+        $builder = new ListEntityResultBuilder($params);
+        $builder->setQueryBuilder(Photo::query())
+            ->setFilter(app(PhotoFilters::class))
+            ->setDefaultSort(['photos.created_at' => 'desc']);
+        $builder->setMultiSort([]);
+        $builder->setDefaultLimit(25);
+
+        return $builder->listResultSetFactory();
+    }
+
+    public function test_malformed_sort_field_falls_back_and_query_runs(): void
+    {
+        $result = $this->buildList("created_at'");
+
+        // Fell back to the safe default rather than the malformed input...
+        $this->assertSame('photos.created_at', $result->getSort());
+        // ...and the built query executes without a bad-column SQLSTATE error.
+        $result->getList()->get();
+        $this->assertTrue(true);
+    }
+
+    public function test_valid_sort_field_is_preserved(): void
+    {
+        $result = $this->buildList('photos.name');
+
+        $this->assertSame('photos.name', $result->getSort());
+        $result->getList()->get();
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
Two Sentry fixes.

## 1. `/photos` sort 500 → harden list sorting (EVENTREPO-VZ, HIGH)
A request hit `/photos` with a malformed sort (`order by photos.created_at' desc` — a stray quote from a fuzz probe or broken link). The sort field flows unvalidated into `orderBy()` via `ListEntityResultBuilder`, producing a `SQLSTATE Unknown column` 500. (Laravel's identifier-quoting means it's not SQL injection — it errors rather than leaks — but it 500s on any bad sort.)

Fix: in `ListEntityResultBuilder::addSort()`, validate the sort field is a plain identifier (`column` or `table.column`) before `orderBy()`, falling back to the default sort otherwise, and normalize the direction to `asc`/`desc`. **This hardens every list page**, not just photos. Valid sorts are unaffected.

Adds `ListSortHardeningTest` (drives the builder with a malformed sort, asserts it falls back and the query runs) — verified it **fails without the fix**.

## 2. `/calendar/tag/{tag}` visibilities N+1 (EVENTREPO-K2, low)
`CalendarController@calendarTags` filters `$e->visibility->name` (events) and `visibility`/`occurrenceType` (series) per item with no eager-loading. Eager-load those relations.

> Note: the events visibility filter there isn't assigned back (`$events->filter(...)` result is discarded) — a separate latent bug (private events may show on the tag calendar). Left as-is here to avoid changing what's displayed; flagging it for a follow-up.

## Verification
- **Full suite green: 879 tests / 1774 assertions** (shared sort component changed — no list page regressed). PHPStan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)