### PR TITLE
Fix: memory-exhaustion DoS from unbounded ?page pagination param [EVENTREPO-WB]

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -13,6 +13,7 @@ use App\Services\SessionStore\ListParameterSessionStore;
 use App\Services\SessionStore\ListParameterStore;
 use Illuminate\Session\Store;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\View;
@@ -23,12 +24,37 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 class AppServiceProvider extends ServiceProvider
 {
     /**
+     * Upper bound for the resolved pagination page number.
+     *
+     * When rendering pagination links Laravel builds a range() of page URLs;
+     * a crafted `?page=<huge>` (e.g. page=792390418) makes that range()
+     * allocate gigabytes and exhaust the request's memory limit before any
+     * output is produced (EVENTREPO-WB). Clamp the page to a value far beyond
+     * any real list depth. Mirrors the MAX_LIMIT page-size clamp in
+     * ListQueryParameters, which hardened the sibling `?limit=<huge>` vector.
+     */
+    public const MAX_PAGE = 100000;
+
+    /**
      * Bootstrap any application services.
      *
      * @return void
      */
     public function boot()
     {
+        // Clamp the resolved pagination page so a hostile ?page value can't
+        // blow up range()/URL generation. Replicates Laravel's default
+        // resolver (valid int >= 1, else 1) and adds the upper bound.
+        Paginator::currentPageResolver(function (string $pageName = 'page') {
+            $page = request()->input($pageName);
+
+            if (filter_var($page, FILTER_VALIDATE_INT) !== false && (int) $page >= 1) {
+                return min((int) $page, self::MAX_PAGE);
+            }
+
+            return 1;
+        });
+
         Auth::extend('session-1yr', function ($app, $name, array $config) {
             $guard = new RememberMeSessionGuard(
                 $name,

--- a/tests/Feature/ApiListPageCapTest.php
+++ b/tests/Feature/ApiListPageCapTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\UserStatus;
+use App\Providers\AppServiceProvider;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Ensures list endpoints cannot be coerced into an unbounded pagination page.
+ * A crafted ?page (e.g. page=792390418) otherwise makes Laravel build a
+ * range() of that many page URLs when rendering pagination links, allocating
+ * gigabytes and exhausting the request memory limit (EVENTREPO-WB). The global
+ * currentPageResolver clamps the page to AppServiceProvider::MAX_PAGE.
+ */
+class ApiListPageCapTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $this->actingAs($user, 'sanctum');
+    }
+
+    /** @test */
+    public function events_index_caps_an_oversized_page_and_does_not_error(): void
+    {
+        $response = $this->getJson('/api/events?page=792390418');
+
+        $response->assertStatus(200);
+        $this->assertSame(AppServiceProvider::MAX_PAGE, $response->json('current_page'));
+    }
+
+    /** @test */
+    public function events_index_honors_a_reasonable_page(): void
+    {
+        $response = $this->getJson('/api/events?page=2');
+
+        $response->assertStatus(200);
+        $this->assertSame(2, $response->json('current_page'));
+    }
+}


### PR DESCRIPTION
## Sentry issue

[EVENTREPO-WB](https://geoff-maddock.sentry.io/issues/7575254762/) — `Symfony\Component\ErrorHandler\Error\FatalError: Allowed memory size of 134217728 bytes exhausted (tried to allocate 17179869192 bytes)` on `GET /activity`. First/last seen through 2026-06-29 (post-dates the `?limit` clamp in #1937). No user feedback attached.

## The error

The captured event's query string was:

```
?sort=509608614&direction=desc&limit=960844393&page=792390418
```

- `limit=960844393` is already clamped to `MAX_LIMIT` (1000) by `ListQueryParameters::getLimit()` (added in #1937).
- `sort=509608614` fails `isValidSortField()` (must start with a letter/underscore) and falls back to the default sort — safe.
- **`page=792390418` is unclamped.**

When Laravel renders pagination links it builds a `range()` of page URLs (`AbstractPaginator::getUrlRange()` → `range($start, $end)`, the frame at `AbstractPaginator.php:157` in the stacktrace). Driven by the hostile page number, PHP tried to build a packed array of ~792,390,418 elements. PHP rounds the hashtable capacity up to the next power of two (2³⁰ = 1,073,741,824 buckets) at 16 bytes per slot → **2³⁴ = 17,179,869,184 bytes**, exactly matching the reported `tried to allocate 17179869192 bytes`. The request OOMs before producing output.

## Root cause

The `?limit` DoS vector was hardened in #1937, but the sibling `?page` vector was left unbounded. `->paginate()` resolves the current page from the request via the global `Paginator::currentPageResolver`, which by default accepts any positive integer — so a crafted `?page=<huge>` reaches the link builder and blows up memory. This affects every paginated list endpoint, not just `/activity`.

## Change

`app/Providers/AppServiceProvider.php` — register a global `Paginator::currentPageResolver` in `boot()` that replicates Laravel's default behavior (valid int ≥ 1, otherwise 1) and adds an upper clamp to `AppServiceProvider::MAX_PAGE` (100000):

```php
Paginator::currentPageResolver(function (string $pageName = 'page') {
    $page = request()->input($pageName);

    if (filter_var($page, FILTER_VALIDATE_INT) !== false && (int) $page >= 1) {
        return min((int) $page, self::MAX_PAGE);
    }

    return 1;
});
```

- **Centralized** — fixes all paginated endpoints at once, mirroring how the `MAX_LIMIT` clamp is centralized in `ListQueryParameters`.
- **Behavior-preserving for real traffic** — legitimate pages are always ≤ the true last page, which is bounded by row count / page size and far below 100000, so the clamp never activates in normal use. 100000 is also small enough that `range()`/URL generation stays trivial (≈100k ints) if it ever does.
- **Minimal** — one resolver registration plus a constant; no controller churn, no schema/seeder/frontend changes.

## Tests

Added `tests/Feature/ApiListPageCapTest.php`, mirroring the existing `ApiListLimitCapTest`:

- `events_index_caps_an_oversized_page_and_does_not_error` — `GET /api/events?page=792390418` returns 200 (not a 500/OOM) and `current_page` is clamped to `MAX_PAGE`.
- `events_index_honors_a_reasonable_page` — `GET /api/events?page=2` returns 200 with `current_page == 2`.

> ⚠️ **Note:** the automated test/lint suite could not be executed in this sandbox — `composer install` is blocked here (proxy could not authenticate against github.com for two dist packages), so vendor is unavailable for PHPUnit/PHPStan. Both changed files pass `php -l`. Please run `composer tests` in CI to confirm.

## How to test manually

1. Before this change: `GET /activity?page=792390418` (or any paginated list) → 500 with "Allowed memory size exhausted".
2. After: the same request returns normally (empty/last page), with the resolved page capped at 100000.
3. Normal pagination (`?page=2`, `?page=3`, …) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4y1jrX3Yc1msAtShCwMrJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4y1jrX3Yc1msAtShCwMrJ)_