### PR TITLE
Harden Build Prod deploy (composer install, npm install, cache rebuild)

### DIFF
--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -19,4 +19,20 @@ jobs:
             git checkout main
             git remote update
             git pull
-            npm run prod
+
+            # Drop stale bootstrap caches before any artisan command boots Laravel,
+            # so a cached config referencing a removed provider can't fatal
+            # (this is what threw "HtmlServiceProvider not found" after a deploy).
+            rm -f bootstrap/cache/*.php
+
+            # Keep PHP + JS deps in sync with the committed lockfiles. The missing
+            # composer install here is what caused the link_to_route "cannot
+            # redeclare" outage when a package was removed from composer.json.
+            composer install --no-dev --optimize-autoloader --no-interaction
+            npm install
+            npm run build
+
+            # Rebuild the production caches from the freshly deployed code.
+            php artisan config:cache
+            php artisan route:cache
+            php artisan view:cache


### PR DESCRIPTION
The `Build Prod` workflow (`.github/workflows/build-prod.yml`) only ran `git pull` + `npm run prod` over SSH — it never synced `vendor/` or `node_modules` to the lockfiles and never refreshed caches. That gap caused the two recent prod outages:
- **`link_to_route` "cannot redeclare"** — code that removed a package was deployed without `composer install`, so the old `vendor/laravelcollective/html` lingered.
- **`HtmlServiceProvider not found`** — a stale cached config still referenced the removed provider.

This brings the workflow in line with the documented update process in `docs/deployment_notes.md` (§Update), plus the cache-clear lesson from the outage:

```bash
git pull
rm -f bootstrap/cache/*.php          # before any artisan boot — kills a stale cached config referencing a removed class
composer install --no-dev --optimize-autoloader --no-interaction
npm install
npm run build
php artisan config:cache && php artisan route:cache && php artisan view:cache
```

Notes:
- **Migrations intentionally left out** (no auto-migrate on deploy, per discussion). Add `php artisan migrate --force` if/when you want that.
- Uses `npm run build` (the Vite build), replacing the old `npm run prod` alias.
- The workflow is `workflow_dispatch` (manual trigger) — you mentioned you're not sure it's actually invoked. If your real deploy is a different manual/automated path, the same five additions (`composer install`, `npm install`, cache clear + rebuild) should go there too; this at least makes the in-repo deploy correct and matches the docs.

No app code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)