### PR TITLE
API security hardening: visibility scoping, DoS limits, authorization guards

### DIFF
--- a/app/Http/Controllers/Api/BlogsController.php
+++ b/app/Http/Controllers/Api/BlogsController.php
@@ -97,7 +97,8 @@ class BlogsController extends Controller
         $query = $listResultSet->getList();
 
         // get the blogs
-        $blogs = $query->paginate($listResultSet->getLimit());
+        /* @phpstan-ignore-next-line */
+        $blogs = $query->visible($this->user)->paginate($listResultSet->getLimit());
 
         return response()->json(new BlogCollection($blogs));
     }

--- a/app/Http/Controllers/Api/EntitiesController.php
+++ b/app/Http/Controllers/Api/EntitiesController.php
@@ -164,8 +164,8 @@ class EntitiesController extends Controller
      */
     public function popular(Request $request): JsonResponse
     {
-        $days = (int) $request->get('days', 30);
-        $limit = (int) $request->get('limit', 30);
+        $days = min(max((int) $request->get('days', 30), 1), 365);
+        $limit = min(max((int) $request->get('limit', 30), 1), \App\Http\Requests\ListQueryParameters::MAX_LIMIT);
         $from = Carbon::now()->subDays($days);
 
         $query = Entity::query()

--- a/app/Http/Controllers/Api/EntitiesController.php
+++ b/app/Http/Controllers/Api/EntitiesController.php
@@ -707,8 +707,12 @@ class EntitiesController extends Controller
      * relations (tags, aliases, roles) sync to the supplied arrays — missing
      * keys mean "detach all", per strict REST semantics.
      */
-    public function update(Entity $entity, EntityRequest $request): JsonResponse
+    public function update(Entity $entity, EntityRequest $request): JsonResponse|\Symfony\Component\HttpFoundation\Response
     {
+        if ($entity->created_by !== $this->user->id) {
+            return $this->unauthorized($request);
+        }
+
         $input = $request->all();
         $input['slug'] = Str::slug($request->input('slug', '-'));
 
@@ -741,8 +745,12 @@ class EntitiesController extends Controller
      * PATCH: partial update. Only fields present in the body are touched;
      * scalars and relations not in the request are left untouched.
      */
-    public function patch(Entity $entity, EntityPatchRequest $request): JsonResponse
+    public function patch(Entity $entity, EntityPatchRequest $request): JsonResponse|\Symfony\Component\HttpFoundation\Response
     {
+        if ($entity->created_by !== $this->user->id) {
+            return $this->unauthorized($request);
+        }
+
         $input = $request->all();
 
         if (array_key_exists('slug', $input)) {

--- a/app/Http/Controllers/Api/EntitiesController.php
+++ b/app/Http/Controllers/Api/EntitiesController.php
@@ -858,6 +858,15 @@ class EntitiesController extends Controller
             'file' => 'required|mimes:jpg,jpeg,png,gif,webp',
         ]);
 
+        // only the entity owner (or an admin) may add photos — checked
+        // before any file is written to storage
+        $entity = Entity::find($id);
+        if ($entity
+            && (!$this->user
+                || ($entity->created_by !== $this->user->id && !$this->user->hasGroup('admin') && !$this->user->hasGroup('super_admin')))) {
+            return response()->json(['message' => 'Not authorized.'], 403);
+        }
+
         $fileName = time().'_'.$request->file->getClientOriginalName();
         $filePath = $request->file('file')->storePubliclyAs('photos', $fileName, 'external');
 

--- a/app/Http/Controllers/Api/EntityStatusesController.php
+++ b/app/Http/Controllers/Api/EntityStatusesController.php
@@ -165,6 +165,10 @@ class EntityStatusesController extends Controller
      */
     public function store(EntityStatusRequest $request, EntityStatus $entityStatus): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $input = $request->all();
 
         $entityStatus = EntityStatus::create($input);
@@ -186,6 +190,10 @@ class EntityStatusesController extends Controller
      */
     public function update(EntityStatus $entityStatus, EntityStatusRequest $request): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $entityStatus->fill($request->all())->save();
 
         return response()->json($entityStatus);
@@ -196,6 +204,10 @@ class EntityStatusesController extends Controller
      */
     public function patch(EntityStatus $entityStatus, EntityStatusPatchRequest $request): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $input = $request->all();
         $scalarInput = array_intersect_key($input, array_flip($entityStatus->getFillable()));
         if (!empty($scalarInput)) {
@@ -210,6 +222,10 @@ class EntityStatusesController extends Controller
      */
     public function destroy(EntityStatus $entityStatus): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $name = $entityStatus->name;
 
         try {

--- a/app/Http/Controllers/Api/EntityTypesController.php
+++ b/app/Http/Controllers/Api/EntityTypesController.php
@@ -166,6 +166,10 @@ class EntityTypesController extends Controller
      */
     public function store(EntityTypeRequest $request): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $input = $request->all();
 
         $entityType = EntityType::create($input);
@@ -189,6 +193,10 @@ class EntityTypesController extends Controller
      */
     public function update(EntityType $entityType, EntityTypeRequest $request): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $entityType->fill($request->all())->save();
 
         return response()->json($entityType);
@@ -199,6 +207,10 @@ class EntityTypesController extends Controller
      */
     public function patch(EntityType $entityType, EntityTypePatchRequest $request): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $input = $request->all();
         $scalarInput = array_intersect_key($input, array_flip($entityType->getFillable()));
         if (!empty($scalarInput)) {
@@ -213,6 +225,10 @@ class EntityTypesController extends Controller
      */
     public function destroy(EntityType $entityType): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $name = $entityType->name;
 
         try {

--- a/app/Http/Controllers/Api/EventStatusesController.php
+++ b/app/Http/Controllers/Api/EventStatusesController.php
@@ -113,6 +113,10 @@ class EventStatusesController extends Controller
 
     public function store(EventStatusRequest $request): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $input = $request->all();
 
         $eventStatus = EventStatus::create($input);
@@ -130,6 +134,10 @@ class EventStatusesController extends Controller
      */
     public function update(EventStatus $eventStatus, EventStatusRequest $request): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $eventStatus->fill($request->all())->save();
 
         return response()->json($eventStatus);
@@ -140,6 +148,10 @@ class EventStatusesController extends Controller
      */
     public function patch(EventStatus $eventStatus, EventStatusPatchRequest $request): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $input = $request->all();
         $scalarInput = array_intersect_key($input, array_flip($eventStatus->getFillable()));
         if (!empty($scalarInput)) {
@@ -151,6 +163,10 @@ class EventStatusesController extends Controller
 
     public function destroy(EventStatus $eventStatus): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $name = $eventStatus->name;
 
         try {

--- a/app/Http/Controllers/Api/EventTypesController.php
+++ b/app/Http/Controllers/Api/EventTypesController.php
@@ -166,6 +166,10 @@ class EventTypesController extends Controller
      */
     public function store(EventTypeRequest $request): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $input = $request->all();
 
         $eventType = EventType::create($input);
@@ -188,6 +192,10 @@ class EventTypesController extends Controller
      */
     public function update(EventType $eventType, EventTypeRequest $request): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $eventType->fill($request->all())->save();
 
         return response()->json($eventType);
@@ -198,6 +206,10 @@ class EventTypesController extends Controller
      */
     public function patch(EventType $eventType, EventTypePatchRequest $request): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $input = $request->all();
         $scalarInput = array_intersect_key($input, array_flip($eventType->getFillable()));
         if (!empty($scalarInput)) {
@@ -212,6 +224,10 @@ class EventTypesController extends Controller
      */
     public function destroy(EventType $eventType): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $name = $eventType->name;
 
         try {

--- a/app/Http/Controllers/Api/EventsController.php
+++ b/app/Http/Controllers/Api/EventsController.php
@@ -1670,6 +1670,13 @@ class EventsController extends Controller
         ]);
 
         if ($event = Event::find($id)) {
+
+            // only the event owner (or an admin) may add photos
+            if (!$this->user
+                || (!$event->ownedBy($this->user) && !$this->user->hasGroup('admin') && !$this->user->hasGroup('super_admin'))) {
+                return response()->json(['message' => 'Not authorized.'], 403);
+            }
+
             $photo = $imageHandler->makePhoto($request->file('file'));
 
             if (isset($event->photos) && 0 === count($event->photos)) {

--- a/app/Http/Controllers/Api/EventsController.php
+++ b/app/Http/Controllers/Api/EventsController.php
@@ -183,8 +183,8 @@ class EventsController extends Controller
      */
     public function popular(Request $request): JsonResponse
     {
-        $days = (int) $request->get('days', 30);
-        $limit = (int) $request->get('limit', 30);
+        $days = min(max((int) $request->get('days', 30), 1), 365);
+        $limit = min(max((int) $request->get('limit', 30), 1), \App\Http\Requests\ListQueryParameters::MAX_LIMIT);
         $from = Carbon::now()->subDays($days);
 
         $query = Event::query()

--- a/app/Http/Controllers/Api/EventsController.php
+++ b/app/Http/Controllers/Api/EventsController.php
@@ -150,6 +150,7 @@ class EventsController extends Controller
         // get the events
         // @phpstan-ignore-next-line
         $events = $query
+            ->visible($this->user)
             ->with([
                 'visibility',
                 'venue.links',
@@ -195,6 +196,7 @@ class EventsController extends Controller
             ->filter($this->filter);
 
         $events = $query
+            ->visible($this->user)
             ->with([
                 'visibility',
                 'venue.links',

--- a/app/Http/Controllers/Api/ForumsController.php
+++ b/app/Http/Controllers/Api/ForumsController.php
@@ -159,7 +159,7 @@ class ForumsController extends Controller
         /* @phpstan-ignore-next-line */
         $forums = $query->visible($this->user)
             ->with(['visibility', 'threadsCount'])
-            ->paginate(1000000);
+            ->paginate($listResultSet->getLimit());
 
         // saves the updated session
         $listParamSessionStore->save();

--- a/app/Http/Controllers/Api/MenusController.php
+++ b/app/Http/Controllers/Api/MenusController.php
@@ -87,6 +87,10 @@ class MenusController extends Controller
 
     public function store(MenuRequest $request, Menu $menu): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $menu = $menu->create($request->all());
 
         return response()->json(new MenuResource($menu), 201);
@@ -98,6 +102,10 @@ class MenusController extends Controller
      */
     public function update(Menu $menu, MenuRequest $request): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $input = $request->all();
 
         if (!array_key_exists('menu_parent_id', $input)) {
@@ -114,6 +122,10 @@ class MenusController extends Controller
      */
     public function patch(Menu $menu, MenuPatchRequest $request): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $input = $request->all();
         $scalarInput = array_intersect_key($input, array_flip($menu->getFillable()));
         if (!empty($scalarInput)) {
@@ -125,6 +137,10 @@ class MenusController extends Controller
 
     public function destroy(Menu $menu): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $menu->delete();
 
         return response()->json([], 204);

--- a/app/Http/Controllers/Api/RolesController.php
+++ b/app/Http/Controllers/Api/RolesController.php
@@ -103,6 +103,10 @@ class RolesController extends Controller
 
     public function store(RoleRequest $request): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $input = $request->all();
         $role = Role::create($input);
 
@@ -120,6 +124,10 @@ class RolesController extends Controller
      */
     public function update(Role $role, RoleRequest $request): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $input = $request->all();
 
         if (!array_key_exists('short', $input)) {
@@ -136,6 +144,10 @@ class RolesController extends Controller
      */
     public function patch(Role $role, RolePatchRequest $request): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $input = $request->all();
         $scalarInput = array_intersect_key($input, array_flip($role->getFillable()));
         if (!empty($scalarInput)) {
@@ -147,6 +159,10 @@ class RolesController extends Controller
 
     public function destroy(Role $role): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $name = $role->name;
 
         try {

--- a/app/Http/Controllers/Api/SeriesController.php
+++ b/app/Http/Controllers/Api/SeriesController.php
@@ -810,6 +810,12 @@ class SeriesController extends Controller
         // attach to series
         if ($series = Series::find($id)) {
 
+            // only the series owner (or an admin) may add photos
+            if (!$this->user
+                || (!$series->ownedBy($this->user) && !$this->user->hasGroup('admin') && !$this->user->hasGroup('super_admin'))) {
+                return response()->json(['message' => 'Not authorized.'], 403);
+            }
+
             // make the photo object from the file in the request
             $photo = $imageHandler->makePhoto($request->file('file'));
 

--- a/app/Http/Controllers/Api/TagsController.php
+++ b/app/Http/Controllers/Api/TagsController.php
@@ -93,6 +93,10 @@ class TagsController extends Controller
      */
     public function destroy(Tag $tag): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $tag->delete();
 
         return response()->json([], 204);
@@ -287,6 +291,10 @@ class TagsController extends Controller
      */
     public function store(Request $request, Tag $tag): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $input = $request->only(['name', 'slug', 'tag_type_id', 'description']);
 
         $input['slug'] = $input['slug'] ?? Str::slug($input['name'], '-');
@@ -513,6 +521,10 @@ class TagsController extends Controller
      */
     public function update(Tag $tag, Request $request): JsonResponse
     {
+        if ($denied = $this->requireAdmin()) {
+            return $denied;
+        }
+
         $tag->fill($request->only(['name', 'slug', 'tag_type_id', 'description']))->save();
 
         return response()->json(new TagResource($tag));

--- a/app/Http/Controllers/Api/ThreadsController.php
+++ b/app/Http/Controllers/Api/ThreadsController.php
@@ -407,8 +407,12 @@ class ThreadsController extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(Thread $thread): RedirectResponse
+    public function destroy(Thread $thread): RedirectResponse|JsonResponse
     {
+        if (!$thread->ownedBy($this->user)) {
+            return response()->json(['message' => 'No way.'], 403);
+        }
+
         // add to activity log
         Activity::log($thread, $this->user, 3);
 

--- a/app/Http/Controllers/Api/ThreadsController.php
+++ b/app/Http/Controllers/Api/ThreadsController.php
@@ -171,7 +171,7 @@ class ThreadsController extends Controller
         $threads = $query->visible($this->user)
             ->with(['visibility', 'forum', 'user', 'tags', 'threadCategory', 'lastPost'])
             ->withCount('posts')
-            ->paginate(1000000);
+            ->paginate($listResultSet->getLimit());
 
         // saves the updated session
         $listParamSessionStore->save();

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\View;
@@ -30,5 +31,21 @@ abstract class Controller extends BaseController
         });
 
 
+    }
+
+    /**
+     * Guard an action so only admins may proceed. Returns a 403 JSON
+     * response to short-circuit the action, or null when the current user
+     * is an admin/super_admin. Usage:
+     *   if ($denied = $this->requireAdmin()) { return $denied; }
+     */
+    protected function requireAdmin(): ?JsonResponse
+    {
+        if (!$this->user
+            || (!$this->user->hasGroup('admin') && !$this->user->hasGroup('super_admin'))) {
+            return response()->json(['message' => 'Not authorized.'], 403);
+        }
+
+        return null;
     }
 }

--- a/app/Http/Controllers/EntitiesController.php
+++ b/app/Http/Controllers/EntitiesController.php
@@ -1171,12 +1171,25 @@ class EntitiesController extends Controller
      */
     public function addPhoto(int $id, Request $request, ImageHandler $imageHandler): void
     {
+        // must be logged in
+        if (!$this->user) {
+            abort(401);
+        }
+
         $this->validate($request, [
             'file' => 'required|mimes:jpg,jpeg,png,gif,webp',
         ]);
 
         // attach to entity
         if ($entity = Entity::find($id)) {
+
+            // only the entity owner (or an admin) may add photos
+            if ($entity->created_by !== $this->user->id
+                && !$this->user->hasGroup('admin')
+                && !$this->user->hasGroup('super_admin')) {
+                abort(403);
+            }
+
             $photo = $imageHandler->makePhoto($request->file('file'));
 
             // count existing photos, and if zero, make this primary

--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -2990,7 +2990,27 @@ class EventsController extends Controller
     {
         // create a thread from a single event
 
+        // must be logged in
+        if (!$this->user) {
+            flash()->error('Error', 'No user is logged in.');
+
+            return redirect('/login');
+        }
+
         $event = Event::find($request->id);
+
+        if (!$event) {
+            abort(404);
+        }
+
+        // only the event owner (or an admin) may spin up its discussion thread
+        if ($event->created_by !== $this->user->id
+            && !$this->user->hasGroup('admin')
+            && !$this->user->hasGroup('super_admin')) {
+            flash()->error('Unauthorized', 'You cannot create a thread for this event.');
+
+            return redirect()->route('events.show', ['event' => $event->id]);
+        }
 
         // initialize the form object with the values from the template
         $thread = new Thread([

--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -2843,6 +2843,11 @@ class EventsController extends Controller
      */
     public function addPhoto(int $id, Request $request, ImageHandler $imageHandler): void
     {
+        // must be logged in
+        if (!$this->user) {
+            abort(401);
+        }
+
         // confirm the file is one of these types
         $this->validate($request, [
             'file' => 'required|mimes:jpg,jpeg,png,gif,webp',
@@ -2850,6 +2855,13 @@ class EventsController extends Controller
 
         // get the event
         if ($event = Event::find($id)) {
+
+            // only the event owner (or an admin) may add photos
+            if (!$event->ownedBy($this->user)
+                && !$this->user->hasGroup('admin')
+                && !$this->user->hasGroup('super_admin')) {
+                abort(403);
+            }
 
             // make the photo object from the file in the request, returning photo object
             $photo = $imageHandler->makePhoto($request->file('file'));

--- a/app/Http/Controllers/ForumsController.php
+++ b/app/Http/Controllers/ForumsController.php
@@ -176,7 +176,7 @@ class ForumsController extends Controller
         /* @phpstan-ignore-next-line */
         $forums = $query->visible($this->user)
             ->with('visibility')
-            ->paginate(1000000);
+            ->paginate($listResultSet->getLimit());
 
         // saves the updated session
         $listParamSessionStore->save();
@@ -346,14 +346,14 @@ class ForumsController extends Controller
         /* @phpstan-ignore-next-line */
         $threads = $query->visible($this->user)
             ->with('visibility')
-            ->paginate(10000000);
+            ->paginate($listResultSet->getLimit());
 
         // saves the updated session
         $listParamSessionStore->save();
 
         $this->hasFilter = $listResultSet->getFilters() != $listResultSet->getDefaultFilters() || $listResultSet->getIsEmptyFilter();
 
-        $threads = Thread::whereRelation('visibility','name','Public')->where('forum_id', $forum->id)->orderBy('created_at', 'desc')->paginate(1000000);
+        $threads = Thread::whereRelation('visibility', 'name', 'Public')->where('forum_id', $forum->id)->orderBy('created_at', 'desc')->paginate(\App\Http\Requests\ListQueryParameters::MAX_LIMIT);
 
         // pass a slug for the forum
         $slug = $forum->description;

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -185,7 +185,7 @@ class PostsController extends Controller
         /* @phpstan-ignore-next-line */
         $posts = $query->visible($this->user)
             ->with('visibility')
-            ->paginate(1000000);
+            ->paginate($listResultSet->getLimit());
 
         // saves the updated session
         $listParamSessionStore->save();

--- a/app/Http/Controllers/SeriesController.php
+++ b/app/Http/Controllers/SeriesController.php
@@ -889,12 +889,25 @@ class SeriesController extends Controller
      */
     public function addPhoto(int $id, Request $request, ImageHandler $imageHandler): void
     {
+        // must be logged in
+        if (!$this->user) {
+            abort(401);
+        }
+
         $this->validate($request, [
             'file' => 'required|mimes:jpg,jpeg,png,gif,webp',
         ]);
 
         // attach to series
         if ($series = Series::find($id)) {
+
+            // only the series owner (or an admin) may add photos
+            if (!$series->ownedBy($this->user)
+                && !$this->user->hasGroup('admin')
+                && !$this->user->hasGroup('super_admin')) {
+                abort(403);
+            }
+
             // make the photo object from the file in the request
             $photo = $imageHandler->makePhoto($request->file('file'));
 

--- a/app/Http/Requests/ListQueryParameters.php
+++ b/app/Http/Requests/ListQueryParameters.php
@@ -10,6 +10,13 @@ use App\Services\SessionStore\ListParameterStore;
 class ListQueryParameters
 {
     /**
+     * Hard ceiling on page size for any list endpoint, to prevent a
+     * single request from pulling an unbounded result set (DoS). Matches
+     * the largest value offered in the UI `limitOptions` (1000).
+     */
+    public const MAX_LIMIT = 1000;
+
+    /**
      * @var ListRequest
      */
     private $listRequest;
@@ -86,6 +93,11 @@ class ListQueryParameters
         } elseif ($this->listParamStore->getLimit()) {
             $limit = $this->listParamStore->getLimit();
         }
+
+        // clamp to a sane range so neither a crafted request nor a poisoned
+        // session value can request an unbounded page size
+        $limit = max(1, min((int) $limit, self::MAX_LIMIT));
+
         $this->listParamStore->setLimit($limit);
 
         return $limit;

--- a/tests/Feature/ApiBlogsCrudTest.php
+++ b/tests/Feature/ApiBlogsCrudTest.php
@@ -109,7 +109,8 @@ class ApiBlogsCrudTest extends TestCase
 
     public function test_index_returns_json_collection(): void
     {
-        $blog = Blog::factory()->create();
+        // public so it is visible to the acting user under the index visibility scope
+        $blog = Blog::factory()->create(['visibility_id' => Visibility::VISIBILITY_PUBLIC]);
 
         $this->getJson('/api/blogs')
             ->assertStatus(200)

--- a/tests/Feature/ApiEntitiesCrudTest.php
+++ b/tests/Feature/ApiEntitiesCrudTest.php
@@ -60,7 +60,10 @@ class ApiEntitiesCrudTest extends TestCase
 
     public function test_update_replaces_entity_fields(): void
     {
-        $entity = Entity::factory()->create(['slug' => 'zz-update-target-'.uniqid()]);
+        $entity = Entity::factory()->create([
+            'created_by' => $this->user->id,
+            'slug' => 'zz-update-target-'.uniqid(),
+        ]);
 
         $payload = $this->validPayload([
             'name' => 'ZZ-Updated-Name',
@@ -76,6 +79,7 @@ class ApiEntitiesCrudTest extends TestCase
     public function test_patch_partial_update_only_touches_supplied_fields(): void
     {
         $entity = Entity::factory()->create([
+            'created_by' => $this->user->id,
             'name' => 'ZZ-Original',
             'slug' => 'zz-patch-target-'.uniqid(),
         ]);

--- a/tests/Feature/ApiEntityUpdateTest.php
+++ b/tests/Feature/ApiEntityUpdateTest.php
@@ -29,6 +29,8 @@ class ApiEntityUpdateTest extends TestCase
     private function makeEntityWithRelations(): array
     {
         $entity = Entity::factory()->create([
+            // owned by the currently-authenticated user so update/patch pass the ownership guard
+            'created_by' => auth('sanctum')->id(),
             'slug' => 'fixture-entity',
             'instagram_username' => 'original_ig',
             'twitter_username' => 'original_tw',

--- a/tests/Feature/ApiEventFiltersTest.php
+++ b/tests/Feature/ApiEventFiltersTest.php
@@ -6,6 +6,7 @@ use App\Models\Event;
 use App\Models\Tag;
 use App\Models\User;
 use App\Models\EventType;
+use App\Models\Visibility;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -47,23 +48,27 @@ class ApiEventFiltersTest extends TestCase
             'slug' => 'test-house-filter',
         ]);
 
-        // Create events
+        // Create events (public so they are visible to the acting user
+        // now that the index endpoint applies the visibility scope)
         $this->jungleEvent = Event::factory()->create([
             'name' => 'Jungle Night',
             'slug' => 'jungle-night',
             'start_at' => Carbon::now()->addDays(1),
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
         ]);
 
         $this->technoEvent = Event::factory()->create([
             'name' => 'Techno Party',
             'slug' => 'techno-party',
             'start_at' => Carbon::now()->addDays(2),
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
         ]);
 
         $this->houseEvent = Event::factory()->create([
             'name' => 'House Music',
             'slug' => 'house-music',
             'start_at' => Carbon::now()->addDays(3),
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
         ]);
 
         // Attach tags to events
@@ -132,6 +137,7 @@ class ApiEventFiltersTest extends TestCase
             'name' => 'Multi Genre Night',
             'slug' => 'multi-genre-night',
             'start_at' => Carbon::now()->addDays(1),
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
         ]);
 
         // Attach multiple tags to the same event

--- a/tests/Feature/ApiListLimitCapTest.php
+++ b/tests/Feature/ApiListLimitCapTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Requests\ListQueryParameters;
+use App\Models\Event;
+use App\Models\User;
+use App\Models\UserStatus;
+use App\Models\Visibility;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Ensures list endpoints cannot be coerced into an unbounded page size.
+ * A crafted ?limit is clamped to ListQueryParameters::MAX_LIMIT both on
+ * the shared listing path (getLimit) and on the bespoke popular endpoint.
+ */
+class ApiListLimitCapTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $this->actingAs($user, 'sanctum');
+    }
+
+    /** @test */
+    public function events_index_caps_an_oversized_limit(): void
+    {
+        $response = $this->getJson('/api/events?limit=999999');
+
+        $response->assertStatus(200);
+        $this->assertSame(ListQueryParameters::MAX_LIMIT, $response->json('per_page'));
+    }
+
+    /** @test */
+    public function events_index_honors_a_reasonable_limit(): void
+    {
+        $response = $this->getJson('/api/events?limit=50');
+
+        $response->assertStatus(200);
+        $this->assertSame(50, $response->json('per_page'));
+    }
+
+    /** @test */
+    public function popular_caps_an_oversized_limit_and_does_not_error(): void
+    {
+        Event::factory()->create(['visibility_id' => Visibility::VISIBILITY_PUBLIC]);
+
+        $response = $this->getJson('/api/events/popular?limit=999999&days=99999');
+
+        $response->assertStatus(200);
+        $this->assertLessThanOrEqual(ListQueryParameters::MAX_LIMIT, (int) $response->json('per_page'));
+    }
+}

--- a/tests/Feature/ApiOwnershipGuardsTest.php
+++ b/tests/Feature/ApiOwnershipGuardsTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Entity;
+use App\Models\EntityStatus;
+use App\Models\EntityType;
+use App\Models\Event;
+use App\Models\Thread;
+use App\Models\User;
+use App\Models\UserStatus;
+use App\Models\Visibility;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Ownership guards on mutations that previously allowed any authenticated
+ * user to alter another user's resource:
+ *  - Api\EntitiesController::update / ::patch (destroy already guarded)
+ *  - Api\ThreadsController::destroy
+ *  - EventsController::createThread (was publicly reachable)
+ *
+ * Following the ApiEventsAuthBypassTest convention, the primary signal is
+ * that data does not change for a non-owner, rather than the exact status.
+ */
+class ApiOwnershipGuardsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private User $owner;
+    private User $attacker;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+        $this->owner = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $this->attacker = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+    }
+
+    private function entityPayload(Entity $entity, string $name): array
+    {
+        return [
+            'name' => $name,
+            'slug' => $entity->slug,
+            'short' => 'short',
+            'description' => 'description',
+            'entity_type_id' => EntityType::first()->id,
+            'entity_status_id' => EntityStatus::first()->id,
+        ];
+    }
+
+    private function ownerEntity(): Entity
+    {
+        return Entity::factory()->create([
+            'created_by' => $this->owner->id,
+            'name' => 'Original ZZ',
+            'slug' => 'zz-owner-entity-'.uniqid(),
+        ]);
+    }
+
+    /** @test */
+    public function entity_update_does_not_mutate_data_for_non_owner(): void
+    {
+        $entity = $this->ownerEntity();
+
+        $this->actingAs($this->attacker, 'sanctum');
+        $this->putJson('/api/entities/'.$entity->slug, $this->entityPayload($entity, 'Hijacked'));
+
+        $this->assertSame('Original ZZ', $entity->fresh()->name);
+    }
+
+    /** @test */
+    public function entity_patch_does_not_mutate_data_for_non_owner(): void
+    {
+        $entity = $this->ownerEntity();
+
+        $this->actingAs($this->attacker, 'sanctum');
+        $this->patchJson('/api/entities/'.$entity->slug, ['name' => 'Hijacked']);
+
+        $this->assertSame('Original ZZ', $entity->fresh()->name);
+    }
+
+    /** @test */
+    public function entity_update_succeeds_for_owner(): void
+    {
+        $entity = $this->ownerEntity();
+
+        $this->actingAs($this->owner, 'sanctum');
+        $this->putJson('/api/entities/'.$entity->slug, $this->entityPayload($entity, 'Renamed ZZ'))
+            ->assertOk();
+
+        $this->assertSame('Renamed ZZ', $entity->fresh()->name);
+    }
+
+    /** @test */
+    public function api_thread_destroy_rejects_non_owner(): void
+    {
+        // authenticate as owner first so the Thread::creating hook stamps created_by
+        $this->actingAs($this->owner);
+        $thread = Thread::factory()->create();
+
+        $this->actingAs($this->attacker, 'sanctum');
+        $this->deleteJson('/api/threads/'.$thread->id)->assertStatus(403);
+
+        $this->assertNotNull(Thread::find($thread->id), 'Thread should still exist.');
+    }
+
+    /** @test */
+    public function api_thread_destroy_succeeds_for_owner(): void
+    {
+        $this->actingAs($this->owner);
+        $thread = Thread::factory()->create();
+
+        $this->actingAs($this->owner, 'sanctum');
+        $this->deleteJson('/api/threads/'.$thread->id);
+
+        $this->assertNull(Thread::find($thread->id), 'Owner should be able to delete their thread.');
+    }
+
+    /** @test */
+    public function create_thread_is_blocked_for_non_owner(): void
+    {
+        $event = Event::factory()->create([
+            'created_by' => $this->owner->id,
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+
+        $this->actingAs($this->attacker);
+        $this->get('/events/create-thread?id='.$event->id);
+
+        $this->assertSame(0, Thread::where('event_id', $event->id)->count());
+    }
+
+    /** @test */
+    public function create_thread_is_blocked_for_guest(): void
+    {
+        $event = Event::factory()->create(['visibility_id' => Visibility::VISIBILITY_PUBLIC]);
+
+        $this->get('/events/create-thread?id='.$event->id)
+            ->assertRedirect('/login');
+
+        $this->assertSame(0, Thread::where('event_id', $event->id)->count());
+    }
+
+    /** @test */
+    public function create_thread_succeeds_for_owner(): void
+    {
+        $event = Event::factory()->create([
+            'created_by' => $this->owner->id,
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+
+        $this->actingAs($this->owner);
+        $this->get('/events/create-thread?id='.$event->id);
+
+        $this->assertSame(1, Thread::where('event_id', $event->id)->count());
+    }
+}

--- a/tests/Feature/ApiPhotoAuthTest.php
+++ b/tests/Feature/ApiPhotoAuthTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Entity;
+use App\Models\Event;
+use App\Models\Series;
+use App\Models\User;
+use App\Models\UserStatus;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Photo uploads must require an authenticated owner (or admin). The web
+ * routes (events/entities/series {id}/photos) were previously reachable
+ * anonymously; the API routes were authenticated but had no ownership
+ * check. The ownership guard runs before any file is processed/stored.
+ */
+class ApiPhotoAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private User $owner;
+    private User $attacker;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+        // CSRF is irrelevant to the auth/ownership guards under test; drop it
+        // so the web POST routes reach the controller.
+        $this->withoutMiddleware(\App\Http\Middleware\VerifyCsrfToken::class);
+        $this->owner = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $this->attacker = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+    }
+
+    private function image(): UploadedFile
+    {
+        return UploadedFile::fake()->image('photo.jpg');
+    }
+
+    private function jsonHeaders(): array
+    {
+        return ['Accept' => 'application/json'];
+    }
+
+    /** @test */
+    public function api_event_add_photo_rejects_non_owner(): void
+    {
+        $event = Event::factory()->create(['created_by' => $this->owner->id]);
+
+        $this->actingAs($this->attacker, 'sanctum');
+        $this->post('/api/events/'.$event->id.'/photos', ['file' => $this->image()], $this->jsonHeaders())
+            ->assertStatus(403);
+
+        $this->assertSame(0, $event->photos()->count());
+    }
+
+    /** @test */
+    public function api_entity_add_photo_rejects_non_owner(): void
+    {
+        $entity = Entity::factory()->create(['created_by' => $this->owner->id]);
+
+        $this->actingAs($this->attacker, 'sanctum');
+        $this->post('/api/entities/'.$entity->id.'/photos', ['file' => $this->image()], $this->jsonHeaders())
+            ->assertStatus(403);
+
+        $this->assertSame(0, $entity->photos()->count());
+    }
+
+    /** @test */
+    public function api_series_add_photo_rejects_non_owner(): void
+    {
+        $series = Series::factory()->create(['created_by' => $this->owner->id]);
+
+        $this->actingAs($this->attacker, 'sanctum');
+        $this->post('/api/series/'.$series->id.'/photos', ['file' => $this->image()], $this->jsonHeaders())
+            ->assertStatus(403);
+
+        $this->assertSame(0, $series->photos()->count());
+    }
+
+    /** @test */
+    public function web_event_add_photo_is_blocked_for_guest(): void
+    {
+        $event = Event::factory()->create(['created_by' => $this->owner->id]);
+
+        $this->post('/events/'.$event->id.'/photos', ['file' => $this->image()])
+            ->assertStatus(401);
+
+        $this->assertSame(0, $event->photos()->count());
+    }
+
+    /** @test */
+    public function web_event_add_photo_rejects_non_owner(): void
+    {
+        $event = Event::factory()->create(['created_by' => $this->owner->id]);
+
+        $this->actingAs($this->attacker);
+        $this->post('/events/'.$event->id.'/photos', ['file' => $this->image()])
+            ->assertStatus(403);
+
+        $this->assertSame(0, $event->photos()->count());
+    }
+}

--- a/tests/Feature/ApiReferenceDataAuthTest.php
+++ b/tests/Feature/ApiReferenceDataAuthTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\EntityStatus;
+use App\Models\EntityType;
+use App\Models\EventStatus;
+use App\Models\EventType;
+use App\Models\Menu;
+use App\Models\Role;
+use App\Models\Tag;
+use App\Models\User;
+use App\Models\UserStatus;
+use App\Models\Visibility;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Global reference data (entity/event types & statuses, roles, menus and
+ * tags) may only be mutated by admins. Previously any authenticated user
+ * could create/update/delete these shared records. The destroy endpoints
+ * take no FormRequest, so they exercise the controller's requireAdmin()
+ * guard directly.
+ */
+class ApiReferenceDataAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private User $member;
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+        $this->member = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $this->admin = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $this->admin->assignGroup('admin');
+    }
+
+    public static function referenceEndpoints(): array
+    {
+        return [
+            'entity-types' => ['entity-types', EntityType::class],
+            'entity-statuses' => ['entity-statuses', EntityStatus::class],
+            'event-types' => ['event-types', EventType::class],
+            'event-statuses' => ['event-statuses', EventStatus::class],
+            'roles' => ['roles', Role::class],
+            'tags' => ['tags', Tag::class],
+        ];
+    }
+
+    /**
+     * @dataProvider referenceEndpoints
+     */
+    public function test_non_admin_cannot_delete_reference_record(string $endpoint, string $modelClass): void
+    {
+        /** @var \Illuminate\Database\Eloquent\Model $record */
+        $record = $modelClass::query()->first();
+        $this->assertNotNull($record, "Expected a seeded {$endpoint} record.");
+
+        $this->actingAs($this->member, 'sanctum');
+        $this->deleteJson('/api/'.$endpoint.'/'.$record->getRouteKey())
+            ->assertStatus(403);
+
+        $this->assertNotNull($modelClass::find($record->getKey()), 'Record must survive a non-admin delete.');
+    }
+
+    public function test_non_admin_cannot_delete_menu(): void
+    {
+        $menu = Menu::create([
+            'name' => 'ZZ Menu',
+            'slug' => 'zz-menu',
+            'body' => 'body',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+
+        $this->actingAs($this->member, 'sanctum');
+        $this->deleteJson('/api/menus/'.$menu->getRouteKey())->assertStatus(403);
+
+        $this->assertNotNull(Menu::find($menu->id));
+    }
+
+    public function test_admin_can_delete_reference_record(): void
+    {
+        $type = EntityType::create([
+            'name' => 'ZZ Disposable Type',
+            'slug' => 'zz-disposable-type',
+            'short' => 'temp',
+        ]);
+
+        $this->actingAs($this->admin, 'sanctum');
+        $this->deleteJson('/api/entity-types/'.$type->getRouteKey())->assertStatus(204);
+
+        $this->assertNull(EntityType::find($type->id));
+    }
+
+    public function test_non_admin_cannot_create_entity_type_with_valid_payload(): void
+    {
+        $this->actingAs($this->member, 'sanctum');
+        $this->postJson('/api/entity-types', [
+            'name' => 'ZZ New Type',
+            'slug' => 'zz-new-type',
+            'short' => 'blurb',
+        ])->assertStatus(403);
+
+        $this->assertDatabaseMissing('entity_types', ['slug' => 'zz-new-type']);
+    }
+
+    public function test_admin_can_create_entity_type(): void
+    {
+        $this->actingAs($this->admin, 'sanctum');
+        $this->postJson('/api/entity-types', [
+            'name' => 'ZZ New Type',
+            'slug' => 'zz-new-type',
+            'short' => 'blurb',
+        ])->assertOk();
+
+        $this->assertDatabaseHas('entity_types', ['slug' => 'zz-new-type']);
+    }
+}

--- a/tests/Feature/ApiTagsCrudExtraTest.php
+++ b/tests/Feature/ApiTagsCrudExtraTest.php
@@ -20,6 +20,7 @@ class ApiTagsCrudExtraTest extends TestCase
         parent::setUp();
         $this->withExceptionHandling();
         $this->user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $this->user->assignGroup('admin'); // tag CRUD is admin-gated
         $this->actingAs($this->user, 'sanctum');
     }
 

--- a/tests/Feature/ApiTagsDeleteTest.php
+++ b/tests/Feature/ApiTagsDeleteTest.php
@@ -18,6 +18,7 @@ class ApiTagsDeleteTest extends TestCase
     {
         $user = User::factory()->create();
         $user->user_status_id = 1;
+        $user->assignGroup('admin'); // tag deletion is admin-gated
         $this->actingAs($user, 'sanctum');
 
         $tag = Tag::factory()->create();

--- a/tests/Feature/ApiTagsStoreTest.php
+++ b/tests/Feature/ApiTagsStoreTest.php
@@ -24,6 +24,7 @@ class ApiTagsStoreTest extends TestCase
     public function it_returns_validation_error_when_slug_already_exists(): void
     {
         $user = User::factory()->create(['user_status_id' => 1]);
+        $user->assignGroup('admin'); // tag CRUD is admin-gated
         $this->actingAs($user, 'sanctum');
 
         Tag::factory()->create(['slug' => 'existing-slug']);
@@ -41,6 +42,7 @@ class ApiTagsStoreTest extends TestCase
     public function it_creates_a_tag_with_unique_slug(): void
     {
         $user = User::factory()->create(['user_status_id' => 1]);
+        $user->assignGroup('admin'); // tag CRUD is admin-gated
         $this->actingAs($user, 'sanctum');
 
         $response = $this->postJson('/api/tags', [

--- a/tests/Feature/ApiVisibilityFilteringTest.php
+++ b/tests/Feature/ApiVisibilityFilteringTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Blog;
+use App\Models\Event;
+use App\Models\User;
+use App\Models\UserStatus;
+use App\Models\Visibility;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Ensures the API listing endpoints apply the model `visible($user)`
+ * scope so private/proposal content created by one user does not leak
+ * into another authenticated user's listings.
+ *
+ * Previously Api\EventsController::index/::popular and
+ * Api\BlogsController::index paginated without ->visible(), exposing
+ * non-public rows. (The owner still sees their own private rows.)
+ */
+class ApiVisibilityFilteringTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private User $owner;
+    private User $other;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+        $this->owner = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $this->other = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+    }
+
+    /** @test */
+    public function events_index_hides_other_users_private_events(): void
+    {
+        $private = Event::factory()->create([
+            'created_by' => $this->owner->id,
+            'name' => 'ZZVIS Private Event',
+            'visibility_id' => Visibility::VISIBILITY_PRIVATE,
+        ]);
+        $public = Event::factory()->create([
+            'created_by' => $this->owner->id,
+            'name' => 'ZZVIS Public Event',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+
+        // Another authenticated user must not see the private event.
+        $this->actingAs($this->other, 'sanctum');
+        $ids = collect($this->getJson('/api/events?filters[name]=ZZVIS&limit=100')->json('data'))->pluck('id');
+        $this->assertTrue($ids->contains($public->id), 'Public event should be listed.');
+        $this->assertFalse($ids->contains($private->id), 'Private event must not leak to another user.');
+
+        // The owner still sees their own private event.
+        $this->actingAs($this->owner, 'sanctum');
+        $ownerIds = collect($this->getJson('/api/events?filters[name]=ZZVIS&limit=100')->json('data'))->pluck('id');
+        $this->assertTrue($ownerIds->contains($private->id), 'Owner should see their own private event.');
+    }
+
+    /** @test */
+    public function events_popular_hides_other_users_private_events(): void
+    {
+        $private = Event::factory()->create([
+            'created_by' => $this->owner->id,
+            'name' => 'ZZPOP Private Event',
+            'visibility_id' => Visibility::VISIBILITY_PRIVATE,
+        ]);
+        $public = Event::factory()->create([
+            'created_by' => $this->owner->id,
+            'name' => 'ZZPOP Public Event',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+
+        $this->actingAs($this->other, 'sanctum');
+        $ids = collect($this->getJson('/api/events/popular?filters[name]=ZZPOP&limit=100')->json('data'))->pluck('id');
+        $this->assertTrue($ids->contains($public->id), 'Public event should be listed.');
+        $this->assertFalse($ids->contains($private->id), 'Private event must not leak via popular.');
+    }
+
+    /** @test */
+    public function blogs_index_hides_other_users_private_blogs(): void
+    {
+        $private = Blog::factory()->create([
+            'created_by' => $this->owner->id,
+            'name' => 'ZZBLOG Private',
+            'visibility_id' => Visibility::VISIBILITY_PRIVATE,
+        ]);
+        $public = Blog::factory()->create([
+            'created_by' => $this->owner->id,
+            'name' => 'ZZBLOG Public',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+
+        $this->actingAs($this->other, 'sanctum');
+        $ids = collect($this->getJson('/api/blogs?filters[name]=ZZBLOG&limit=100')->json('data'))->pluck('id');
+        $this->assertTrue($ids->contains($public->id), 'Public blog should be listed.');
+        $this->assertFalse($ids->contains($private->id), 'Private blog must not leak to another user.');
+    }
+}


### PR DESCRIPTION
Follow-up to #1936. A multi-agent audit surfaced three further clusters of live, user-reachable API security issues. Landed as **five focused, individually-revertable commits** (safest-first). Every fix ships with a regression test that was confirmed to **fail against the pre-fix code**. PHPStan is clean across the diff; 82 tests across the new/affected suites pass.

## Commit 1 — Visibility leaks (information disclosure)
`Api\EventsController::index`/`::popular` and `Api\BlogsController::index` paginated without the model `visible($user)` scope, leaking another user's private/proposal events and non-public blogs. Added `->visible($this->user)`, mirroring the already-correct `indexByDate`/`filter` methods. (`ApiVisibilityFilteringTest`)

## Commit 2 — Unbounded queries / DoS
Added `ListQueryParameters::MAX_LIMIT` (1000, the existing UI ceiling) and clamped `getLimit()` — the single chokepoint feeding every list endpoint's `paginate()`. Also fixed the explicit `paginate(1000000)` calls that bypass it: the **publicly-reachable** web `forums/all` and `posts/all` listings, a forum-show thread query, and the `popular` endpoints' raw `limit`/`days` params. (`ApiListLimitCapTest`)

## Commit 3 — Ownership on authenticated mutations
Any logged-in user could alter another user's resource. Added ownership guards to `Api\EntitiesController::update`/`::patch` (matching its `destroy`), `Api\ThreadsController::destroy`, and `EventsController::createThread` — the last was publicly reachable and 500'd on a bad id; it now requires auth, 404s on a missing event, and limits thread creation to the event owner/admin. (`ApiOwnershipGuardsTest`)

## Commit 4a — Admin-gate global reference data + tags
Any authenticated user could create/update/delete shared reference data (entity/event types & statuses, roles, menus) and global tags. Added a shared `Controller::requireAdmin()` helper and applied it to the six reference-data controllers' `store`/`update`/`patch`/`destroy` and `Api\TagsController` `store`/`update`/`destroy`. Read endpoints stay public. (`ApiReferenceDataAuthTest`)

## Commit 4b — Require authenticated owner (or admin) to add photos
The web photo-upload routes (`events`/`entities`/`series` `{id}/photos`) were reachable **anonymously**; the API equivalents were authenticated but had no ownership check (the API entity path even wrote the file to storage first). Each `addPhoto` now requires authentication + ownership; the API entity check runs before the upload is stored. (`ApiPhotoAuthTest`)

## Decisions
- Reference-data and global-tag mutations are gated to **admins only** (`hasGroup('admin')`/`super_admin`), per the agreed approach. Existing tag CRUD tests were updated to act as an admin.
- `addPhoto` is restricted to the resource **owner or an admin**. If community photo contributions by any member are desired, relax the `addPhoto` guards to an auth-only check.

## Deferred — Post/Blog mass-assignment (separate PR)
The planned mass-assignment commit was deliberately **not** included: `Post` and `Blog` use `$guarded = []`, Blog's `created_by` auto-stamp is commented out, and the `allow_html` superuser gate is non-functional — so a crafted request can spoof `created_by` (defeating ownership checks) and set `allow_html`. A correct fix needs explicit `created_by`/`allow_html` handling plus app-level validation of the blog/post create/edit flows, so it warrants its own carefully-verified PR rather than being bundled here. (For `$fillable` models, `$request->all()` is already bounded by Eloquent, so no change is needed there.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)