### PR TITLE
Fix unfollow/unlike 500s, alias data corruption, and a post visibility leak

### DIFF
--- a/app/Http/Controllers/Api/BlogsController.php
+++ b/app/Http/Controllers/Api/BlogsController.php
@@ -376,13 +376,15 @@ class BlogsController extends Controller
             return back();
         }
 
-        // update the likes
-        --$blog->likes;
-        $blog->save();
-
         // delete the like
         $response = Like::where('object_id', '=', $id)->where('user_id', '=', $this->user->id)->where('object_type', '=', 'blog')->first();
-        $response->delete();
+        if ($response) {
+            $response->delete();
+
+            // update the likes
+            --$blog->likes;
+            $blog->save();
+        }
 
         flash()->success('Success', 'You are no longer liking the blog.');
 

--- a/app/Http/Controllers/Api/EntitiesController.php
+++ b/app/Http/Controllers/Api/EntitiesController.php
@@ -662,7 +662,7 @@ class EntitiesController extends Controller
 
         // check the elements in the alias list, and if any don't match, add the alias
         foreach ($aliasArray as $key => $alias) {
-            if (DB::table('aliases')->where('id', $alias)->count() > 0) {
+            if (!is_numeric($alias) || DB::table('aliases')->where('id', $alias)->count() === 0) {
                 $newAlias = new Alias();
                 $newAlias->name = ucwords(strtolower($alias));
                 $newAlias->save();
@@ -1352,10 +1352,12 @@ class EntitiesController extends Controller
 
         // delete the follow
         $follow = Follow::where('object_id', '=', $id)->where('user_id', '=', $this->user->id)->where('object_type', '=', 'entity')->first();
-        $follow->delete();
+        if ($follow) {
+            $follow->delete();
 
-        // add to activity log
-        Activity::log($entity, $this->user, 7);
+            // add to activity log
+            Activity::log($entity, $this->user, 7);
+        }
 
         // handle the request if ajax
         if ($request->ajax()) {

--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -127,15 +127,6 @@ class PostsController extends Controller
 
         $this->hasFilter = $listResultSet->getFilters() != $listResultSet->getDefaultFilters() || $listResultSet->getIsEmptyFilter();
 
-        // get the result set from the builder
-        $listResultSet = $listEntityResultBuilder->listResultSetFactory();
-
-        // get the query builder
-        $query = $listResultSet->getList();
-
-        // get the posts
-        $posts = $query->paginate($listResultSet->getLimit());
-
         return response()->json(new PostCollection($posts));
     }
 
@@ -592,13 +583,15 @@ class PostsController extends Controller
             return back();
         }
 
-        // update the likes
-        --$post->likes;
-        $post->save();
-
         // delete the like
         $response = Like::where('object_id', '=', $id)->where('user_id', '=', $this->user->id)->where('object_type', '=', 'post')->first();
-        $response->delete();
+        if ($response) {
+            $response->delete();
+
+            // update the likes
+            --$post->likes;
+            $post->save();
+        }
 
         flash()->success('Success', 'You are no longer liking the post.');
 

--- a/app/Http/Controllers/Api/SeriesController.php
+++ b/app/Http/Controllers/Api/SeriesController.php
@@ -576,7 +576,7 @@ class SeriesController extends Controller
 
         // check the elements in the tag list, and if any don't match, add the tag
         foreach ($tagArray as $key => $tag) {
-            if (count(DB::table('tags')->where('id', $tag)->get()) > 0) {
+            if (!is_numeric($tag) || count(DB::table('tags')->where('id', $tag)->get()) === 0) {
                 $newTag = new Tag();
                 $newTag->name = ucwords(strtolower($tag));
                 $newTag->slug = Str::slug($tag);
@@ -904,10 +904,12 @@ class SeriesController extends Controller
 
         // delete the follow
         $response = Follow::where('object_id', '=', $id)->where('user_id', '=', $this->user->id)->where('object_type', '=', 'series')->first();
-        $response->delete();
+        if ($response) {
+            $response->delete();
 
-        // add to activity log
-        Activity::log($series, $this->user, 7);
+            // add to activity log
+            Activity::log($series, $this->user, 7);
+        }
 
         if ($request->ajax()) {
             return [

--- a/app/Http/Controllers/Api/TagsController.php
+++ b/app/Http/Controllers/Api/TagsController.php
@@ -384,12 +384,14 @@ class TagsController extends Controller
             return back();
         }
 
-        // add to activity log
-        Activity::log($tag, $this->user, 7);
-
         // delete the follow
         $response = Follow::where('object_id', '=', $id)->where('user_id', '=', $this->user->id)->where('object_type', '=', $type)->first();
-        $response->delete();
+        if ($response) {
+            $response->delete();
+
+            // add to activity log
+            Activity::log($tag, $this->user, 7);
+        }
 
         // handle the request if ajax
         if ($request->ajax()) {

--- a/app/Http/Controllers/BlogsController.php
+++ b/app/Http/Controllers/BlogsController.php
@@ -417,13 +417,15 @@ class BlogsController extends Controller
             return back();
         }
 
-        // update the likes
-        --$blog->likes;
-        $blog->save();
-
         // delete the like
         $response = Like::where('object_id', '=', $id)->where('user_id', '=', $this->user->id)->where('object_type', '=', 'blog')->first();
-        $response->delete();
+        if ($response) {
+            $response->delete();
+
+            // update the likes
+            --$blog->likes;
+            $blog->save();
+        }
 
         flash()->success('Success', 'You are no longer liking the blog.');
 

--- a/app/Http/Controllers/EntitiesController.php
+++ b/app/Http/Controllers/EntitiesController.php
@@ -759,7 +759,7 @@ class EntitiesController extends Controller
 
         // check the elements in the alias list, and if any don't match, add the alias
         foreach ($aliasArray as $key => $alias) {
-            if (DB::table('aliases')->where('id', $alias)->count() > 0) {
+            if (!is_numeric($alias) || DB::table('aliases')->where('id', $alias)->count() === 0) {
                 $newAlias = new Alias();
                 $newAlias->name = ucwords(strtolower($alias));
                 $newAlias->save();
@@ -1272,10 +1272,12 @@ class EntitiesController extends Controller
 
         // delete the follow
         $follow = Follow::where('object_id', '=', $id)->where('user_id', '=', $this->user->id)->where('object_type', '=', 'entity')->first();
-        $follow->delete();
+        if ($follow) {
+            $follow->delete();
 
-        // add to activity log
-        Activity::log($entity, $this->user, Action::UNFOLLOW);
+            // add to activity log
+            Activity::log($entity, $this->user, Action::UNFOLLOW);
+        }
 
         // handle the request if ajax
         if ($request->ajax()) {

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -645,13 +645,15 @@ class PostsController extends Controller
             return back();
         }
 
-        // update the likes
-        --$post->likes;
-        $post->save();
-
         // delete the like
         $response = Like::where('object_id', '=', $id)->where('user_id', '=', $this->user->id)->where('object_type', '=', 'post')->first();
-        $response->delete();
+        if ($response) {
+            $response->delete();
+
+            // update the likes
+            --$post->likes;
+            $post->save();
+        }
 
         flash()->success('Success', 'You are no longer liking the post.');
 

--- a/app/Http/Controllers/SeriesController.php
+++ b/app/Http/Controllers/SeriesController.php
@@ -977,10 +977,12 @@ class SeriesController extends Controller
 
         // delete the follow
         $response = Follow::where('object_id', '=', $id)->where('user_id', '=', $this->user->id)->where('object_type', '=', 'series')->first();
-        $response->delete();
+        if ($response) {
+            $response->delete();
 
-        // add to activity log
-        Activity::log($series, $this->user, 7);
+            // add to activity log
+            Activity::log($series, $this->user, 7);
+        }
 
         if ($request->ajax()) {
             return [

--- a/app/Http/Controllers/TagsController.php
+++ b/app/Http/Controllers/TagsController.php
@@ -430,12 +430,14 @@ class TagsController extends Controller
             return back();
         }
 
-        // add to activity log
-        Activity::log($tag, $this->user, 7);
-
         // delete the follow
         $response = Follow::where('object_id', '=', $id)->where('user_id', '=', $this->user->id)->where('object_type', '=', $type)->first();
-        $response->delete();
+        if ($response) {
+            $response->delete();
+
+            // add to activity log
+            Activity::log($tag, $this->user, 7);
+        }
 
         // handle the request if ajax
         if ($request->ajax()) {

--- a/tests/Feature/ApiEntityAliasSyncTest.php
+++ b/tests/Feature/ApiEntityAliasSyncTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Alias;
+use App\Models\Entity;
+use App\Models\EntityStatus;
+use App\Models\EntityType;
+use App\Models\User;
+use App\Models\UserStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Regression test for the inverted alias-existence condition in
+ * EntitiesController::store (and its API twin).
+ *
+ * The original condition created a brand-new alias whenever the supplied
+ * id ALREADY existed (and tried to attach a raw id-string as an alias id
+ * when it did NOT). The result was duplicate alias rows and the wrong
+ * alias being attached. The fix flips the condition so an existing alias
+ * id is attached as-is and only genuinely new names create rows.
+ */
+class ApiEntityAliasSyncTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+        $this->user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $this->actingAs($this->user, 'sanctum');
+    }
+
+    private function payload(array $overrides = []): array
+    {
+        return array_merge([
+            'name' => 'ZZ-Alias-Entity',
+            'slug' => 'zz-alias-entity-'.uniqid(),
+            'short' => 'short',
+            'description' => 'description',
+            'entity_type_id' => EntityType::first()->id,
+            'entity_status_id' => EntityStatus::first()->id,
+        ], $overrides);
+    }
+
+    /** @test */
+    public function storing_with_an_existing_alias_id_attaches_it_without_duplicating(): void
+    {
+        $alias = Alias::create(['name' => 'The Original Alias']);
+        $aliasCountBefore = Alias::count();
+
+        $response = $this->postJson('/api/entities', $this->payload([
+            'alias_list' => [$alias->id],
+        ]));
+
+        $response->assertOk();
+
+        $entity = Entity::where('name', 'ZZ-Alias-Entity')->firstOrFail();
+
+        // The existing alias is attached...
+        $this->assertTrue(
+            $entity->aliases->contains('id', $alias->id),
+            'Existing alias should be attached to the entity.'
+        );
+        // ...and no duplicate alias row was created.
+        $this->assertSame($aliasCountBefore, Alias::count());
+    }
+}

--- a/tests/Feature/UnfollowUnlikeNullGuardTest.php
+++ b/tests/Feature/UnfollowUnlikeNullGuardTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Entity;
+use App\Models\Post;
+use App\Models\Series;
+use App\Models\Tag;
+use App\Models\User;
+use App\Models\UserStatus;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Regression tests for the unfollow/unlike null-dereference bug.
+ *
+ * Previously these endpoints called ->delete() on the result of a
+ * Follow/Like lookup without checking it was non-null, so hitting an
+ * unfollow/unlike URL for something you were not actually following
+ * (e.g. a stale link, a double-click, or a crafted request) threw a
+ * 500. The fix guards the delete behind an existence check; these
+ * tests lock in the graceful behaviour.
+ */
+class UnfollowUnlikeNullGuardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private function activeUser(): User
+    {
+        return User::factory()->create([
+            'email_verified_at' => Carbon::now(),
+            'user_status_id' => UserStatus::ACTIVE,
+        ]);
+    }
+
+    /** @test */
+    public function unfollowing_an_entity_you_do_not_follow_does_not_error(): void
+    {
+        $this->actingAs($this->activeUser());
+        $entity = Entity::factory()->create();
+
+        $response = $this->get('/entities/'.$entity->id.'/unfollow');
+
+        $response->assertRedirect();
+        $this->assertEquals(0, $entity->follows()->count());
+    }
+
+    /** @test */
+    public function unfollowing_a_series_you_do_not_follow_does_not_error(): void
+    {
+        $this->actingAs($this->activeUser());
+        $series = Series::factory()->create();
+
+        $response = $this->get('/series/'.$series->id.'/unfollow');
+
+        $response->assertRedirect();
+    }
+
+    /** @test */
+    public function unfollowing_a_tag_you_do_not_follow_does_not_error(): void
+    {
+        $this->actingAs($this->activeUser());
+        $tag = Tag::factory()->create();
+
+        $response = $this->get('/tags/'.$tag->id.'/unfollow');
+
+        $response->assertRedirect();
+    }
+
+    /** @test */
+    public function unliking_a_post_you_do_not_like_does_not_error_or_decrement_likes(): void
+    {
+        $this->actingAs($this->activeUser());
+        $post = Post::factory()->create(['likes' => 3]);
+
+        $response = $this->get('/posts/'.$post->id.'/unlike');
+
+        $response->assertRedirect();
+        // Likes must not be decremented when no like existed.
+        $this->assertEquals(3, $post->fresh()->likes);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a cluster of real, user-reachable correctness & security bugs surfaced by an API/controller audit. All fixes verified against the live route bindings (the web routes bind the non-`Api\` controllers — the `Api\*` plain `unfollow`/`unlike` methods are unrouted, so the reachable copies are fixed too).

### 1. Null-dereference 500s — `unfollow` / `unlike`
These looked up a `Follow`/`Like` and called `->delete()` on it with **no null check**. Hitting the endpoint for something you weren't actually following/liking (stale link, double-click, crafted request) threw a **500**. Now guarded behind an existence check on the live web controllers (Entities/Series/Tags `unfollow`, Posts `unlike`) and mirrored in the API copies. For `unlike`, the `--likes` decrement now only runs when a like existed, so the counter can't drift negative on a no-op.

### 2. Inverted alias/tag existence condition — data corruption
`EntitiesController::store` had an **inverted alias check**: an existing alias id created a *duplicate* alias and attached the wrong one, while a new name was attached as a raw id. Fixed in the web + API copies, plus the matching inverted tag condition in `Api\SeriesController::store`. Hardened with an `is_numeric` guard to match the sibling tag loop.

### 3. Visibility leak + double query
`Api\PostsController::index` built a `visible($user)`-scoped query, then rebuilt and **overwrote it without the scope** — leaking private posts and running the query twice. Removed the duplicate.

## Tests
- `tests/Feature/UnfollowUnlikeNullGuardTest.php` — covers the live unfollow/unlike routes.
- `tests/Feature/ApiEntityAliasSyncTest.php` — locks in correct alias attachment / no duplication.

Both were confirmed to **fail against the buggy code** and pass after the fix. Related API suites (59 tests) all pass; PHPStan is clean across the diff.

## Deferred follow-ups (need a product decision)
Left untouched because they're behavior-changing: missing auth on `addPhoto`/`createThread`, lookup-table controllers letting any logged-in user mutate global reference data, `EntitiesController::update`/`patch` missing the ownership check `destroy` has, and mass-assignment via `$request->all()` in `store`/`update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)