### PR TITLE
Fix: 'start_at' order-clause crash on /users listing [EVENTREPO-WC]

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -123,7 +123,8 @@ class UsersController extends Controller
         $listEntityResultBuilder
             ->setFilter($this->filter)
             ->setQueryBuilder($baseQuery)
-            ->setDefaultSort($this->defaultSortCriteria);
+            ->setDefaultSort($this->defaultSortCriteria)
+            ->setAllowedSortFields(array_keys($this->getListControlOptions()['sortOptions']));
 
         // get the result set from the builder
         $listResultSet = $listEntityResultBuilder->listResultSetFactory();
@@ -186,7 +187,8 @@ class UsersController extends Controller
         $listEntityResultBuilder
             ->setFilter($this->filter)
             ->setQueryBuilder($baseQuery)
-            ->setDefaultSort(['users.name' => 'asc']);
+            ->setDefaultSort(['users.name' => 'asc'])
+            ->setAllowedSortFields(array_keys($this->getListControlOptions()['sortOptions']));
 
         // get the result set from the builder
         $listResultSet = $listEntityResultBuilder->listResultSetFactory();

--- a/app/Http/ResultBuilder/ListEntityResultBuilder.php
+++ b/app/Http/ResultBuilder/ListEntityResultBuilder.php
@@ -30,6 +30,8 @@ class ListEntityResultBuilder implements ListResultBuilderInterface
 
     private array $multiSort;
 
+    private array $allowedSortFields = [];
+
     private ?string $appliedSortField;
 
     private ?string $appliedSortDirection;
@@ -81,6 +83,22 @@ class ListEntityResultBuilder implements ListResultBuilderInterface
     public function setDefaultSort(array $defaultSort): ListEntityResultBuilder
     {
         $this->defaultSort = $defaultSort;
+
+        return $this;
+    }
+
+    /**
+     * Restrict which sort fields may reach orderBy(). A syntactically valid
+     * identifier (e.g. "start_at") can still be a column that doesn't exist on
+     * the current table, which crashes the query (EVENTREPO-WC). When a
+     * non-empty allowlist is set, any field outside it falls back to the
+     * default sort. Pass the keys of the controller's sortOptions.
+     *
+     * @param array<int, string> $allowedSortFields
+     */
+    public function setAllowedSortFields(array $allowedSortFields): ListEntityResultBuilder
+    {
+        $this->allowedSortFields = $allowedSortFields;
 
         return $this;
     }
@@ -193,8 +211,19 @@ class ListEntityResultBuilder implements ListResultBuilderInterface
      */
     private function isValidSortField(?string $field): bool
     {
-        return is_string($field)
-            && preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)?$/', $field) === 1;
+        if (!is_string($field)
+            || preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)?$/', $field) !== 1) {
+            return false;
+        }
+
+        // When an allowlist is configured, the field must be one of the columns
+        // the caller actually exposes for sorting; otherwise a valid-looking but
+        // non-existent column (e.g. a stale session sort) would reach orderBy().
+        if (!empty($this->allowedSortFields)) {
+            return in_array($field, $this->allowedSortFields, true);
+        }
+
+        return true;
     }
 
     public function setMultiSort(array $multiSort): void


### PR DESCRIPTION
## Sentry issue

[EVENTREPO-WC](https://geoff-maddock.sentry.io/issues/7583227664/) — `Illuminate\Database\QueryException: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'start_at' in 'order clause'`

- Route: `GET /users` (`UsersController::index`, `UsersController.php:135`)
- Still recurring (last seen 2026-06-30); ~3 events.

## The error

The users listing applies the sort field coming from the request/session straight to `orderBy()`. `ListEntityResultBuilder` already guards the sort, but the existing guard (`isValidSortField`) only checks that the value is a *syntactically valid SQL identifier*. `start_at` is a valid identifier — and a real column on `events`, but **not** on `users` — so it sails past the check and reaches the query:

```
select `users`.*, ( ... ) as `last_active` from `users` ... order by `start_at` ...
```

MySQL then rejects it with "Unknown column 'start_at' in 'order clause'", producing a 500. A stale sort persisted in the session (or a crafted `?sort=` param) is enough to trigger it.

## Root cause

Syntactic validation isn't sufficient — a well-formed identifier can still be a column that doesn't exist on the current table.

## What changed

- **`ListEntityResultBuilder`**: added an opt-in `setAllowedSortFields(array $fields)`. When a non-empty allowlist is set, `isValidSortField()` additionally requires the field to be one of the allowed columns; anything else falls back to the builder's default sort. When no allowlist is set the behavior is unchanged, so no other controller is affected.
- **`UsersController::index` and `::filter`**: pass the allowlist using the existing `getListControlOptions()['sortOptions']` keys (`users.name`, `user_statuses.name`, `users.created_at`, `last_active`) — the exact columns the UI already exposes for sorting. Unknown columns now degrade to the default sort (`users.created_at`) instead of throwing.

Minimal and additive; no migrations, no behavior change for lists that don't opt in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VjUWq4DJ8Qv3nZ3rEXiQKA)_