### PR TITLE
Sentry batch: /profile, user tabs, list sort, event-update created_by (+ regression coverage)

### DIFF
--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -2197,6 +2197,11 @@ class EventsController extends Controller
         $input = $request->input();
         $input['updated_by'] = $this->user->id;
 
+        // created_by is immutable after creation; never let request input (e.g. an
+        // empty hidden field coerced to null) overwrite it and trip the NOT NULL
+        // constraint (EVENTREPO-VM).
+        unset($input['created_by']);
+
         $event->fill($input)->save();
 
         $tagArray = $request->input('tag_list', []);

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -71,7 +71,7 @@ class UsersController extends Controller
 
     public function __construct(UserFilters $filter)
     {
-        $this->middleware('auth', ['only' => ['create', 'edit', 'store', 'update']]);
+        $this->middleware('auth', ['only' => ['create', 'edit', 'store', 'update', 'profile']]);
         $this->filter = $filter;
 
         // prefix for session storage
@@ -287,14 +287,22 @@ class UsersController extends Controller
 
     public function setTabs(Request $request): void
     {
-        if (null !== $request->input('tabs')) {
-            $request->session()->put($this->prefix.'tabs', $request->input('tabs'));
+        // Only persist a well-formed tabs array; a scalar like ?tabs=foo would otherwise
+        // poison the session and break array access in the view.
+        $tabs = $request->input('tabs');
+        if (is_array($tabs)) {
+            $request->session()->put($this->prefix.'tabs', $tabs);
         }
     }
 
     public function getTabs(Request $request): array
     {
-        return $request->session()->get($this->prefix.'tabs', $this->getDefaultTabs());
+        // Merge over the defaults so every expected key (events, following) is always
+        // present, even when only a subset was supplied, e.g. ?tabs[events]=created
+        // (EVENTREPO-TJ).
+        $stored = $request->session()->get($this->prefix.'tabs', []);
+
+        return array_merge($this->getDefaultTabs(), is_array($stored) ? $stored : []);
     }
 
     public function show(User $user, Request $request): RedirectResponse | View
@@ -345,9 +353,13 @@ class UsersController extends Controller
         return view('users.show-tw', compact('user', 'tabs', 'token', 'canViewFullProfile'));
     }
 
-    public function profile(User $user, Request $request): RedirectResponse
+    public function profile(Request $request): RedirectResponse
     {
-        $this->middleware('auth');
+        // The 'auth' middleware (registered in the constructor) guarantees a signed-in
+        // user here; guard anyway so a null user can never dereference ->id (EVENTREPO-HH).
+        if (!$this->user) {
+            return redirect()->guest(route('login'));
+        }
 
         return redirect('users/'.$this->user->id);
     }

--- a/app/Http/ResultBuilder/ListEntityResultBuilder.php
+++ b/app/Http/ResultBuilder/ListEntityResultBuilder.php
@@ -212,7 +212,9 @@ class ListEntityResultBuilder implements ListResultBuilderInterface
         // getQueryResult() must be called first otherwise sort isn't set correctly
         $listResult->setList($this->getQueryResult());
 
-        $listResult->setSort($this->appliedSortField);
+        // appliedSortField can be null when no valid sort resolves and the builder has
+        // no single default column; setSort() requires a string (EVENTREPO-TB).
+        $listResult->setSort($this->appliedSortField ?? '');
         $listResult->setSortDirection($this->appliedSortDirection);
         $listResult->setFilters($this->userFilters);
         $listResult->setDefaultFilters($this->defaultFilters);

--- a/tests/Feature/ActivityTest.php
+++ b/tests/Feature/ActivityTest.php
@@ -16,6 +16,14 @@ class ActivityTest extends TestCase
     protected $seed = true;
 
     /** @test */
+    public function the_activity_index_loads()
+    {
+        // Exercises ListEntityResultBuilder::listResultSetFactory()/setSort(); must not
+        // 500 on a null sort field (EVENTREPO-TB).
+        $this->get('/activity')->assertOk();
+    }
+
+    /** @test */
     public function it_records_activity_when_a_thread_is_created()
     {
         $this->signIn();

--- a/tests/Feature/ApiForumsCrudTest.php
+++ b/tests/Feature/ApiForumsCrudTest.php
@@ -65,6 +65,20 @@ class ApiForumsCrudTest extends TestCase
         $this->assertDatabaseHas('forums', ['slug' => $slug]);
     }
 
+    public function test_store_ignores_non_fillable_short_field(): void
+    {
+        // 'short' is not a forums column; it must be ignored, not reach the INSERT
+        // and 500 with "Unknown column 'short'" (EVENTREPO-W0).
+        $slug = 'test-forum-short-'.uniqid();
+
+        $this->postJson('/api/forums', $this->payload([
+            'slug' => $slug,
+            'short' => 'should be ignored',
+        ]))->assertStatus(200);
+
+        $this->assertDatabaseHas('forums', ['slug' => $slug]);
+    }
+
     public function test_store_rejects_payload_missing_required_fields(): void
     {
         $this->postJson('/api/forums', ['description' => 'incomplete'])

--- a/tests/Feature/EventsTest.php
+++ b/tests/Feature/EventsTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\Entity;
+use App\Models\Event;
 use App\Models\Tag;
 use App\Models\User;
 use App\Models\UserStatus;
@@ -42,6 +43,27 @@ class EventsTest extends TestCase
             ->assertOk()
             ->assertSee('No age limit specified')
             ->assertSeeInOrder(['id="min_age"', 'option value="" selected'], false);
+    }
+
+    public function testUpdateDoesNotNullCreatedByFromEmptyInput()
+    {
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $event = Event::factory()->create(['created_by' => $user->id]);
+
+        $response = $this->actingAs($user)->put('/events/'.$event->id, [
+            'name' => 'Updated Event Name',
+            'slug' => 'updated-event-name-'.$event->id,
+            'start_at' => '2026-07-01 20:00:00',
+            'event_type_id' => $event->event_type_id,
+            'visibility_id' => $event->visibility_id,
+            // An empty hidden field becomes null via ConvertEmptyStringsToNull and
+            // must not overwrite created_by and trip the NOT NULL constraint
+            // (EVENTREPO-VM).
+            'created_by' => '',
+        ]);
+
+        $response->assertRedirect();
+        $this->assertSame($user->id, (int) $event->fresh()->created_by);
     }
 
     /**

--- a/tests/Feature/ListSortHardeningTest.php
+++ b/tests/Feature/ListSortHardeningTest.php
@@ -28,13 +28,13 @@ class ListSortHardeningTest extends TestCase
         parent::tearDown();
     }
 
-    private function buildList(?string $sortField)
+    private function buildList(?string $sortField, ?string $sortDirection = 'desc')
     {
         $params = Mockery::mock(ListQueryParameters::class);
         $params->shouldReceive('getFilters')->andReturn([]);
         $params->shouldReceive('getIsEmptyFilter')->andReturn(false);
         $params->shouldReceive('getSortFieldName')->andReturn($sortField);
-        $params->shouldReceive('getSortDirection')->andReturn('desc');
+        $params->shouldReceive('getSortDirection')->andReturn($sortDirection);
         $params->shouldReceive('getLimit')->andReturn(25);
         $params->shouldReceive('getPage')->andReturn(1);
 
@@ -55,6 +55,29 @@ class ListSortHardeningTest extends TestCase
         // Fell back to the safe default rather than the malformed input...
         $this->assertSame('photos.created_at', $result->getSort());
         // ...and the built query executes without a bad-column SQLSTATE error.
+        $result->getList()->get();
+        $this->assertTrue(true);
+    }
+
+    public function test_malformed_sort_direction_falls_back_and_query_runs(): void
+    {
+        // A bad direction (e.g. from a stale session or fuzz probe) must normalize
+        // to a safe value rather than throwing "Order direction must be 'asc' or
+        // 'desc'" (EVENTREPO-V4 on /photos, EVENTREPO-TD on /series).
+        $result = $this->buildList('photos.name', 'garbage');
+
+        $this->assertSame('desc', $result->getSortDirection());
+        $result->getList()->get();
+        $this->assertTrue(true);
+    }
+
+    public function test_null_sort_field_does_not_break_set_sort(): void
+    {
+        // With no resolvable field and a multi-column default, appliedSortField is
+        // null; setSort() must still receive a string (EVENTREPO-TB).
+        $result = $this->buildList(null);
+
+        $this->assertIsString($result->getSort());
         $result->getList()->get();
         $this->assertTrue(true);
     }

--- a/tests/Feature/Web/UsersControllerTest.php
+++ b/tests/Feature/Web/UsersControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Web;
 
+use App\Models\Profile;
 use App\Models\User;
 use App\Models\UserStatus;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -50,5 +51,33 @@ class UsersControllerTest extends TestCase
         $response = $this->actingAs($viewer)->get('/profile/'.$target->id);
 
         $this->assertContains($response->status(), [200, 302]);
+    }
+
+    public function test_profile_redirect_requires_auth(): void
+    {
+        // Guests must be redirected to login, not dereference a null user (EVENTREPO-HH).
+        $this->get('/profile')->assertStatus(302);
+    }
+
+    public function test_profile_redirects_authenticated_user_to_their_page(): void
+    {
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        $this->actingAs($user)->get('/profile')->assertRedirect('users/'.$user->id);
+    }
+
+    public function test_show_with_partial_tabs_does_not_error(): void
+    {
+        $target = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        Profile::factory()->create([
+            'user_id' => $target->id,
+            'setting_public_profile' => 1,
+        ]);
+
+        // A partial tabs param (no "following") must not throw "Undefined array
+        // key" when the view renders the tab bar (EVENTREPO-TJ).
+        $this->actingAs($target)
+            ->get('/users/'.$target->id.'?tabs[events]=created')
+            ->assertOk();
     }
 }


### PR DESCRIPTION
## Summary

Fixes a batch of `eventrepo` Sentry application bugs. Some are fixed with code here; others were already fixed on `main` in earlier PRs but keep firing because prod hasn't been deployed — for those this PR adds regression coverage and references the issues so they auto-close on merge.

## Fixed in this PR (code change)

### EVENTREPO-HH — `Attempt to read property "id" on null` on `/profile` (218)
`UsersController::profile()` dereferenced `$this->user->id` for guests; the in-method `$this->middleware('auth')` was a no-op. `profile` is now in the constructor's `auth` list, with a null guard redirecting guests to login. Unused `User $user` param removed (the route has no `{user}`).

### EVENTREPO-TJ — `Undefined array key "following"` on `/users/{user}` (151)
`setTabs()` persisted partial input like `?tabs[events]=created`, so the view read a missing `$tabs['following']`. `getTabs()` now merges over the defaults (both keys always present); `setTabs()` only stores an array (a scalar `?tabs=foo` no longer poisons the session).

### EVENTREPO-VM — `Column 'created_by' cannot be null` on `PATCH /events/{event}` (8)
`EventsController::update()` let request input set `created_by` to null (empty hidden field coerced by `ConvertEmptyStringsToNull`). `created_by` is immutable after creation, so it's now unset from the update input.

### EVENTREPO-TB — `setSort(): … null given` on `/activity` (212) — defensive
`ListResultSet::setSort()` requires a string but `appliedSortField` can be null for lists without a single default column. Coerced to `''` at the call site, closing the null path for **every** list page. (`/activity` itself was already covered by #1923.)

## Regression coverage only (already fixed on `main`, pending prod deploy)

- **EVENTREPO-V4 (`/photos`) / EVENTREPO-TD (`/series`)** — `Order direction must be "asc" or "desc"`. Fixed in #1923 (direction normalization); added a test asserting a malformed direction normalizes instead of throwing.
- **EVENTREPO-W0** — `Unknown column 'short'` on `POST /api/forums`. Fixed in #1919 (removed `short` from `Forum::$fillable`); added a test that an extra `short` field is ignored.

## Not a code change

- **EVENTREPO-V8** — `Unknown column 'setting_notify_threads_by_follow'`. The idempotent migration already ships in the repo (`2026_05_14_…`); this was a missing-migration-on-prod (deploy) issue.

## Tests
- `UsersControllerTest`: profile auth + redirect; user show with partial tabs
- `EventsTest::testUpdateDoesNotNullCreatedByFromEmptyInput`
- `ActivityTest::the_activity_index_loads`
- `ListSortHardeningTest`: malformed direction + null sort field
- `ApiForumsCrudTest::test_store_ignores_non_fillable_short_field`

All pass; PHPStan clean on changed files.

Fixes EVENTREPO-HH
Fixes EVENTREPO-TJ
Fixes EVENTREPO-TB
Fixes EVENTREPO-VM
Fixes EVENTREPO-V4
Fixes EVENTREPO-TD
Fixes EVENTREPO-W0

🤖 Generated with [Claude Code](https://claude.com/claude-code)