### PR TITLE
Fix: N+1 Query on entity show page related-events card [EVENTREPO-TC]

### DIFF
--- a/app/Http/Controllers/EntitiesController.php
+++ b/app/Http/Controllers/EntitiesController.php
@@ -896,6 +896,7 @@ class EntitiesController extends Controller
                 'entities.links',
                 'eventStatus',
                 'visibility',
+                'eventType',
             ])
             ->where('start_at', '>=', $filterStartAt)
             ->orderBy('start_at', 'asc');

--- a/tests/Feature/Web/EntitiesControllerTest.php
+++ b/tests/Feature/Web/EntitiesControllerTest.php
@@ -86,4 +86,34 @@ class EntitiesControllerTest extends TestCase
             'Past-event primary photos should be eager-loaded, not queried per event (N+1).'
         );
     }
+
+    public function test_show_eager_loads_related_event_type_without_n_plus_one(): void
+    {
+        $entity = Entity::factory()->create();
+
+        // Two upcoming events for the related-events card, each with an event type.
+        // (Limited to 2, not 3+, to stay below the entity's "frequently performs with"
+        // computation threshold, which is unrelated to this regression.)
+        for ($i = 1; $i <= 2; $i++) {
+            $event = Event::factory()->create([
+                'start_at' => now()->addDays($i),
+                'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            ]);
+            $entity->events()->attach($event);
+        }
+
+        DB::enableQueryLog();
+        $this->get('/entities/'.$entity->slug)->assertOk();
+        $queries = collect(DB::getQueryLog())->pluck('query');
+
+        // The per-event event-type lookup must be eager-loaded, not run once per event.
+        $perEventTypeQueries = $queries->filter(fn ($q) => str_contains($q, 'event_types')
+            && str_contains($q, 'limit 1'));
+
+        $this->assertLessThanOrEqual(
+            1,
+            $perEventTypeQueries->count(),
+            'Related-event event types should be eager-loaded, not queried per event (N+1).'
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a Sentry-reported N+1 query on `/entities/{entity}`:

- [EVENTREPO-TC](https://geoff-maddock.sentry.io/issues/7394381953/) (732 events) — `select * from event_types where event_types.id = ? limit 1`
- [EVENTREPO-TE](https://geoff-maddock.sentry.io/issues/7395238239/) (711 events) — same root cause, different fingerprint
- [EVENTREPO-TN](https://geoff-maddock.sentry.io/issues/7428816073/) (230 events) — same root cause, different fingerprint

All three issues share the same root cause and are fixed by this single change, so they're bundled into one PR rather than three near-identical ones.

## Root cause

`EntitiesController::show()` builds the "related events" (upcoming events) card query with eager-loaded `venue`, `photos`, `entities`, `eventStatus`, and `visibility` — but not `eventType`. The card partial (`resources/views/events/card-tw.blade.php`) reads `$event->eventType->slug` / `->name` per event, so `EventType` was being lazy-loaded once per event in the list.

The sibling "past events" query in the same method already eager-loads `eventType` (added in a prior fix) — this change mirrors that for the related-events query.

## What changed

- `app/Http/Controllers/EntitiesController.php`: add `'eventType'` to the related-events eager-load list.
- `tests/Feature/Web/EntitiesControllerTest.php`: regression test asserting the per-event `event_types` query doesn't repeat when multiple upcoming events are shown.

## Test plan

- [x] New regression test fails without the fix (confirmed: query count 2, not ≤1) and passes with it.
- [x] Full `EntitiesControllerTest` + `EntitiesTest` suites pass (one pre-existing, unrelated failure in this sandbox due to a MariaDB `ONLY_FULL_GROUP_BY` quirk in `getFrequentlyPerformsWith()`, not present on the project's real MySQL 8 target and not touched by this change).
- [x] PHPStan clean on the changed file.

🤖 Generated with autonomous Sentry triage.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VymL9AeMQgJ8AiuHnx5tgp)_