### PR TITLE
Fix: N+1 Query on photos listings [EVENTREPO-WD]

### DIFF
--- a/app/Http/Controllers/PhotosController.php
+++ b/app/Http/Controllers/PhotosController.php
@@ -121,7 +121,11 @@ class PhotosController extends Controller
         $query = $listResultSet->getList();
 
         // get the photos
+        // Eager-load each photo's events and their venue; the grid card (photos/cell-tw)
+        // reads $photo->events->first()->venue per row, which otherwise fires an N+1
+        // lookup on the entities table (the venue) for every photo (EVENTREPO-WD).
         $photos = $query
+            ->with('events.venue')
             ->paginate($listResultSet->getLimit());
 
         // saves the updated session
@@ -187,7 +191,11 @@ class PhotosController extends Controller
         $query = $listResultSet->getList();
 
         // get the photos
+        // Eager-load each photo's events and their venue; the grid card (photos/cell-tw)
+        // reads $photo->events->first()->venue per row, which otherwise fires an N+1
+        // lookup on the entities table (the venue) for every photo (EVENTREPO-WD).
         $photos = $query
+            ->with('events.venue')
             ->paginate($listResultSet->getLimit());
 
         // saves the updated session
@@ -247,7 +255,11 @@ class PhotosController extends Controller
         $query = $listResultSet->getList();
 
         // get the photos
+        // Eager-load each photo's events and their venue; the grid card (photos/cell-tw)
+        // reads $photo->events->first()->venue per row, which otherwise fires an N+1
+        // lookup on the entities table (the venue) for every photo (EVENTREPO-WD).
         $photos = $query
+            ->with('events.venue')
             ->paginate($listResultSet->getLimit());
 
         // saves the updated session


### PR DESCRIPTION
## Sentry issue

[EVENTREPO-WD](https://sentry.io/organizations/geoff-maddock/issues/7594349741/) — **N+1 Query** on `/photos/filter` (also affects `/photos` and `/photos/tag/{tag}`). Still firing in production (last seen 2026-07-06).

Repeating query flagged by Sentry:
```
select * from `entities` where `entities`.`id` = ? limit 1
```
Parent span: `view.render - photos.index-tw`.

No user feedback was attached to this issue.

## Root cause

The photo grid card `resources/views/photos/cell-tw.blade.php` renders, per photo:

```blade
@if ($event = $photo->events->first())
    ... /entities/{{ $event->venue->slug }} ... {{ $event->venue->name }} ...
```

`Event::venue()` is a `belongsTo(Entity)`, so `$event->venue` issues `select * from entities where id = ? limit 1`. The three photo-grid list actions in `PhotosController` — `index()`, `filter()`, and `indexTags()` — paginate the photos without eager-loading that relation chain, so the venue lookup fires once **per photo** rendered on the page.

## Change

Add `->with('events.venue')` to the paginated query in all three photo-grid list actions. The card only reads `$photo->events->first()` and that event's `venue` (name/slug), so eager-loading `events.venue` hydrates everything the grid needs in a fixed number of queries regardless of page size.

- `app/Http/Controllers/PhotosController.php` — `index()`, `filter()`, `indexTags()`

No migrations, model, or view changes. Minimal, behavior-preserving.

## Verification

- `php -l` clean; `Photo::events()` (`BelongsToMany`) and `Event::venue()` (`BelongsTo`) confirmed to exist, so the eager-load path is valid.
- Could not run PHPStan or the PHPUnit suite here — this sandbox has no `vendor/` install or MySQL database (the project's `composer tests` requires both). The change is a self-contained eager-load addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2nGP4Qj6wCxW5AKdpDtna)_