### PR TITLE
Fail gracefully on invalid list sort param (#1942)

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -5,6 +5,7 @@ namespace App\Exceptions;
 use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Validation\ValidationException;
 use Symfony\Component\HttpFoundation\Response;
@@ -52,6 +53,25 @@ class Handler extends ExceptionHandler
     {
         if ($e instanceof ModelNotFoundException) {
             abort(404);
+        }
+
+        // A malformed list query param (typically an unknown `sort` column, e.g.
+        // /users?sort=start_at) reaches orderBy() and throws a QueryException,
+        // which would otherwise surface as an opaque 500. Rather than fail hard,
+        // strip the offending sort params, flash a notice, and redirect back so
+        // the list renders in its default order. Kept deliberately narrow (GET
+        // requests carrying sort/direction) so genuine DB errors on ordinary
+        // pages are not masked. The exception is still reported (see report()).
+        if ($e instanceof QueryException
+            && $request->isMethod('get')
+            && ($request->has('sort') || $request->has('direction'))
+        ) {
+            flash()->error(
+                'Invalid sort',
+                'That sort parameter is not valid; showing the default order instead.'
+            );
+
+            return redirect()->to($request->fullUrlWithoutQuery(['sort', 'direction']));
         }
 
         return parent::render($request, $e);

--- a/tests/Feature/UsersTest.php
+++ b/tests/Feature/UsersTest.php
@@ -68,6 +68,62 @@ class UsersTest extends TestCase
     }
 
     /** @test */
+    public function an_invalid_sort_param_redirects_instead_of_500(): void
+    {
+        // /users?sort=start_at reaches orderBy() on a column that does not exist
+        // on the users table, throwing a QueryException. Rather than 500, the
+        // exception handler should strip the sort params, flash a notice, and
+        // redirect back to the list (#1942).
+        $this->withExceptionHandling();
+
+        $admin = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $admin->assignGroup('admin');
+        $this->actingAs($admin);
+
+        $response = $this->get('/users?limit=25&sort=start_at&direction=desc');
+
+        // Redirects back to the list with the bad sort params stripped but other
+        // params (e.g. limit) preserved.
+        $response->assertStatus(302);
+        $location = $response->headers->get('Location');
+        $this->assertStringStartsWith(route('users.index'), $location);
+        $this->assertStringNotContainsString('sort', $location);
+        $this->assertStringNotContainsString('direction', $location);
+        $response->assertSessionHas('flash_message');
+    }
+
+    /** @test */
+    public function following_the_invalid_sort_redirect_renders_the_list(): void
+    {
+        $this->withExceptionHandling();
+
+        $admin = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $admin->assignGroup('admin');
+        $this->actingAs($admin);
+
+        // The redirect target carries no sort params, so the list falls back to
+        // the default order and renders normally.
+        $response = $this->get(route('users.index'));
+
+        $response->assertStatus(200);
+    }
+
+    /** @test */
+    public function a_valid_sort_param_still_works(): void
+    {
+        $this->withExceptionHandling();
+
+        $admin = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $admin->assignGroup('admin');
+        $this->actingAs($admin);
+
+        // A real column and a computed/aliased column (last_active, added via
+        // addSelect) must both continue to sort without error.
+        $this->get('/users?sort=name&direction=asc')->assertStatus(200);
+        $this->get('/users?sort=last_active&direction=desc')->assertStatus(200);
+    }
+
+    /** @test */
     public function updating_a_user_with_no_profile_row_does_not_error(): void
     {
         // UserFactory doesn't create a profile row (EVENTREPO-VW regression).


### PR DESCRIPTION
## Summary

Fixes #1942. An invalid list query param — typically an unknown `sort` column, e.g. `GET /users?limit=25&sort=start_at&direction=desc` — reached `orderBy()` on a column that doesn't exist on the table, throwing a `QueryException` that surfaced as an opaque **500**.

The existing `ListEntityResultBuilder::isValidSortField()` guard only validates the *format* of the sort field (an anti-injection regex), so a well-formed-but-nonexistent column like `start_at` passed the guard and blew up at the DB.

## Change

`app/Exceptions/Handler.php` — in `render()`, catch `QueryException` for **GET** requests that carry a `sort` or `direction` param:

- Flash an error notice ("That sort parameter is not valid; showing the default order instead.")
- Redirect back to the same URL with `sort`/`direction` stripped (other params like `limit`, `filters`, `page` are preserved via `fullUrlWithoutQuery`).

The list then re-renders in its default order and the flash banner tells the user what happened — matching the issue's ask to "wrap and bubble up that error and return a better error message that the user can react to."

### Why this approach
- **Centralized** — fixes all 42 list endpoints (events, entities, series, tags, users, …) at once, no per-controller churn.
- **Handles computed sort columns** (`last_active`, `follows_count`) for free — a `Schema::hasColumn`/whitelist check would wrongly reject those legitimate sorts.
- **Narrow** — gated to GET + sort/direction present, so genuine DB errors on ordinary pages aren't masked.
- **Still reported to Sentry** — `report()` is untouched, so these remain visible.
- **No redirect loop** — the failing request throws before the controller's `$listParamSessionStore->save()`, so the bad sort is never persisted to the session.

## How to test

Automated:
```bash
./vendor/bin/phpunit tests/Feature/UsersTest.php
```
New coverage:
- `an_invalid_sort_param_redirects_instead_of_500` — `/users?sort=start_at` returns 302 (not 500), sort/direction stripped from the redirect, flash set.
- `following_the_invalid_sort_redirect_renders_the_list` — the redirect target renders 200 in default order.
- `a_valid_sort_param_still_works` — a real column (`name`) and a computed/aliased column (`last_active`) both still return 200.

Manual:
1. Log in and visit `/users?limit=25&sort=start_at&direction=desc`.
2. Before: 500 error. After: redirected to `/users?limit=25` in default order with a flash notice about the invalid sort.
3. Confirm a valid sort (e.g. `/users?sort=name&direction=asc`) still works.

## Scope
- Covers GET requests (how sort links are generated and the reported case). POST-based filter submissions with a bad sort aren't caught by the GET gate — can be a follow-up if desired.
- No migrations, seeder, or frontend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)