### PR TITLE
Fix: N+1 Query on tag-filtered entity listings [EVENTREPO-VN]

### DIFF
--- a/app/Http/Controllers/EntitiesController.php
+++ b/app/Http/Controllers/EntitiesController.php
@@ -562,7 +562,10 @@ class EntitiesController extends Controller
         $query = $listResultSet->getList();
 
         // Get the entities
+        // roles is eager-loaded because index-json-ld calls getSchemaType(), which checks
+        // hasRole() per entity; without it that's an N+1 query per row (EVENTREPO-VN).
         $entities = $query
+            ->with('roles')
             ->paginate($listResultSet->getLimit());
 
         // Save the updated session


### PR DESCRIPTION
## Summary
- Sentry: [EVENTREPO-VN](https://geoff-maddock.sentry.io/issues/7510622337/) — N+1 Query at `GET /entities/tag/{tag}`, ~26 occurrences, most recently today. No user feedback attached.
- Sentry's performance trace shows the repeating query `select count(*) as aggregate from roles inner join entity_role on roles.id = entity_role.role_id where entity_role.entity_id = ? and name = ?`, repeated 54 times while rendering `entities.index-json-ld`.
- **Root cause:** `EntitiesController::indexTags()` paginates entities without eager-loading the `roles` relation. `entities/index-json-ld.blade.php` calls `Entity::getSchemaType()`, which calls `hasRole()` several times per entity; `hasRole()` falls back to a live query whenever `roles` isn't already loaded (`relationLoaded('roles')` is false), so every entity in the listing fires several extra queries. `EntitiesController::index()` already eager-loads `roles` for exactly this reason — `indexTags()` was simply missing it.
- **Fix:** add `->with('roles')` to the query in `indexTags()` before `paginate()`.

## Test plan
- [x] `./vendor/bin/phpstan analyse` — no errors.
- [x] `./vendor/bin/phpunit tests/Feature/Web/EntitiesControllerSmokeTest.php` (covers `/entities/tag/{tag}`) — pass.
- [x] `./vendor/bin/phpunit tests/Feature/EntitiesTest.php tests/Feature/ApiEntitiesHappyPathTest.php` — pass (20/20 total).
- [x] Full `tests/Feature` suite run locally against MariaDB — no new failures introduced (2 pre-existing failures unrelated to this change, reproduced identically without it).

🤖 Generated by an automated Sentry-triage routine. Please review before merging.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9my3XKmPwPBqUZjf2Wzrv)_