### PR TITLE
Fix: N+1 queries on user interested-ical feed [EVENTREPO-T6]

### DIFF
--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -3285,6 +3285,11 @@ class EventsController extends Controller
 
         $events = $user->followedEvents();
 
+        // Eager-load the relations ICalBuilder touches per event (venue, the
+        // promoter and its contacts, and photos for the primary image) so the
+        // feed doesn't fire a query per event (EVENTREPO-T6 N+1).
+        $events->load(['venue', 'promoter.contacts', 'photos']);
+
         // create a calendar object for the user
         $calendar = $iCalBuilder->buildCalendar('arcane-city-interested-ical.ics', $events);
 


### PR DESCRIPTION
## Sentry issue

[EVENTREPO-T6](https://geoff-maddock.sentry.io/issues/7329867929/) — N+1 Query

- Route: `GET /users/{id}/interested-ical` (`EventsController::indexUserInterestedIcal`)
- Still recurring (last seen 2026-06-28); ~13 events.

## The problem

The interested-ical endpoint builds an ICS calendar from `$user->followedEvents()`. `ICalBuilder::buildCalendar()` loops over the events and, for each one, reads:

- `$event->venue` (belongsTo)
- `$event->promoter` and `$event->promoter->contacts` (belongsTo → belongsToMany)
- the primary photo via `$event->getPrimaryPhoto()` (uses the `photos` relation)

`followedEvents()` returns a merged `Collection` with none of these relations preloaded, so each event triggers its own set of queries — the N+1 pattern Sentry flagged. This grows linearly with how many events a user follows.

## What changed

`app/Http/Controllers/EventsController.php` — eager-load the relations the builder touches on the collection before handing it to `buildCalendar`:

```php
$events->load(['venue', 'promoter.contacts', 'photos']);
```

This collapses the per-event lookups into a handful of batched queries. `getPrimaryPhoto()` already checks `relationLoaded('photos')` and uses the preloaded collection when present, so it benefits automatically. Purely additive — the ICS output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VjUWq4DJ8Qv3nZ3rEXiQKA)_