### PR TITLE
Harden upcoming-events date param + series feed null start_at (Sentry)

### DIFF
--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -928,11 +928,20 @@ class EventsController extends Controller
         // set the index tab in the session
         $listParamSessionStore->setIndexTab(action([EventsController::class, 'index']));
 
+        // $date is a user-supplied route param; crawlers hit this with non-date junk
+        // (e.g. /events/upcoming/www.parktildark.com), which makes Carbon::parse() throw.
+        // Treat anything that isn't a real date as a missing page rather than a 500.
+        try {
+            $baseDate = $date === '' ? Carbon::now() : Carbon::parse($date);
+        } catch (\Throwable $e) {
+            abort(404);
+        }
+
         // use the window to get the last date and set the criteria between
-        $next_day = Carbon::parse($date)->addDays(1);
-        $next_day_window = Carbon::parse($date)->addDays($this->defaultWindow);
-        $prev_day = Carbon::parse($date)->subDays(1);
-        $prev_day_window = Carbon::parse($date)->subDays($this->defaultWindow);
+        $next_day = $baseDate->copy()->addDays(1);
+        $next_day_window = $baseDate->copy()->addDays($this->defaultWindow);
+        $prev_day = $baseDate->copy()->subDays(1);
+        $prev_day_window = $baseDate->copy()->subDays($this->defaultWindow);
 
         // create the base query including any required joins; needs select to make sure only event entities are returned
         $baseQuery = Event::query()->leftJoin('event_types', 'events.event_type_id', '=', 'event_types.id')->select('events.*');
@@ -985,11 +994,20 @@ class EventsController extends Controller
         // set the index tab in the session
         $listParamSessionStore->setIndexTab(action([EventsController::class, 'index']));
 
+        // $date is a user-supplied route param; crawlers hit this with non-date junk
+        // (e.g. /events/upcoming/www.parktildark.com), which makes Carbon::parse() throw.
+        // Treat anything that isn't a real date as a missing page rather than a 500.
+        try {
+            $baseDate = $date === '' ? Carbon::now() : Carbon::parse($date);
+        } catch (\Throwable $e) {
+            abort(404);
+        }
+
         // use the window to get the last date and set the criteria between
-        $next_day = Carbon::parse($date)->addDays(1);
-        $next_day_window = Carbon::parse($date)->addDays($this->defaultWindow);
-        $prev_day = Carbon::parse($date)->subDays(1);
-        $prev_day_window = Carbon::parse($date)->subDays($this->defaultWindow);
+        $next_day = $baseDate->copy()->addDays(1);
+        $next_day_window = $baseDate->copy()->addDays($this->defaultWindow);
+        $prev_day = $baseDate->copy()->subDays(1);
+        $prev_day_window = $baseDate->copy()->subDays($this->defaultWindow);
 
         // create the base query including any required joins; needs select to make sure only event entities are returned
         $baseQuery = Event::query()->leftJoin('event_types', 'events.event_type_id', '=', 'event_types.id')->select('events.*');

--- a/resources/views/series/feed.blade.php
+++ b/resources/views/series/feed.blade.php
@@ -3,11 +3,13 @@
 	<?php $month = '';?>
 	@foreach ($series as $s)
 
-		@if ($month != $s->start_at->format('F'))
-		<?php $month = $s->start_at->format('F')?>
-		@endif
+		@if ($s->start_at)
+			@if ($month != $s->start_at->format('F'))
+			<?php $month = $s->start_at->format('F')?>
+			@endif
 
-		{!! $s->start_at->format('l F jS Y') !!} <br>
+			{!! $s->start_at->format('l F jS Y') !!} <br>
+		@endif
 		{{ $s->name }}
 
 

--- a/tests/Feature/SeriesTest.php
+++ b/tests/Feature/SeriesTest.php
@@ -56,6 +56,21 @@ class SeriesTest extends TestCase
     }
 
     /**
+     * The /series/export feed must render even when a series has no start_at.
+     *
+     * @return void
+     */
+    public function testExportHandlesSeriesWithNullStartAt()
+    {
+        Series::factory()->create([
+            'start_at' => null,
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+
+        $this->get('/series/export')->assertStatus(200);
+    }
+
+    /**
      * Check the series name appears on the series show page
      *
      * @return void

--- a/tests/Feature/Web/EventsControllerTest.php
+++ b/tests/Feature/Web/EventsControllerTest.php
@@ -54,6 +54,17 @@ class EventsControllerTest extends TestCase
         $this->get('/events/upcoming')->assertOk();
     }
 
+    public function test_index_upcoming_with_valid_date_loads(): void
+    {
+        $this->get('/events/upcoming/2026-06-16')->assertOk();
+    }
+
+    public function test_index_upcoming_with_invalid_date_returns_404(): void
+    {
+        // Crawlers hit this route with non-date junk; it must 404, not 500. (EVENTREPO-EB)
+        $this->get('/events/upcoming/www.parktildark.com')->assertNotFound();
+    }
+
     public function test_show_loads_for_existing_event(): void
     {
         $event = Event::factory()->create();


### PR DESCRIPTION
## Summary

Fixes two high-volume Sentry application bugs in the `eventrepo` project, both 500s triggered by data/input the code didn't guard.

### EVENTREPO-EB — `Carbon\InvalidFormatException` on `/events/upcoming/{date?}` (503 events)
`indexUpcoming()` called `Carbon::parse($date)` directly on a user-supplied route param. Crawlers hit the route with non-date junk (e.g. `/events/upcoming/www.parktildark.com`), throwing a 500.

- Invalid dates now `abort(404)`; an empty param still falls back to `now()` (unchanged behavior).
- Parses once and uses `->copy()` for the window offsets instead of re-parsing the string four times.
- The **identical bug existed in the sibling `indexAdd()` method** — fixed there too.

### EVENTREPO-HF — `Call to a member function format() on null` on `/series/export` (1851 events)
`resources/views/series/feed.blade.php` called `$s->start_at->format(...)` unconditionally; any series with a null `start_at` crashed the export feed. The date output is now guarded with `@if ($s->start_at)`, matching the existing guard further down the same view.

## Tests
- `EventsControllerTest::test_index_upcoming_with_valid_date_loads`
- `EventsControllerTest::test_index_upcoming_with_invalid_date_returns_404`
- `SeriesTest::testExportHandlesSeriesWithNullStartAt`

All pass; PHPStan clean on the changed files.

Fixes EVENTREPO-EB
Fixes EVENTREPO-HF

🤖 Generated with [Claude Code](https://claude.com/claude-code)