### PR TITLE
Link Privacy Policy from About/Help/All Modules; update FB data section (#1950)

### DIFF
--- a/resources/views/pages/about-tw.blade.php
+++ b/resources/views/pages/about-tw.blade.php
@@ -39,6 +39,14 @@
         </div>
     @endif
 
+    <div class="card-tw p-4 md:p-6 mt-4 md:mt-6">
+        <h2 class="text-lg font-semibold text-foreground mb-3">Policies &amp; Info</h2>
+        <ul class="space-y-2 text-muted-foreground">
+            <li><a href="{{ url('/privacy') }}" class="text-primary hover:underline"><i class="bi bi-shield-check mr-2"></i>Privacy Policy</a></li>
+            <li><a href="{{ url('/tos') }}" class="text-primary hover:underline"><i class="bi bi-file-earmark-text mr-2"></i>Terms of Service</a></li>
+        </ul>
+    </div>
+
     @include('partials.social-footer-tw')
 </div>
 @stop

--- a/resources/views/pages/all-modules-tw.blade.php
+++ b/resources/views/pages/all-modules-tw.blade.php
@@ -55,6 +55,40 @@
 		</div>
 	</div>
 
+	<!-- Policies & Info -->
+	<div class="card-tw mb-6">
+		<div class="p-6">
+			<h2 class="text-2xl font-bold text-foreground mb-4 flex items-center gap-2">
+				<i class="bi bi-shield-check text-primary"></i>
+				Policies &amp; Info
+			</h2>
+			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+				@php
+				$policyModules = [
+					['name' => 'Privacy Policy', 'url' => '/privacy', 'icon' => 'bi-shield-check', 'description' => 'How we handle your data'],
+					['name' => 'Terms of Service', 'url' => '/tos', 'icon' => 'bi-file-earmark-text', 'description' => 'Terms and conditions of use'],
+					['name' => 'About', 'url' => '/about', 'icon' => 'bi-info-circle', 'description' => 'About this site'],
+					['name' => 'Help', 'url' => '/help', 'icon' => 'bi-question-circle', 'description' => 'How to use the site'],
+				];
+				@endphp
+
+				@foreach($policyModules as $module)
+				<a href="{{ url($module['url']) }}" class="block p-4 bg-muted/50 hover:bg-muted rounded-lg border border-border hover:border-primary transition-all group">
+					<div class="flex items-start gap-3">
+						<div class="p-2 bg-primary/10 rounded-lg group-hover:bg-primary/20 transition-colors">
+							<i class="{{ $module['icon'] }} text-primary text-xl"></i>
+						</div>
+						<div class="flex-1">
+							<h3 class="font-semibold text-foreground group-hover:text-primary transition-colors">{{ $module['name'] }}</h3>
+							<p class="text-sm text-muted-foreground mt-1">{{ $module['description'] }}</p>
+						</div>
+					</div>
+				</a>
+				@endforeach
+			</div>
+		</div>
+	</div>
+
 	<!-- Admin Modules -->
 	@can('admin')
 	<div class="card-tw">

--- a/resources/views/pages/help-tw.blade.php
+++ b/resources/views/pages/help-tw.blade.php
@@ -537,6 +537,9 @@
 						<a href="{{ url('/privacy') }}" class="inline-flex items-center px-3 py-2 bg-accent text-foreground border border-border rounded-lg hover:bg-accent/80 transition-colors text-sm">
 							<i class="bi bi-shield-check mr-2"></i> Privacy
 						</a>
+						<a href="{{ url('/tos') }}" class="inline-flex items-center px-3 py-2 bg-accent text-foreground border border-border rounded-lg hover:bg-accent/80 transition-colors text-sm">
+							<i class="bi bi-file-earmark-text mr-2"></i> Terms of Service
+						</a>
 					</div>
 				</div>
 			</section>

--- a/resources/views/pages/privacy-tw.blade.php
+++ b/resources/views/pages/privacy-tw.blade.php
@@ -44,7 +44,7 @@
                 </li>
                 <li>
                     <strong class="text-foreground">Facebook Data.</strong>
-                    When you auth using the FB integration, we collect the account ID for future authentications. When you grant access to your attended events, and choose to import that data, we store public data related to FB events you are attending. This data is collected to allow you to log in more easily as well as share your event information more easily.
+                    We no longer offer any Facebook integration. The app does not collect, use, or store any private Facebook data, and no previously imported private Facebook data is retained.
                 </li>
                 <li>
                     <strong class="text-foreground">Settings and Account information.</strong>


### PR DESCRIPTION
Fixes #1950.

## Background

The Privacy Policy page (`/privacy`) was reported as "missing." Investigation showed the page itself is intact — the route (`routes/web.php:79`), controller (`PagesController::privacy()`), and view (`resources/views/pages/privacy-tw.blade.php`) all exist and render. The real problem was **discoverability**: `/privacy` was only linked in the Help dropdown, so it was effectively unfindable. This PR adds clear links from the pages called out in the issue and refreshes the now-stale Facebook copy.

## Changes

- **All Modules page** (`all-modules-tw.blade.php`): new "Policies & Info" section with tiles for Privacy Policy, Terms of Service, About, and Help (reuses the existing module-tile markup).
- **About page** (`about-tw.blade.php`): new "Policies & Info" card linking Privacy Policy and Terms of Service (the About body is DB-driven, so the links live in the template).
- **Help page** (`help-tw.blade.php`): added a Terms of Service tile next to the existing Privacy tile in Quick Links.
- **Privacy Policy** (`privacy-tw.blade.php`): reworded the "Facebook Data" section — the FB integration has been removed and no private Facebook data is collected or retained.

Per the issue's confirmed scope, Terms of Service is grouped alongside Privacy wherever links were added.

## How to test

1. Visit `/privacy` — page loads and Section 2 now states the Facebook integration is gone and no private FB data is retained.
2. Visit `/about` — a "Policies & Info" card appears with working Privacy Policy and Terms of Service links.
3. Visit `/help` — the Quick Links grid shows both **Privacy** and **Terms of Service** tiles.
4. Visit `/all-modules` — a "Policies & Info" section appears with Privacy Policy, Terms of Service, About, and Help.
5. Click each new link and confirm it loads the correct page (no 404).

## Notes

- View-only changes; no route/controller/migration changes.
- If `/privacy` still 404s in production after deploy, that's a route/view cache artifact — the deploy should run `php artisan route:cache` / `view:clear`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)