### PR TITLE
Fix calendar visibility leak + sweep N+1s across event/series listings

### DIFF
--- a/app/Http/Controllers/Api/EventsController.php
+++ b/app/Http/Controllers/Api/EventsController.php
@@ -558,7 +558,7 @@ class EventsController extends Controller
             ->orderBy('name', 'ASC')
             ->get();
 
-        $events->filter(function ($e) {
+        $events = $events->filter(function ($e) {
             return ('Public' == $e->visibility->name) || ($this->user && $e->created_by == $this->user->id);
         });
 
@@ -621,7 +621,7 @@ class EventsController extends Controller
             ->orderBy('name', 'ASC')
             ->get();
 
-        $events->filter(function ($e) {
+        $events = $events->filter(function ($e) {
             return ('Public' == $e->visibility->name) || ($this->user && $e->created_by == $this->user->id);
         });
 
@@ -1441,11 +1441,8 @@ class EventsController extends Controller
      */
     public function indexWeek(Request $request)
     {
-        // no filters or sorting applied, just future events
-        $events = Event::future()->get();
-        $events->filter(function ($e) {
-            return ('Public' == $e->visibility->name) || ($this->user && $e->created_by == $this->user->id);
-        });
+        // no filters or sorting applied, just future events the user may see
+        $events = Event::visible($this->user)->with('visibility')->future()->get();
 
         return view('events.indexWeek', compact('events'));
     }

--- a/app/Http/Controllers/Api/TagsController.php
+++ b/app/Http/Controllers/Api/TagsController.php
@@ -249,13 +249,13 @@ class TagsController extends Controller
 
         // get all the events linked to the tag
         $events = Event::getByTag(ucfirst($tag))
+                    ->where(function ($query) {
+                        /* @phpstan-ignore-next-line */
+                        $query->visible($this->user);
+                    })
                     ->orderBy('start_at', 'DESC')
                     ->orderBy('name', 'ASC')
                     ->simplePaginate($this->limit);
-
-        $events->filter(function ($e) {
-            return ($e->visibility->name == 'Public') || ($this->user && $e->created_by == $this->user->id);
-        });
 
         // get all entities linked to the tag
         $entities = Entity::getByTag(ucfirst($tag))

--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -271,16 +271,17 @@ class CalendarController extends Controller
         // get all events related to the entity
         // \PHPStan\dumpType(Event::getByEntity(strtolower($slug))->get());
         $events = Event::getByEntity(strtolower($slug))
+            ->with('visibility')
             ->orderBy('start_at', 'ASC')
             ->orderBy('name', 'ASC')
             ->get();
 
-        $events->filter(function ($e) {
+        $events = $events->filter(function ($e) {
             return ('Public' == $e->visibility->name) || ($this->user && $e->created_by == $this->user->id);
         });
 
         // get all the upcoming series events
-        $series = Series::getByEntity(strtolower($slug))->active()->get();
+        $series = Series::getByEntity(strtolower($slug))->active()->with('visibility', 'occurrenceType')->get();
 
         $series = $series->filter(function ($e) {
             return (('Public' == $e->visibility->name) || ($this->user && $e->created_by == $this->user->id)) and 'No Schedule' != $e->occurrenceType->name;
@@ -339,7 +340,7 @@ class CalendarController extends Controller
             ->orderBy('name', 'ASC')
             ->get();
 
-        $events->filter(function ($e) {
+        $events = $events->filter(function ($e) {
             return ('Public' == $e->visibility->name) || ($this->user && $e->created_by == $this->user->id);
         });
 
@@ -572,10 +573,10 @@ class CalendarController extends Controller
         $events = Event::where(function ($query) {
             /* @phpstan-ignore-next-line */
             $query->visible($this->user);
-        })->get();
+        })->with('eventType')->get();
 
         // get all the upcoming series events
-        $series = Series::active()->get();
+        $series = Series::active()->with('visibility', 'occurrenceType')->get();
 
         // filter for only events that are public or that were created by the current user and are not "no schedule"
         $series = $series->filter(function ($e) {
@@ -704,7 +705,7 @@ class CalendarController extends Controller
             })->get();
 
         // get all the upcoming series events
-        $series = Series::active()->get();
+        $series = Series::active()->with('visibility', 'occurrenceType')->get();
 
         // filter for only events that are public or that were created by the current user and are not "no schedule"
         $series = $series->filter(function ($e) {
@@ -756,16 +757,16 @@ class CalendarController extends Controller
         $start = $request->query('start', Carbon::now()->startOfMonth());
         $end = $request->query('end', Carbon::now()->endOfMonth());
 
-        // get all public events
+        // get all public events (eager-load tags for the $event->tagNames accessor)
         $events = Event::where('start_at', '>=', $start)
             ->where('start_at', '<=', $end)
             ->where(function ($query) {
                 /* @phpstan-ignore-next-line */
                 $query->visible($this->user);
-            })->get();
+            })->with('tags')->get();
 
         // get all the upcoming series events
-        $series = Series::active()->get();
+        $series = Series::active()->with('visibility', 'occurrenceType')->get();
 
         // filter for only events that are public or that were created by the current user and are not "no schedule"
         $series = $series->filter(function ($e) {
@@ -1030,7 +1031,7 @@ class CalendarController extends Controller
             ->with('visibility','eventType')
             ->get();
 
-        $events->filter(function ($e) {
+        $events = $events->filter(function ($e) {
             return ('Public' == $e->visibility->name) || ($this->user && $e->created_by == $this->user->id);
         });
 

--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -312,7 +312,7 @@ class EventsController extends Controller
             })
             ->orderBy('start_at', 'ASC')
             ->orderBy('name', 'ASC')
-            ->with('visibility', 'venue')
+            ->with($this->cardEventEagerLoad())
             ->paginate($listResultSet->getLimit());
 
         // saves the updated session
@@ -345,6 +345,27 @@ class EventsController extends Controller
             'sortOptions' => ['events.name' => 'Name', 'events.start_at' => 'Start At', 'event_types.name' => 'Event Type', 'events.updated_at' => 'Updated At'],
             'directionOptions' => ['asc' => 'asc', 'desc' => 'desc'],
         ];
+    }
+
+    /**
+     * Relations consumed by events/card-tw for every event in the listing grids.
+     * Eager-loading these keeps each index/filter page a fixed number of queries
+     * instead of running venue/type/tag/photo/entity/thread lookups once per card (N+1).
+     *
+     * @return array<int|string, string|\Closure>
+     */
+    protected function cardEventEagerLoad(): array
+    {
+        $eager = ['visibility', 'venue', 'eventType', 'tags', 'photos', 'entities', 'threads'];
+
+        if ($this->user) {
+            // The attend/unattend button reads getEventResponse($user)->responseType per card.
+            $eager['eventResponses'] = function ($query) {
+                $query->where('user_id', $this->user->id)->with('responseType');
+            };
+        }
+
+        return $eager;
     }
 
     protected function getFilterOptions(): array
@@ -410,7 +431,7 @@ class EventsController extends Controller
         // get the events
         // @phpstan-ignore-next-line
         $events = $query->visible($this->user)
-            ->with('visibility', 'venue')
+            ->with($this->cardEventEagerLoad())
             ->paginate($listResultSet->getLimit());
 
         // persist resolved sort values so subsequent requests don't revert to a different default
@@ -867,7 +888,7 @@ class EventsController extends Controller
                 /* @phpstan-ignore-next-line */
                 $query->visible($this->user);
             })
-            ->with('visibility', 'venue')
+            ->with($this->cardEventEagerLoad())
             ->paginate($listResultSet->getLimit());
 
         // saves the updated session
@@ -1052,7 +1073,7 @@ class EventsController extends Controller
 
         // get the events
         $events = $query
-            ->with('visibility', 'venue')
+            ->with($this->cardEventEagerLoad())
             ->paginate($listResultSet->getLimit());
 
         // saves the updated session
@@ -1112,7 +1133,7 @@ class EventsController extends Controller
                 /* @phpstan-ignore-next-line */
                 $query->visible($this->user);
             })
-            ->with('visibility', 'venue')
+            ->with($this->cardEventEagerLoad())
             ->paginate($listResultSet->getLimit());
 
         // saves the updated session
@@ -1174,7 +1195,7 @@ class EventsController extends Controller
 
         // get the events
         $events = $query
-            ->with('visibility', 'venue','tags', 'entities','series','eventType','threads')
+            ->with($this->cardEventEagerLoad())
             ->paginate($listResultSet->getLimit());
 
         // saves the updated session
@@ -1236,7 +1257,7 @@ class EventsController extends Controller
         // get the events
         // @phpstan-ignore-next-line
         $events = $query->visible($this->user)
-            ->with('visibility', 'venue','eventType','entities','tags')
+            ->with('visibility', 'venue', 'eventType', 'entities', 'tags', 'series')
             ->paginate(1000);
 
         return view('events.feed-tw', compact('events'));
@@ -2410,14 +2431,11 @@ class EventsController extends Controller
 
         // @phpstan-ignore-next-line
         $events = $query
-            ->with('visibility', 'venue','tags','entities','series','eventType','threads')
+            ->visible($this->user)
+            ->with($this->cardEventEagerLoad())
             ->orderBy('events.start_at', 'DESC')
             ->orderBy('events.name', 'ASC')
             ->paginate($listResultSet->getLimit());
-
-        $events->filter(function (Event $e): bool {
-            return ('Public' == $e->visibility->name) || ($this->user && $e->created_by == $this->user->id);
-        });
 
         // saves the updated session
         $listParamSessionStore->save();
@@ -2476,14 +2494,11 @@ class EventsController extends Controller
 
         // @phpstan-ignore-next-line
         $events = $query
-            ->with('visibility', 'venue','tags', 'entities','series','eventType','threads')
+            ->visible($this->user)
+            ->with($this->cardEventEagerLoad())
             ->orderBy('events.start_at', 'ASC')
             ->orderBy('events.name', 'ASC')
             ->paginate($listResultSet->getLimit());
-
-        $events->filter(function (\App\Models\Event $e) {
-            return ('Public' == $e->visibility->name) || ($this->user && $e->created_by == $this->user->id);
-        });
 
         // saves the updated session
         $listParamSessionStore->save();
@@ -2543,7 +2558,7 @@ class EventsController extends Controller
         $cdate_tomorrow = Carbon::parse($date)->addDay();
 
         $future_events = Event::where('events.start_at', '>', $cdate_yesterday->toDateString())
-            ->with('visibility', 'venue','tags', 'entities','series','eventType','threads')
+            ->with($this->cardEventEagerLoad())
             ->where('events.start_at', '<', $cdate_tomorrow->toDateString())
             ->where(function ($query) {
                 /* @phpstan-ignore-next-line */
@@ -2606,7 +2621,7 @@ class EventsController extends Controller
         $query = $listResultSet->getList();
 
         $future_events = Event::getByVenue(strtolower($slug))
-            ->with('visibility', 'venue','tags', 'entities','series','eventType','threads')
+            ->with($this->cardEventEagerLoad())
             ->future()
             ->where(function ($query) {
                 /* @phpstan-ignore-next-line */
@@ -2617,7 +2632,7 @@ class EventsController extends Controller
             ->paginate($this->limit);
 
         $past_events = Event::getByVenue(strtolower($slug))
-            ->with('visibility', 'venue','tags', 'entities','series','eventType','threads')
+            ->with($this->cardEventEagerLoad())
             ->past()
             ->where(function ($query) {
                 /* @phpstan-ignore-next-line */
@@ -2683,7 +2698,7 @@ class EventsController extends Controller
         // @phpstan-ignore-next-line
         $events = $query
             ->select('events.*')
-            ->with('visibility', 'venue','tags', 'entities','series','eventType','threads')
+            ->with($this->cardEventEagerLoad())
             ->orderBy('events.start_at', 'ASC')
             ->orderBy('events.name', 'ASC')
             ->paginate($listResultSet->getLimit());
@@ -2745,27 +2760,21 @@ class EventsController extends Controller
 
         // @phpstan-ignore-next-line
         $future_events = $futureQuery
-            ->with('visibility', 'venue','tags', 'entities','series','eventType','threads')
+            ->visible($this->user)
+            ->with($this->cardEventEagerLoad())
             ->future()
             ->orderBy('events.start_at', 'ASC')
             ->orderBy('events.name', 'ASC')
             ->paginate($listResultSet->getLimit());
 
-        $future_events->filter(function ($e) {
-            return ('Public' == $e->visibility->name) || ($this->user && $e->created_by == $this->user->id);
-        });
-
         // @phpstan-ignore-next-line
         $past_events = $pastQuery
-            ->with('visibility', 'venue','tags', 'entities','series','eventType','threads')
+            ->visible($this->user)
+            ->with($this->cardEventEagerLoad())
             ->past()
             ->orderBy('events.start_at', 'ASC')
             ->orderBy('events.name', 'ASC')
             ->paginate($listResultSet->getLimit());
-
-        $past_events->filter(function ($e) {
-            return ($e->visibility && 'Public' == $e->visibility->name) || ($this->user && $e->created_by == $this->user->id);
-        });
 
         // saves the updated session
         $listParamSessionStore->save();
@@ -2798,11 +2807,8 @@ class EventsController extends Controller
      */
     public function indexWeek(Request $request)
     {
-        // no filters or sorting applied, just future events
-        $events = Event::with('visibility')->future()->get();
-        $events->filter(function ($e) {
-            return ('Public' == $e->visibility->name) || ($this->user && $e->created_by == $this->user->id);
-        });
+        // no filters or sorting applied, just future events the user may see
+        $events = Event::visible($this->user)->with('venue')->future()->get();
 
         return view('events.indexWeek-tw', compact('events'));
     }
@@ -3125,7 +3131,7 @@ class EventsController extends Controller
 
         // get the events
         $events = $query
-            ->with('visibility', 'venue')
+            ->with($this->cardEventEagerLoad())
             ->paginate($listResultSet->getLimit());
 
         // saves the updated session

--- a/app/Http/Controllers/SeriesController.php
+++ b/app/Http/Controllers/SeriesController.php
@@ -654,8 +654,22 @@ class SeriesController extends Controller
         // eager-load relations consumed by the page + JSON-LD
         $series->loadMissing(['photos', 'venue.locations']);
 
-        $events = $series->events()->with('venue')->paginate($this->childLimit);
-        $threads = $series->threads()->paginate($this->childLimit);
+        // Each event renders through events/card-tw, which touches venue, eventType,
+        // visibility, tags, photos (getPrimaryPhoto), entities and threads per card —
+        // eager-load them so the grid is a fixed number of queries, not N per event.
+        $eventEager = ['venue', 'eventType', 'visibility', 'tags', 'photos', 'entities', 'threads'];
+        if ($this->user) {
+            // The attend/unattend button reads getEventResponse($user)->responseType per card.
+            $eventEager['eventResponses'] = function ($query) {
+                $query->where('user_id', $this->user->id)->with('responseType');
+            };
+        }
+        $events = $series->events()->with($eventEager)->paginate($this->childLimit);
+
+        // posts/briefList renders each thread's posts with their user/tags/entities.
+        $threads = $series->threads()
+            ->with(['posts.user', 'posts.tags', 'posts.entities'])
+            ->paginate($this->childLimit);
 
         // Embeds are deferred to an AJAX call via the playlist-tw placeholder.
         $embeds = [];

--- a/app/Http/Controllers/TagsController.php
+++ b/app/Http/Controllers/TagsController.php
@@ -227,13 +227,13 @@ class TagsController extends Controller
 
         // get all the events linked to the tag
         $events = Event::getByTag(ucfirst($tag))
+                    ->where(function ($query) {
+                        /* @phpstan-ignore-next-line */
+                        $query->visible($this->user);
+                    })
                     ->orderBy('start_at', 'DESC')
                     ->orderBy('name', 'ASC')
                     ->simplePaginate($this->limit);
-
-        $events->filter(function ($e) {
-            return ($e->visibility->name == 'Public') || ($this->user && $e->created_by == $this->user->id);
-        });
 
         // get all entities linked to the tag
         $entities = Entity::getByTag(ucfirst($tag))

--- a/tests/Feature/Web/EventsControllerTest.php
+++ b/tests/Feature/Web/EventsControllerTest.php
@@ -3,9 +3,13 @@
 namespace Tests\Feature\Web;
 
 use App\Models\Event;
+use App\Models\Photo;
+use App\Models\Tag;
 use App\Models\User;
 use App\Models\UserStatus;
+use App\Models\Visibility;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class EventsControllerTest extends TestCase
@@ -87,6 +91,68 @@ class EventsControllerTest extends TestCase
         $this->assertTrue(
             str_contains($response->headers->get('Location'), '/login')
             || str_contains($response->headers->get('Location'), '/email/verify')
+        );
+    }
+
+    /**
+     * The tag listing previously filtered visibility in-memory and discarded the
+     * result, leaking non-public events into the public page. A guest must only
+     * ever see public events.
+     */
+    public function test_tag_listing_hides_non_public_events_from_guests(): void
+    {
+        $tag = Tag::factory()->create();
+
+        $public = Event::factory()->create([
+            'name' => 'Public Tag Probe Event',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => now()->addWeek(),
+        ]);
+        $private = Event::factory()->create([
+            'name' => 'Secret Private Tag Probe Event',
+            'visibility_id' => Visibility::VISIBILITY_PRIVATE,
+            'start_at' => now()->addWeek(),
+        ]);
+        $public->tags()->attach($tag);
+        $private->tags()->attach($tag);
+
+        $response = $this->get('/events/tag/'.$tag->slug);
+
+        $response->assertOk();
+        $response->assertSee('Public Tag Probe Event');
+        $response->assertDontSee('Secret Private Tag Probe Event');
+    }
+
+    /**
+     * The card grid touches venue/type/tags/photos/etc. per event; those must be
+     * eager-loaded so the tag listing is a fixed number of queries, not N per card.
+     */
+    public function test_tag_listing_eager_loads_event_relations_without_n_plus_one(): void
+    {
+        $tag = Tag::factory()->create();
+
+        for ($i = 1; $i <= 3; $i++) {
+            $event = Event::factory()->create([
+                'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+                'start_at' => now()->addDays($i),
+            ]);
+            $event->photos()->attach(Photo::factory()->create(['is_primary' => 1]));
+            $event->tags()->attach($tag);
+        }
+
+        DB::enableQueryLog();
+        $this->get('/events/tag/'.$tag->slug)->assertOk();
+        $queries = collect(DB::getQueryLog())->pluck('query');
+
+        // The per-event primary-photo lookup must be eager-loaded, not run once per card.
+        $perEventPhotoQueries = $queries->filter(fn ($q) => str_contains($q, 'event_photo')
+            && str_contains($q, 'is_primary')
+            && str_contains($q, 'limit 1'));
+
+        $this->assertLessThanOrEqual(
+            1,
+            $perEventPhotoQueries->count(),
+            'Tag-listing event primary photos should be eager-loaded, not queried per event (N+1).'
         );
     }
 }


### PR DESCRIPTION
## Summary

Two related correctness fixes across the event/series/tag **listing** surface, done together as requested.

### 1. Visibility leak (the calendar fix, generalized)

Several listings filtered visibility *in-memory but discarded the result* — `$events->filter(...)` with no reassignment — then iterated the **unfiltered** collection. The result: private/proposal events leaked into public-facing pages. Fixed everywhere the pattern appeared:

- **CalendarController** — `calendarRelatedTo`, `calendarTags`, and `calendarTypes` (newly spotted) now reassign the filtered collection.
- **EventsController** — `indexTags`, `indexRelatedTo`, `indexSeries` (future + past), `indexWeek` now apply the canonical `->visible($user)` **scope at the query level** (which also correctly handles guarded-for-logged-in) and drop the dead in-memory filter.
- **TagsController** + **Api\TagsController** — match the adjacent series query's DB-level `visible()` instead of the discarded filter.
- **Api\EventsController** — `calendarRelatedTo`, `calendarTags`, `indexWeek`.

A guest must only ever see public events — locked in with a regression test.

### 2. N+1 sweep

The card grids (`events/card-tw`, `single-tw`) touch `venue / eventType / visibility / tags / photos / entities / threads` (+ per-user `eventResponses`) **per event**, but most index methods eager-loaded only `visibility + venue`, running per-card lookups.

- Introduced a shared **`cardEventEagerLoad()`** helper and routed every `index-tw` renderer through it (`indexByDate`, `filter`, `indexFuture`, `indexToday`, `indexPast`, `indexAttending`, `indexTags`, `indexRelatedTo`, `indexStarting`, `indexVenues`, `indexTypes`, `indexSeries`, `indexUserAttending`).
- **SeriesController@show** eager-loads the card relations + thread posts (`posts.user/tags/entities`).
- **CalendarController** eager-loads `visibility / eventType / tags / occurrenceType` across its methods (incl. the `tagNames` accessor's `tags`).
- `feed()` gained the `series` relation its view reads; `indexWeek` gained `venue`.

Grid (`cell-compact-tw`), events show, threads show, entity show and `day-tw` were checked and already eager-load correctly — left untouched.

## Testing

- Full suite green: **880 tests** + **2 new regression tests** (visibility-leak on the tag listing; tag-listing primary-photo N+1).
- PHPStan (level 3) clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)