### PR TITLE
Add publicly available modules to search results (#1949)

### DIFF
--- a/app/Http/Controllers/Api/SearchController.php
+++ b/app/Http/Controllers/Api/SearchController.php
@@ -33,7 +33,7 @@ class SearchController extends Controller
 
         $types = null;
         if (! empty($validated['types'])) {
-            $allowed = ['events', 'entities', 'series', 'tags'];
+            $allowed = ['events', 'entities', 'series', 'tags', 'modules'];
             $requested = array_map('trim', explode(',', $validated['types']));
             $types = array_values(array_intersect($allowed, $requested)) ?: null;
         }

--- a/app/Services/ModuleRegistry.php
+++ b/app/Services/ModuleRegistry.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+
+/**
+ * Resolves the site's top-level "modules" (pages/features) from config/modules.php,
+ * filtered by what a given user is allowed to see, and provides a lightweight
+ * keyword search over their titles and descriptions.
+ *
+ * @phpstan-type Module array{name:string, url:string, icon:string, description:string}
+ */
+class ModuleRegistry
+{
+    /**
+     * Modules the given user is permitted to see:
+     *   - public + policy: everyone
+     *   - auth: any authenticated user
+     *   - admin: users in the "admin" group
+     *
+     * @return list<array{name:string, url:string, icon:string, description:string}>
+     */
+    public function visibleTo(?User $user): array
+    {
+        $modules = array_merge(
+            config('modules.public', []),
+            config('modules.policy', []),
+        );
+
+        if ($user !== null) {
+            $modules = array_merge($modules, config('modules.auth', []));
+
+            if ($user->hasGroup('admin')) {
+                $modules = array_merge($modules, config('modules.admin', []));
+            }
+        }
+
+        return array_values($modules);
+    }
+
+    /**
+     * Case-insensitive search over the visible modules' name and description.
+     * Empty keyword returns no results.
+     *
+     * @return list<array{name:string, url:string, icon:string, description:string}>
+     */
+    public function search(string $keyword, ?User $user): array
+    {
+        $keyword = trim($keyword);
+        if ($keyword === '') {
+            return [];
+        }
+
+        $matches = array_filter($this->visibleTo($user), function (array $module) use ($keyword) {
+            return stripos($module['name'], $keyword) !== false
+                || stripos($module['description'], $keyword) !== false;
+        });
+
+        return array_values($matches);
+    }
+}

--- a/app/Services/SearchService.php
+++ b/app/Services/SearchService.php
@@ -26,6 +26,10 @@ class SearchService
      */
     private const FULLTEXT_MIN_LENGTH = 3;
 
+    public function __construct(private readonly ModuleRegistry $moduleRegistry = new ModuleRegistry)
+    {
+    }
+
     /**
      * Run all six section searches and return an associative array of paginators.
      *
@@ -42,6 +46,8 @@ class SearchService
      *   usersCount: int,
      *   threads: LengthAwarePaginator,
      *   threadsCount: int,
+     *   modules: \Illuminate\Support\Collection<int, array{name:string, url:string, icon:string, description:string}>,
+     *   modulesCount: int,
      * }
      */
     public function all(string $keyword, ?User $user, int $perPage = 20): array
@@ -55,11 +61,12 @@ class SearchService
         $tags     = $this->tags($keyword, $perPage);
         $users    = $this->users($keyword, $perPage);
         $threads  = $this->threads($keyword, $perPage);
+        $modules  = collect($this->moduleRegistry->search($keyword, $user));
 
         $tagsCount    = $this->countLike(Tag::query(), ['name'], $keyword);
         $usersCount   = $this->countLike(User::query(), ['name'], $keyword);
 
-        $this->logSearch($keyword, $user, 'web', $events->total() + $series->total() + $entities->total() + $tagsCount + $usersCount + $threads->total());
+        $this->logSearch($keyword, $user, 'web', $events->total() + $series->total() + $entities->total() + $tagsCount + $usersCount + $threads->total() + $modules->count());
 
         return [
             'events'        => $events,
@@ -74,6 +81,8 @@ class SearchService
             'usersCount'    => $usersCount,
             'threads'       => $threads,
             'threadsCount'  => $threads->total(),
+            'modules'       => $modules,
+            'modulesCount'  => $modules->count(),
         ];
     }
 
