### PR TITLE
Move Notifications from sidebar to All Modules (#1948)

### DIFF
--- a/resources/views/pages/all-modules-tw.blade.php
+++ b/resources/views/pages/all-modules-tw.blade.php
@@ -51,6 +51,26 @@
 					</div>
 				</a>
 				@endforeach
+
+				@auth
+				@php $notificationsUnread = Auth::user()->unreadNotifications()->count(); @endphp
+				<a href="{{ route('job-status.index') }}" class="block p-4 bg-muted/50 hover:bg-muted rounded-lg border border-border hover:border-primary transition-all group">
+					<div class="flex items-start gap-3">
+						<div class="p-2 bg-primary/10 rounded-lg group-hover:bg-primary/20 transition-colors">
+							<i class="bi bi-bell text-primary text-xl"></i>
+						</div>
+						<div class="flex-1">
+							<h3 class="font-semibold text-foreground group-hover:text-primary transition-colors">
+								Notifications
+								@if($notificationsUnread > 0)
+								<span class="ml-2 inline-flex items-center justify-center text-xs font-semibold rounded-full bg-red-600 text-white px-2 py-0.5">{{ $notificationsUnread }}</span>
+								@endif
+							</h3>
+							<p class="text-sm text-muted-foreground mt-1">Background jobs and notifications</p>
+						</div>
+					</div>
+				</a>
+				@endauth
 			</div>
 		</div>
 	</div>

--- a/resources/views/pages/all-modules-tw.blade.php
+++ b/resources/views/pages/all-modules-tw.blade.php
@@ -35,6 +35,11 @@
 					['name' => 'Threads', 'url' => '/threads', 'icon' => 'bi-chat-dots', 'description' => 'Forum discussions'],
 					['name' => 'Users', 'url' => '/users', 'icon' => 'bi-person', 'description' => 'Community members'],
 				];
+				$notificationsUnread = 0;
+				if (Auth::check()) {
+					$notificationsUnread = Auth::user()->unreadNotifications()->count();
+					$publicModules[] = ['name' => 'Notifications', 'url' => '/job-status', 'icon' => 'bi-bell', 'description' => 'Background jobs and notifications'];
+				}
 				sort($publicModules);
 				@endphp
 
@@ -45,32 +50,17 @@
 							<i class="{{ $module['icon'] }} text-primary text-xl"></i>
 						</div>
 						<div class="flex-1">
-							<h3 class="font-semibold text-foreground group-hover:text-primary transition-colors">{{ $module['name'] }}</h3>
+							<h3 class="font-semibold text-foreground group-hover:text-primary transition-colors">
+								{{ $module['name'] }}
+								@if($module['url'] === '/job-status' && $notificationsUnread > 0)
+								<span class="ml-2 inline-flex items-center justify-center text-xs font-semibold rounded-full bg-red-600 text-white px-2 py-0.5">{{ $notificationsUnread }}</span>
+								@endif
+							</h3>
 							<p class="text-sm text-muted-foreground mt-1">{{ $module['description'] }}</p>
 						</div>
 					</div>
 				</a>
 				@endforeach
-
-				@auth
-				@php $notificationsUnread = Auth::user()->unreadNotifications()->count(); @endphp
-				<a href="{{ route('job-status.index') }}" class="block p-4 bg-muted/50 hover:bg-muted rounded-lg border border-border hover:border-primary transition-all group">
-					<div class="flex items-start gap-3">
-						<div class="p-2 bg-primary/10 rounded-lg group-hover:bg-primary/20 transition-colors">
-							<i class="bi bi-bell text-primary text-xl"></i>
-						</div>
-						<div class="flex-1">
-							<h3 class="font-semibold text-foreground group-hover:text-primary transition-colors">
-								Notifications
-								@if($notificationsUnread > 0)
-								<span class="ml-2 inline-flex items-center justify-center text-xs font-semibold rounded-full bg-red-600 text-white px-2 py-0.5">{{ $notificationsUnread }}</span>
-								@endif
-							</h3>
-							<p class="text-sm text-muted-foreground mt-1">Background jobs and notifications</p>
-						</div>
-					</div>
-				</a>
-				@endauth
 			</div>
 		</div>
 	</div>

