### PR TITLE
Fix: Unknown column 'event_types.name' in order clause on event tag/related listings [EVENTREPO-VE]

### DIFF
--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -2443,7 +2443,7 @@ class EventsController extends Controller
 
         $listEntityResultBuilder
             ->setFilter($this->filter)
-            ->setQueryBuilder(Event::query())
+            ->setQueryBuilder(Event::query()->leftJoin('event_types', 'events.event_type_id', '=', 'event_types.id')->select('events.*'))
             ->setDefaultSort(['events.start_at' => 'desc'])
             ->setParentFilter(['tag' => $slug]);
 
@@ -2506,7 +2506,7 @@ class EventsController extends Controller
 
         $listEntityResultBuilder
             ->setFilter($this->filter)
-            ->setQueryBuilder(Event::query())
+            ->setQueryBuilder(Event::query()->leftJoin('event_types', 'events.event_type_id', '=', 'event_types.id')->select('events.*'))
             ->setDefaultSort(['events.start_at' => 'desc'])
             ->setParentFilter(['related' => $related->slug]);
 
@@ -2568,7 +2568,7 @@ class EventsController extends Controller
 
         $listEntityResultBuilder
             ->setFilter($this->filter)
-            ->setQueryBuilder(Event::query())
+            ->setQueryBuilder(Event::query()->leftJoin('event_types', 'events.event_type_id', '=', 'event_types.id')->select('events.*'))
             ->setDefaultSort(['evebts.start_at' => 'desc']);
 
         // get the result set from the builder
@@ -2635,7 +2635,7 @@ class EventsController extends Controller
 
         $listEntityResultBuilder
             ->setFilter($this->filter)
-            ->setQueryBuilder(Event::query())
+            ->setQueryBuilder(Event::query()->leftJoin('event_types', 'events.event_type_id', '=', 'event_types.id')->select('events.*'))
             ->setDefaultSort(['events.start_at' => 'desc']);
 
         // get the result set from the builder
@@ -2771,7 +2771,7 @@ class EventsController extends Controller
 
         $listEntityResultBuilder
             ->setFilter($this->filter)
-            ->setQueryBuilder(Event::query())
+            ->setQueryBuilder(Event::query()->leftJoin('event_types', 'events.event_type_id', '=', 'event_types.id')->select('events.*'))
             ->setDefaultSort(['events.start_at' => 'desc'])
             ->setParentFilter(['series' => $slug]);
 


### PR DESCRIPTION
## Sentry issue

[EVENTREPO-VE](https://sentry.io/organizations/geoff-maddock/issues/7504236748/) — `Illuminate\Database\QueryException: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'event_types.name' in 'order clause'`. Still firing in production (last seen **2026-07-05**).

- Transaction: `/events/tag/{tag}` (observed: `/events/tag/rave`)
- Culprit: `EventsController::indexTags` → `ListEntityResultBuilder::addSort` → `orderBy`

No user feedback was attached to this issue.

## Root cause

`EventsController::indexTags()` builds its query with a bare `Event::query()`:

```php
->setQueryBuilder(Event::query())
```

Nearly every other event-list action in the controller (~20 of them, e.g. `index()`, `indexAll()`, `indexPast()`) instead uses:

```php
Event::query()
    ->leftJoin('event_types', 'events.event_type_id', '=', 'event_types.id')
    ->select('events.*')
```

so that `event_types.name` is a valid, sortable column.

All of these actions call `setBaseIndex('internal_event')`, so they **share one session sort key**. When a user sorts the main events index by `event_types.name` (valid there — that query joins `event_types`), the sort is persisted in the session and then replayed by the shared `ListEntityResultBuilder` against the bare-query actions. Those queries have no `event_types` join, so `orderBy('event_types.name', …)` reaches the database as an unknown column and throws SQLSTATE 42S22.

The existing sort hardening in `ListEntityResultBuilder` (`isValidSortField`, direction normalization) guards against *malformed* identifiers, but `event_types.name` is a *well-formed* identifier that simply isn't present unless the table is joined — so it slips through.

## Change

`app/Http/Controllers/EventsController.php` — add the standard `->leftJoin('event_types', …)->select('events.*')` to the five event-list actions that were still using a bare `Event::query()` and share the `internal_event` session sort key:

- `indexTags()` (the reported `/events/tag/{tag}` crash)
- the related, starting, index, and series event listings

This mirrors the established pattern used throughout the rest of the controller, so the shared session sort resolves against a real column. A `leftJoin` on `event_type_id` yields one row per event (no fan-out), and `select('events.*')` prevents the joined `event_types` columns from colliding during model hydration — exactly as the other actions already do.

## Scope / verification

- `php -l` clean.
- Behaviour-preserving: no change to filters, pagination, or the explicit `orderBy('events.start_at')` / `orderBy('events.name')` these actions already apply; only the base builder now joins `event_types` and selects `events.*`, matching sibling actions.
- Could not run PHPUnit/PHPStan here — this sandbox has no `vendor/` install or MySQL database (the project's `composer tests` requires both). The change is a self-contained, in-pattern query adjustment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9FntAMhibUwyVRzDaM2SB)_