@@ -231,7 +240,7 @@ class SearchService
     /**
      * Lightweight grouped typeahead results: flat arrays per type.
      *
-     * @param  array<int, string>|null  $types  Subset of ['events','entities','series','tags']. Null = all four.
+     * @param  array<int, string>|null  $types  Subset of ['events','entities','series','tags','modules']. Null = all.
      * @return array{
      *   query: string,
      *   results: array<string, list<array{id:int,name:string,slug:?string,subtitle:?string,url:string}>>,
@@ -240,7 +249,7 @@ class SearchService
     public function lite(string $keyword, ?User $user, int $limit = 6, ?array $types = null): array
     {
         $keyword = trim(preg_replace('/\s+/', ' ', $keyword) ?? '');
-        $types = $types ?: ['events', 'entities', 'series', 'tags'];
+        $types = $types ?: ['events', 'entities', 'series', 'tags', 'modules'];
         $results = [];
 
         if ($keyword === '') {
@@ -313,6 +322,17 @@ class SearchService
                 'subtitle' => null,
                 'url'      => url('/tags/' . $t->slug),
             ])->all();
+        }
+
+        if (in_array('modules', $types, true)) {
+            $modules = array_slice($this->moduleRegistry->search($keyword, $user), 0, $limit);
+            $results['modules'] = array_map(fn ($module, $index) => [
+                'id'       => $index,
+                'name'     => $module['name'],
+                'slug'     => null,
+                'subtitle' => $module['description'],
+                'url'      => url($module['url']),
+            ], $modules, array_keys($modules));
         }
 
         $totalCount = array_sum(array_map('count', $results));

--- a/config/modules.php
+++ b/config/modules.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Site Modules
+|--------------------------------------------------------------------------
+|
+| Authoritative list of the site's top-level pages ("modules"), grouped by
+| the access level required to see them. Consumed by the All Modules page
+| (resources/views/pages/all-modules-tw.blade.php) and by search
+| (App\Services\ModuleRegistry / App\Services\SearchService) so the two
+| never drift.
+|
+| Access groups:
+|   public  - visible to everyone
+|   auth    - visible to any authenticated user
+|   policy  - informational pages, visible to everyone
+|   admin   - visible only to users in the "admin" group
+|
+| Each module: name, url, icon (Bootstrap Icons class), description.
+|
+*/
+
+return [
+    'public' => [
+        ['name' => 'Activity', 'url' => '/activity', 'icon' => 'bi-activity', 'description' => 'View recent site activity'],
+        ['name' => 'Calendar', 'url' => '/calendar', 'icon' => 'bi-calendar3', 'description' => 'Browse events by calendar'],
+        ['name' => 'Entities', 'url' => '/entities', 'icon' => 'bi-people', 'description' => 'Artists, venues, promoters'],
+        ['name' => 'Events', 'url' => '/events', 'icon' => 'bi-calendar-event', 'description' => 'Concerts and club nights'],
+        ['name' => 'Photos', 'url' => '/photos', 'icon' => 'bi-images', 'description' => 'Browse event photos'],
+        ['name' => 'Popular', 'url' => '/popular', 'icon' => 'bi-graph-up-arrow', 'description' => 'Popular events, entities, and tags'],
+        ['name' => 'Posts', 'url' => '/posts', 'icon' => 'bi-file-text', 'description' => 'Community posts'],
+        ['name' => 'Reviews', 'url' => '/reviews', 'icon' => 'bi-star', 'description' => 'Event reviews'],
+        ['name' => 'Search', 'url' => '/search', 'icon' => 'bi-search', 'description' => 'Search events, entities, series, and more'],
+        ['name' => 'Series', 'url' => '/series', 'icon' => 'bi-collection', 'description' => 'Recurring event series'],
+        ['name' => 'Tags', 'url' => '/tags', 'icon' => 'bi-tags', 'description' => 'Browse by tags'],
+        ['name' => 'Threads', 'url' => '/threads', 'icon' => 'bi-chat-dots', 'description' => 'Forum discussions'],
+        ['name' => 'Users', 'url' => '/users', 'icon' => 'bi-person', 'description' => 'Community members'],
+    ],
+
+    'auth' => [
+        ['name' => 'Notifications', 'url' => '/job-status', 'icon' => 'bi-bell', 'description' => 'Background jobs and notifications'],
+    ],
+
+    'policy' => [
+        ['name' => 'Privacy Policy', 'url' => '/privacy', 'icon' => 'bi-shield-check', 'description' => 'How we handle your data'],
+        ['name' => 'Terms of Service', 'url' => '/tos', 'icon' => 'bi-file-earmark-text', 'description' => 'Terms and conditions of use'],
+        ['name' => 'About', 'url' => '/about', 'icon' => 'bi-info-circle', 'description' => 'About this site'],
+        ['name' => 'Help', 'url' => '/help', 'icon' => 'bi-question-circle', 'description' => 'How to use the site'],
+    ],
+
+    'admin' => [
+        ['name' => 'Activity Graph', 'url' => '/activity/graph', 'icon' => 'bi-activity', 'description' => 'Visualize and export activity trends'],
+        ['name' => 'Blogs', 'url' => '/blogs', 'icon' => 'bi-journal-text', 'description' => 'Manage blog posts'],
+        ['name' => 'Categories', 'url' => '/categories', 'icon' => 'bi-folder', 'description' => 'Manage forum categories'],
+        ['name' => 'Entity Types', 'url' => '/entity-types', 'icon' => 'bi-diagram-3', 'description' => 'Manage entity types'],
+        ['name' => 'Forums', 'url' => '/forums', 'icon' => 'bi-chat-square-text', 'description' => 'Manage forum sections'],
+        ['name' => 'Groups', 'url' => '/groups', 'icon' => 'bi-people-fill', 'description' => 'Manage user groups'],
+        ['name' => 'Menus', 'url' => '/menus', 'icon' => 'bi-menu-button-wide', 'description' => 'Manage navigation menus'],
+        ['name' => 'Permissions', 'url' => '/permissions', 'icon' => 'bi-key', 'description' => 'Manage permissions'],
+        ['name' => 'Roles', 'url' => '/roles', 'icon' => 'bi-person-badge', 'description' => 'Manage entity roles'],
+    ],
+];

