### PR TITLE
Fix: N+1 Query on tag-filtered event listings [EVENTREPO-W5]

### DIFF
--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -356,7 +356,8 @@ class EventsController extends Controller
      */
     protected function cardEventEagerLoad(): array
     {
-        $eager = ['visibility', 'venue', 'eventType', 'tags', 'photos', 'entities', 'threads'];
+        // venue.locations avoids an N+1 in card-tw's getPrimaryLocationMap()/getPrimaryLocationAddress() (EVENTREPO-W5).
+        $eager = ['visibility', 'venue.locations', 'eventType', 'tags', 'photos', 'entities', 'threads'];
 
         if ($this->user) {
             // The attend/unattend button reads getEventResponse($user)->responseType per card.


### PR DESCRIPTION
## Summary
- Sentry: [EVENTREPO-W5](https://geoff-maddock.sentry.io/issues/7564404992/) — N+1 Query at `GET /events/tag/{tag}`, ~25 occurrences, most recently today. No user feedback attached.
- Sentry's performance trace shows the repeating query is `select * from locations where entity_id = ? and entity_id is not null`, firing once per event card while rendering `events.index-tw` → `events.card-tw`, with `view.render - events.index-sort-pagination` / `components.ui.select-field` around it in the pattern.
- **Root cause:** `EventsController::cardEventEagerLoad()` (shared by every card-based event listing route, including `indexTags()`) eager-loads `venue` but not the venue's `locations` relation. `events/card-tw.blade.php` calls `Entity::getPrimaryLocationMap()` / `getPrimaryLocationAddress()`, which read `$this->locations`, triggering one query per event whenever `locations` isn't already loaded.
- **Fix:** change `'venue'` to `'venue.locations'` in `cardEventEagerLoad()`. Minimal, single-line fix; since the helper is reused across ~15 listing routes, this closes the same N+1 everywhere it can occur, not just on the tag route.

## Test plan
- [x] `./vendor/bin/phpstan analyse` — no errors.
- [x] `./vendor/bin/phpunit tests/Feature/Web/EventsControllerTest.php` (covers `/events/tag/{tag}`) — pass (14/14).
- [x] `./vendor/bin/phpunit tests/Feature/EventsTest.php tests/Feature/EventFilterUrlTest.php tests/Feature/ApiEventsHappyPathTest.php` — pass (20/20).
- [x] Full `tests/Feature` suite run locally against MariaDB — no new failures introduced (2 pre-existing failures unrelated to this change, reproduced identically without it).

🤖 Generated by an automated Sentry-triage routine. Please review before merging.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9my3XKmPwPBqUZjf2Wzrv)_