### PR TITLE
Fix: N+1 Query on calendar page series next-event lookup [EVENTREPO-NA]

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -468,7 +468,9 @@ class CalendarController extends Controller
         $events = $eventsQuery->with('eventType', 'visibility')->get();
 
         // get all the upcoming series events
-        $seriesQuery = Series::active()->with('visibility','occurrenceType');
+        // eager-load upcomingEvent so Series::nextEvent() uses the loaded relation
+        // instead of issuing a query per series (Sentry N+1 on /calendar)
+        $seriesQuery = Series::active()->with('visibility', 'occurrenceType', 'upcomingEvent');
         
         // Apply same filters to series if present
         if ($request->has('filters')) {
@@ -576,7 +578,7 @@ class CalendarController extends Controller
         })->with('eventType')->get();
 
         // get all the upcoming series events
-        $series = Series::active()->with('visibility', 'occurrenceType')->get();
+        $series = Series::active()->with('visibility', 'occurrenceType', 'upcomingEvent')->get();
 
         // filter for only events that are public or that were created by the current user and are not "no schedule"
         $series = $series->filter(function ($e) {
@@ -705,7 +707,7 @@ class CalendarController extends Controller
             })->get();
 
         // get all the upcoming series events
-        $series = Series::active()->with('visibility', 'occurrenceType')->get();
+        $series = Series::active()->with('visibility', 'occurrenceType', 'upcomingEvent')->get();
 
         // filter for only events that are public or that were created by the current user and are not "no schedule"
         $series = $series->filter(function ($e) {
@@ -766,7 +768,7 @@ class CalendarController extends Controller
             })->with('tags')->get();
 
         // get all the upcoming series events
-        $series = Series::active()->with('visibility', 'occurrenceType')->get();
+        $series = Series::active()->with('visibility', 'occurrenceType', 'upcomingEvent')->get();
 
         // filter for only events that are public or that were created by the current user and are not "no schedule"
         $series = $series->filter(function ($e) {

--- a/tests/Feature/Web/CalendarControllerTest.php
+++ b/tests/Feature/Web/CalendarControllerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature\Web;
+
+use App\Models\Event;
+use App\Models\Series;
+use App\Models\Visibility;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class CalendarControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    public function test_index_loads(): void
+    {
+        $this->get('/calendar')->assertOk();
+    }
+
+    public function test_index_eager_loads_series_upcoming_event_without_n_plus_one(): void
+    {
+        // Several active series, each with a future event, so Series::nextEvent()
+        // is called once per series while building the calendar event list.
+        for ($i = 1; $i <= 3; $i++) {
+            $series = Series::factory()->create([
+                'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            ]);
+            Event::factory()->create([
+                'series_id' => $series->id,
+                'start_at' => now()->addDays($i),
+                'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            ]);
+        }
+
+        DB::enableQueryLog();
+        $this->get('/calendar')->assertOk();
+        $queries = collect(DB::getQueryLog())->pluck('query');
+
+        // The per-series "next event" lookup must be eager-loaded, not run once per series.
+        $perSeriesNextEventQueries = $queries->filter(fn ($q) => str_contains($q, 'from `events`')
+            && str_contains($q, 'series_id'));
+
+        $this->assertLessThanOrEqual(
+            1,
+            $perSeriesNextEventQueries->count(),
+            'Series next-event lookups should be eager-loaded, not queried per series (N+1).'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a Sentry-reported N+1 query on `/calendar`:

- [EVENTREPO-NA](https://geoff-maddock.sentry.io/issues/6839925121/) (204 events) — `select * from events where series_id = ? and start_at >= ? order by start_at asc limit 1` repeated ~28 times in a single request.

No user feedback attached to this issue.

## Root cause

`CalendarController::index()` fetches all active series, then loops over them calling `$s->nextEvent()` to decide whether to add the series' next occurrence to the calendar feed. `Series::nextEvent()` issues a fresh query per call — one per series.

`Series` already has an `upcomingEvent()` `hasOne` relation, and `nextEvent()` already checks `relationLoaded('upcomingEvent')` and uses the loaded relation when available — but nothing ever eager-loaded it, so that fast path was dead code and every call fell through to a fresh query.

The same per-series query pattern (`Series::active()->with('visibility', 'occurrenceType')->get()` followed by a `nextEvent()` loop) is duplicated in three sibling methods in the same controller (`indexByDate`, `calendarEventsApi`, `tagCalendarEventsApi`), so the same one-line fix is applied to all four call sites for consistency.

## What changed

- `app/Http/Controllers/CalendarController.php`: add `'upcomingEvent'` to the `Series::active()->with(...)` eager-load list in `index`, `indexByDate`, `calendarEventsApi`, and `tagCalendarEventsApi`.
- `tests/Feature/Web/CalendarControllerTest.php` (new): regression test asserting the per-series `events` query doesn't repeat when multiple series have upcoming events.

## Test plan

- [x] New regression test fails without the fix (3 queries for 3 series) and passes with it (≤1 query).
- [x] Full `CalendarControllerTest`, `EventsTest`, `SeriesTest` suites pass.
- [x] Full `tests/Feature` suite: 669/671 pass; the 2 failures are pre-existing, unrelated to this change — a MariaDB `ONLY_FULL_GROUP_BY` incompatibility in `getFrequentlyPerformsWith()` / a series "popular" query, reproducible on `main` without this diff, specific to this sandbox's MariaDB substitute for the project's real MySQL 8 target.
- [x] PHPStan clean on the changed file.

🤖 Generated with autonomous Sentry triage.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VymL9AeMQgJ8AiuHnx5tgp)_