--- a/resources/views/events/create.blade.php
+++ b/resources/views/events/create.blade.php
@@ -83,8 +83,7 @@
             </div>
 
             <p class="text-sm text-muted-foreground mb-4">
-                Upload an event flyer and the app will attempt to extract the event details and pre-fill the form below.
-                You can review and edit the information before saving.
+                Upload a primary event image here and optionally use the "Analyze Image" button to automatically pre-fill the event form with details extracted from the flyer.
             </p>
 
             <div id="flyer-status" class="hidden text-sm mb-4 p-3 rounded-md"></div>

--- a/resources/views/pages/all-modules-tw.blade.php
+++ b/resources/views/pages/all-modules-tw.blade.php
@@ -20,25 +20,11 @@
 			</h2>
 			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 				@php
-				$publicModules = [
-					['name' => 'Activity', 'url' => '/activity', 'icon' => 'bi-activity', 'description' => 'View recent site activity'],
-					['name' => 'Calendar', 'url' => '/calendar', 'icon' => 'bi-calendar3', 'description' => 'Browse events by calendar'],
-					['name' => 'Entities', 'url' => '/entities', 'icon' => 'bi-people', 'description' => 'Artists, venues, promoters'],
-					['name' => 'Events', 'url' => '/events', 'icon' => 'bi-calendar-event', 'description' => 'Concerts and club nights'],
-					['name' => 'Photos', 'url' => '/photos', 'icon' => 'bi-images', 'description' => 'Browse event photos'],
-					['name' => 'Popular', 'url' => '/popular', 'icon' => 'bi-graph-up-arrow', 'description' => 'Popular events, entities, and tags'],
-					['name' => 'Posts', 'url' => '/posts', 'icon' => 'bi-file-text', 'description' => 'Community posts'],
-					['name' => 'Reviews', 'url' => '/reviews', 'icon' => 'bi-star', 'description' => 'Event reviews'],
-					['name' => 'Search', 'url' => '/search', 'icon' => 'bi-search', 'description' => 'Search events, entities, series, and more'],
-					['name' => 'Series', 'url' => '/series', 'icon' => 'bi-collection', 'description' => 'Recurring event series'],
-					['name' => 'Tags', 'url' => '/tags', 'icon' => 'bi-tags', 'description' => 'Browse by tags'],
-					['name' => 'Threads', 'url' => '/threads', 'icon' => 'bi-chat-dots', 'description' => 'Forum discussions'],
-					['name' => 'Users', 'url' => '/users', 'icon' => 'bi-person', 'description' => 'Community members'],
-				];
+				$publicModules = config('modules.public', []);
 				$notificationsUnread = 0;
 				if (Auth::check()) {
 					$notificationsUnread = Auth::user()->unreadNotifications()->count();
-					$publicModules[] = ['name' => 'Notifications', 'url' => '/job-status', 'icon' => 'bi-bell', 'description' => 'Background jobs and notifications'];
+					$publicModules = array_merge($publicModules, config('modules.auth', []));
 				}
 				sort($publicModules);
 				@endphp
