### PR TITLE
Fix: N+1 entities lookup on interested-events iCal feed [EVENTREPO-T6]

### DIFF
--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -3285,6 +3285,11 @@ class EventsController extends Controller
 
         $events = $user->followedEvents();
 
+        // Eager-load the relations the iCal builder reads per event (venue,
+        // promoter + its contacts, and photos for getPrimaryPhoto()) to avoid
+        // an N+1 entities lookup while rendering the feed (EVENTREPO-T6).
+        $events->loadMissing(['venue', 'promoter.contacts', 'photos']);
+
         // create a calendar object for the user
         $calendar = $iCalBuilder->buildCalendar('arcane-city-interested-ical.ics', $events);
 


### PR DESCRIPTION
## Sentry issue

[EVENTREPO-T6](https://geoff-maddock.sentry.io/issues/7329867929/) — N+1 Query on `GET /users/{id}/interested-ical` (`EventsController@indexUserInterestedIcal`). Last seen 2026-06-28. No user feedback attached.

**Offending span (from Sentry):** `db - select * from \`entities\` where \`entities\`.\`id\` = ? limit 1`, repeated ~30× per request, under `http.route - App\Http\Controllers\EventsController@indexUserInterestedIcal`.

## Root cause

`indexUserInterestedIcal` builds the iCal feed from `User::followedEvents()`, which merges several `Event::…->get()` result sets and returns a plain (un-eager-loaded) collection. `ICalBuilder::buildCalendar()` then, for **every** event, reads:

- `$event->venue` — `belongsTo(Entity, 'venue_id')`
- `$event->promoter` and `$event->promoter->contacts` — `belongsTo(Entity, 'promoter_id')` + its contacts
- `$event->getPrimaryPhoto()` — falls back to a `photos` query when the relation isn't loaded

The two `Entity` belongs-to reads are the `entities where id = ?` N+1 that Sentry flagged; the promoter contacts and primary-photo reads add further per-event queries.

## Change

`app/Http/Controllers/EventsController.php` — after fetching the events, eager-load the relations the builder consumes before handing the collection to `ICalBuilder`:

```php
$events->loadMissing(['venue', 'promoter.contacts', 'photos']);
```

`getPrimaryPhoto()` already prefers the loaded `photos` relation (`relationLoaded('photos')`), so this also removes the per-event photo query. `loadMissing` is a no-op for relations already present, and the feed contents are unchanged — only the query count drops. Mirrors the eager-load pattern already used elsewhere (e.g. `EntitiesController::show`, `cardEventEagerLoad`).

## Scope
- One-line change plus comment; no schema, seeder, or frontend changes.
- Behavior-preserving: eager loading reduces query count without altering the rendered `.ics` output.

## How to test
1. As a user following some tags/entities/events, request `/users/{id}/interested-ical`.
2. With Telescope/Debugbar (or Sentry performance), confirm the repeated `select * from entities where id = ?` per event is gone and the `.ics` output matches the prior response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cm2kRtysx8imkju8PeCEQc