--- a/resources/views/partials/sidebar-tw.blade.php
+++ b/resources/views/partials/sidebar-tw.blade.php
@@ -132,15 +132,6 @@
             <i class="bi bi-person-circle text-lg"></i>
             <a href="{{ url('/users/'.Auth::user()->id) }}" class="hover:text-foreground">{{ Auth::user()->name }}</a>
         </div>
-        <!-- Notifications -->
-        @php $unreadCount = Auth::user()->unreadNotifications()->count(); @endphp
-        <a href="{{ route('job-status.index') }}" class="nav-item-tw mt-1 {{ Request::is('job-status*') ? 'nav-item-active-tw' : '' }}">
-            <i class="bi bi-bell text-lg"></i>
-            <span>Notifications</span>
-            @if ($unreadCount > 0)
-            <span class="ml-auto inline-flex items-center justify-center text-xs font-semibold rounded-full bg-red-600 text-white px-2 py-0.5">{{ $unreadCount }}</span>
-            @endif
-        </a>
         @can('admin')
         <a href="{{ route('pages.allModules') }}" class="nav-item-tw mt-1 {{ Request::is('all-modules') ? 'nav-item-active-tw' : '' }}">
             <i class="bi bi-grid-3x3-gap text-lg"></i>
@@ -298,15 +289,6 @@
             <i class="bi bi-person-circle text-lg shrink-0"></i>
             <a href="{{ url('/users/'.Auth::user()->id) }}" class="hover:text-foreground truncate">{{ Auth::user()->name }}</a>
         </div>
-        <!-- Notifications -->
-        @php $unreadCountMobile = Auth::user()->unreadNotifications()->count(); @endphp
-        <a href="{{ route('job-status.index') }}" class="nav-item-tw mt-1 {{ Request::is('job-status*') ? 'nav-item-active-tw' : '' }}">
-            <i class="bi bi-bell text-lg"></i>
-            <span>Notifications</span>
-            @if ($unreadCountMobile > 0)
-            <span class="ml-auto inline-flex items-center justify-center text-xs font-semibold rounded-full bg-red-600 text-white px-2 py-0.5">{{ $unreadCountMobile }}</span>
-            @endif
-        </a>
         @can('admin')
         <a href="{{ route('pages.allModules') }}" class="nav-item-tw mt-1 {{ Request::is('all-modules') ? 'nav-item-active-tw' : '' }}">
             <i class="bi bi-grid-3x3-gap text-lg"></i>


### PR DESCRIPTION
Fixes #1948.

## Background

Per the issue, the Notifications link doesn't need to live in the sidebar. This moves it to the All Modules page.

## Changes

- **Sidebar** (`partials/sidebar-tw.blade.php`): removed the Notifications link from both the desktop and mobile sections.
- **All Modules** (`pages/all-modules-tw.blade.php`): added an `@auth`-gated Notifications tile at the end of the Public Modules grid, linking to `job-status.index` with the `bi-bell` icon and the same red unread-count badge (`Auth::user()->unreadNotifications()`). It's `@auth`-wrapped because the All Modules page is publicly viewable.

No route/controller changes — `job-status.index` already exists.

## How to test

1. **Logged in:** open `/all-modules` — a **Notifications** tile appears in Public Modules; if you have unread notifications, the red count badge shows; clicking it loads `/job-status`.
2. **Logged in:** confirm the sidebar no longer shows a Notifications link at both desktop and mobile widths.
3. **Logged out:** open `/all-modules` — the Notifications tile is absent and the page renders without error.

## Note

This is a literal move: the All Modules sidebar link remains admin-only, so non-admin users now reach Notifications via a direct `/all-modules` or `/job-status` URL rather than the sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)