@@ -74,12 +60,7 @@
 			</h2>
 			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 				@php
-				$policyModules = [
-					['name' => 'Privacy Policy', 'url' => '/privacy', 'icon' => 'bi-shield-check', 'description' => 'How we handle your data'],
-					['name' => 'Terms of Service', 'url' => '/tos', 'icon' => 'bi-file-earmark-text', 'description' => 'Terms and conditions of use'],
-					['name' => 'About', 'url' => '/about', 'icon' => 'bi-info-circle', 'description' => 'About this site'],
-					['name' => 'Help', 'url' => '/help', 'icon' => 'bi-question-circle', 'description' => 'How to use the site'],
-				];
+				$policyModules = config('modules.policy', []);
 				@endphp
 
 				@foreach($policyModules as $module)
@@ -109,17 +90,7 @@
 			</h2>
 			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 				@php
-				$adminModules = [
-					['name' => 'Activity Graph', 'url' => '/activity/graph', 'icon' => 'bi-activity', 'description' => 'Visualize and export activity trends'],
-					['name' => 'Blogs', 'url' => '/blogs', 'icon' => 'bi-journal-text', 'description' => 'Manage blog posts'],
-					['name' => 'Categories', 'url' => '/categories', 'icon' => 'bi-folder', 'description' => 'Manage forum categories'],
-					['name' => 'Entity Types', 'url' => '/entity-types', 'icon' => 'bi-diagram-3', 'description' => 'Manage entity types'],
-					['name' => 'Forums', 'url' => '/forums', 'icon' => 'bi-chat-square-text', 'description' => 'Manage forum sections'],
-					['name' => 'Groups', 'url' => '/groups', 'icon' => 'bi-people-fill', 'description' => 'Manage user groups'],
-					['name' => 'Menus', 'url' => '/menus', 'icon' => 'bi-menu-button-wide', 'description' => 'Manage navigation menus'],
-					['name' => 'Permissions', 'url' => '/permissions', 'icon' => 'bi-key', 'description' => 'Manage permissions'],
-					['name' => 'Roles', 'url' => '/roles', 'icon' => 'bi-person-badge', 'description' => 'Manage entity roles'],
-				];
+				$adminModules = config('modules.admin', []);
 				sort($adminModules);
 				@endphp
 

--- a/resources/views/pages/search.blade.php
+++ b/resources/views/pages/search.blade.php
@@ -14,6 +14,13 @@
 
 <!-- Jump Links -->
 <div class="mb-6 flex flex-wrap gap-2">
+	@if (isset($modulesCount) && $modulesCount > 0)
+	<a href="#modules-results" class="inline-flex items-center px-4 py-2 bg-card border-2 border-primary text-foreground rounded-lg hover:bg-accent transition-colors text-sm font-medium">
+		<i class="bi bi-grid-3x3-gap mr-2"></i>
+		Pages ({{ $modulesCount }})
+	</a>
+	@endif
+
 	@if (isset($entities) && $entitiesCount > 0)
 	<a href="#entities-results" class="inline-flex items-center px-4 py-2 bg-card border-2 border-primary text-foreground rounded-lg hover:bg-accent transition-colors text-sm font-medium">
 		<i class="bi bi-people mr-2"></i>
@@ -51,6 +58,38 @@
 </div>
 
 <div class="space-y-6">
