### PR TITLE
Fix: Call to a member function fill() on null [EVENTREPO-VW]

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -402,7 +402,8 @@ class UsersController extends Controller
         $input['setting_public_profile'] = isset($input['setting_public_profile']) ? 1 : 0;
 
         $user->fill($input)->save();
-        $user->profile->fill($input)->save();
+        // Some legacy users have no profile row yet (EVENTREPO-VW); create one on demand.
+        $user->profile()->firstOrCreate([])->fill($input)->save();
 
         if ($request->has('group_list')) {
             $user->groups()->sync($request->input('group_list', []));

--- a/tests/Feature/UsersTest.php
+++ b/tests/Feature/UsersTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\Post;
 use App\Models\User;
+use App\Models\UserStatus;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -51,18 +52,36 @@ class UsersTest extends TestCase
     public function a_non_admin_cannot_access_password_reset_form()
     {
         $this->withExceptionHandling();
-        
+
         // Create a regular user without admin permissions
         $regularUser = User::factory()->create();
-        
+
         // Create another user whose password would be reset
         $targetUser = User::factory()->create();
-        
+
         $this->actingAs($regularUser);
-        
+
         $response = $this->get(route('users.showResetPassword', ['id' => $targetUser->id]));
-        
+
         // Should be redirected or receive 403 when authorization fails
         $this->assertContains($response->status(), [302, 301, 403]);
+    }
+
+    /** @test */
+    public function updating_a_user_with_no_profile_row_does_not_error(): void
+    {
+        // UserFactory doesn't create a profile row (EVENTREPO-VW regression).
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $this->assertNull($user->profile);
+
+        $this->actingAs($user);
+
+        $response = $this->patch(route('users.update', ['user' => $user]), [
+            'name' => $user->name,
+            'email' => $user->email,
+        ]);
+
+        $response->assertRedirect(route('users.show', ['user' => $user]));
+        $this->assertNotNull($user->profile()->first());
     }
 }


### PR DESCRIPTION
## Summary
- Sentry: [EVENTREPO-VW](https://geoff-maddock.sentry.io/issues/7537045701/) — `Error: Call to a member function fill() on null` at `PATCH /users/{user}`, in `UsersController::update`, ~4 occurrences since 2026-06-08, most recently 2026-06-30. No user feedback attached.
- **Root cause:** `UsersController::update()` called `$user->profile->fill($input)->save()` directly. `profile()` is a `hasOne` relation, and it returns `null` for any user that doesn't have a `profiles` row — which happens for legacy users, and is also reproducible locally since `UserFactory` doesn't create a profile either. Profiles are normally created in `store()` and lazily in `show()`, but `update()` had no such guard.
- **Fix:** use `$user->profile()->firstOrCreate([])->fill($input)->save();` so a missing profile is created on demand instead of the property access throwing.

## Test plan
- [x] Added a regression test (`tests/Feature/UsersTest.php::updating_a_user_with_no_profile_row_does_not_error`) that creates a user with no profile row and asserts `PATCH /users/{user}` succeeds and a profile is created.
- [x] `./vendor/bin/phpstan analyse` — no errors.
- [x] `./vendor/bin/phpunit tests/Feature/UsersTest.php` — pass (3/3).
- [x] Full `tests/Feature` suite run locally against MariaDB — no new failures introduced (2 pre-existing failures unrelated to this change, reproduced identically without it, due to sandbox DB differences from the project's MySQL 8/CI environment).

🤖 Generated by an automated Sentry-triage routine. Please review before merging.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9my3XKmPwPBqUZjf2Wzrv)_