+	<!-- Pages / Modules Results -->
+	@if (isset($modules) && $modulesCount > 0)
+	<div id="modules-results" class="card-tw scroll-mt-6">
+		<div class="p-4 border-b border-border flex items-center justify-between">
+			<div class="flex items-center gap-3">
+				<h2 class="text-xl font-semibold text-foreground">Pages</h2>
+				<span class="badge-tw bg-muted text-foreground">{{ $modulesCount }}</span>
+			</div>
+			<button class="text-muted-foreground hover:text-foreground" onclick="toggleSection('search-modules')">
+				<i class="bi bi-eye-fill"></i>
+			</button>
+		</div>
+		<div id="search-modules" class="p-4">
+			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+				@foreach($modules as $module)
+				<a href="{{ url($module['url']) }}" class="block p-4 bg-muted/50 hover:bg-muted rounded-lg border border-border hover:border-primary transition-all group">
+					<div class="flex items-start gap-3">
+						<div class="p-2 bg-primary/10 rounded-lg group-hover:bg-primary/20 transition-colors">
+							<i class="{{ $module['icon'] }} text-primary text-xl"></i>
+						</div>
+						<div class="flex-1">
+							<h3 class="font-semibold text-foreground group-hover:text-primary transition-colors">{{ $module['name'] }}</h3>
+							<p class="text-sm text-muted-foreground mt-1">{{ $module['description'] }}</p>
+						</div>
+					</div>
+				</a>
+				@endforeach
+			</div>
+		</div>
+	</div>
+	@endif
+
 	<!-- Entities Results -->
 	@if (isset($entities) && $entitiesCount > 0)
 	<div id="entities-results" class="card-tw scroll-mt-6">

--- a/resources/views/partials/search-autocomplete.blade.php
+++ b/resources/views/partials/search-autocomplete.blade.php
@@ -154,7 +154,7 @@
             overlay: false,
             loading: false,
             controller: null,
-            results: { events: [], entities: [], series: [], tags: [] },
+            results: { events: [], entities: [], series: [], tags: [], modules: [] },
             activeKey: null,
             activeIdx: -1,
             _savedBodyOverflow: '',
@@ -170,6 +170,7 @@
                     { key: 'entities', label: 'Entities', items: this.results.entities || [] },
                     { key: 'series',   label: 'Series',   items: this.results.series   || [] },
                     { key: 'tags',     label: 'Tags',     items: this.results.tags     || [] },
+                    { key: 'modules',  label: 'Pages',    items: this.results.modules  || [] },
                 ];
             },
 
@@ -212,7 +213,7 @@
             async fetch() {
                 const q = this.query.trim();
                 if (q.length < 3) {
-                    this.results = { events: [], entities: [], series: [], tags: [] };
+                    this.results = { events: [], entities: [], series: [], tags: [], modules: [] };
                     if (!this.overlay) this.open = false;
                     return;
                 }
@@ -229,7 +230,7 @@
                     if (!res.ok) throw new Error('search request failed');
                     const data = await res.json();
                     this.results = Object.assign(
-                        { events: [], entities: [], series: [], tags: [] },
+                        { events: [], entities: [], series: [], tags: [], modules: [] },
                         data.results || {}
                     );
                     this.activeKey = null;

--- a/tests/Feature/SearchModulesTest.php
+++ b/tests/Feature/SearchModulesTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\UserStatus;
+use App\Services\ModuleRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SearchModulesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected bool $seed = true;
+
+    private function activeUser(): User
+    {
+        /** @var User $user */
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        return $user;
+    }
+
+    private function admin(): User
+    {
+        $admin = $this->activeUser();
+        $admin->assignGroup('admin');
+
+        return $admin;
+    }
+
+    /** @test */
+    public function module_registry_matches_on_name_and_description(): void
+    {
+        $registry = new ModuleRegistry;
+
+        // Name match.
+        $byName = collect($registry->search('calendar', null))->pluck('name');
+        $this->assertContains('Calendar', $byName);
+
+        // Description match ("Concerts and club nights" -> Events).
+        $byDescription = collect($registry->search('concerts', null))->pluck('name');
+        $this->assertContains('Events', $byDescription);
+
+        // Empty keyword returns nothing.
+        $this->assertSame([], $registry->search('   ', null));
+    }
+
+    /** @test */
+    public function guests_only_see_public_and_policy_modules(): void
+    {
+        $registry = new ModuleRegistry;
+
+        $this->assertContains('Calendar', collect($registry->search('calendar', null))->pluck('name'));
+        $this->assertContains('About', collect($registry->search('about', null))->pluck('name'));
+
+        // Admin-only and auth-only pages are hidden from guests.
+        $this->assertEmpty($registry->search('permissions', null));
+        $this->assertEmpty($registry->search('notifications', null));
+    }
+
+    /** @test */
+    public function authenticated_users_see_notifications_but_not_admin_modules(): void
+    {
+        $registry = new ModuleRegistry;
+        $user = $this->activeUser();
+
+        $this->assertContains('Notifications', collect($registry->search('notifications', $user))->pluck('name'));
+        $this->assertEmpty($registry->search('permissions', $user));
+    }
+
+    /** @test */
+    public function admins_see_admin_modules(): void
+    {
+        $registry = new ModuleRegistry;
+        $admin = $this->admin();
+
+        $this->assertContains('Permissions', collect($registry->search('permissions', $admin))->pluck('name'));
+    }
+
+    /** @test */
+    public function search_page_shows_matching_public_module_to_guests(): void
+    {
+        $response = $this->get('/search?keyword=calendar');
+
+        $response->assertStatus(200);
+        $response->assertSee('id="modules-results"', false);
+        $response->assertSee('Browse events by calendar');
+    }
+
+    /** @test */
+    public function api_search_returns_modules_scoped_by_permission(): void
+    {
+        // Guest: gets public module, no admin module.
+        $guest = $this->getJson('/api/search?q=calendar');
+        $guest->assertStatus(200);
+        $this->assertContains('Calendar', collect($guest->json('results.modules'))->pluck('name'));
+
+        $guestAdminTerm = $this->getJson('/api/search?q=permissions');
+        $this->assertSame([], $guestAdminTerm->json('results.modules'));
+
+        // Admin: gets the admin module.
+        $this->actingAs($this->admin());
+        $adminResponse = $this->getJson('/api/search?q=permissions');
+        $adminResponse->assertStatus(200);
+        $this->assertContains('Permissions', collect($adminResponse->json('results.modules'))->pluck('name'));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1949.

When a user searches, results now include links to the site's top-level pages ("modules") that are available to them:

- **Guests** → public pages + info/policy pages (Events, Calendar, Photos, Reviews, About, Privacy, etc.)
- **Authenticated users** → also **Notifications**
- **Admins** → also the admin-only pages (Permissions, Roles, Groups, etc.)

Matching is on each module's **title and description** (the issue explicitly allows title-only; description is the closest thing to "page content" we have for these static pages). Modules appear in **both** the full `/search` results page and the typeahead autocomplete dropdown.

## Changes

**New**
- `config/modules.php` — single authoritative list of all modules, grouped by access level (`public` / `auth` / `policy` / `admin`).
- `app/Services/ModuleRegistry.php` — resolves modules visible to a user (`public`+`policy` for everyone; `auth` for logged-in; `admin` for `hasGroup('admin')`) and searches them case-insensitively by name/description.
- `tests/Feature/SearchModulesTest.php` — coverage for matching, per-role visibility, the search page, and the API endpoint.

**Modified**
- `app/Services/SearchService.php` — injects `ModuleRegistry` (default arg keeps `new SearchService()` working); adds `modules`/`modulesCount` to `all()` and a `modules` group to typeahead `lite()`; counts modules in the search log total.
- `app/Http/Controllers/Api/SearchController.php` — `modules` added to allowed typeahead types.
- `resources/views/pages/search.blade.php` — "Pages" jump link + results section.
- `resources/views/partials/search-autocomplete.blade.php` — "Pages" group in the Alpine dropdown.
- `resources/views/pages/all-modules-tw.blade.php` — now reads from `config('modules')` instead of hardcoded arrays (single source of truth; Notifications unread badge preserved).

## How to test

Automated:
```bash
php artisan config:clear   # config/modules.php is new
./vendor/bin/phpunit tests/Feature/SearchModulesTest.php \
  tests/Feature/SearchTest.php tests/Feature/SearchVisibilityTest.php
composer phpstan
```

Manual:
```bash
php artisan config:clear
php artisan serve
```
- Visit `/search?keyword=calendar` as a **guest** → a **Pages** section shows the Calendar link; admin-only pages are absent.
- Repeat as a **logged-in user** (`/search?keyword=notifications` shows Notifications) and as an **admin** (`/search?keyword=permissions` shows Permissions).
- Type "cal" / "reviews" in the sidebar search box → a **Pages** group appears in the dropdown with working links.
- Visit `/all-modules` → renders identically (public / policies / admin sections, Notifications badge intact).

## Notes
- **Deploy:** a new config file is added, so config cache must be cleared/rebuilt (`php artisan config:clear` / `config:cache`).
- Full page-content indexing is out of scope (possible follow-up); this matches title + description only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)