### PR TITLE
Fix: add missing CategoriesController::indexAll for categories/all route [EVENTREPO-VX]

### DIFF
--- a/app/Http/Controllers/CategoriesController.php
+++ b/app/Http/Controllers/CategoriesController.php
@@ -126,6 +126,63 @@ class CategoriesController extends Controller
     }
 
     /**
+     * Display a listing of all categories.
+     *
+     * Backs the `categories/all` route, mirroring index() (EVENTREPO-VX: the
+     * route referenced a non-existent indexAll method).
+     */
+    public function indexAll(
+        Request $request,
+        ListParameterSessionStore $listParamSessionStore,
+        ListEntityResultBuilder $listEntityResultBuilder
+    ): string {
+        // initialized listParamSessionStore with baseindex key
+        $listParamSessionStore->setBaseIndex('internal_category');
+        $listParamSessionStore->setKeyPrefix('internal_category_index');
+
+        // set the index tab in the session
+        $listParamSessionStore->setIndexTab(action([CategoriesController::class, 'index']));
+
+        // create the base query including any required joins; needs select to make sure only event entities are returned
+        $baseQuery = ThreadCategory::query()->select('thread_categories.*');
+
+        $listEntityResultBuilder
+            ->setFilter($this->filter)
+            ->setQueryBuilder($baseQuery)
+            ->setDefaultLimit($this->defaultLimit)
+            ->setDefaultSort($this->defaultSortCriteria);
+
+        // get the result set from the builder
+        $listResultSet = $listEntityResultBuilder->listResultSetFactory();
+
+        // get the query builder
+        $query = $listResultSet->getList();
+
+        // query and paginate the categories
+        $categories = $query->paginate($listResultSet->getLimit());
+
+        // saves the updated session
+        $listParamSessionStore->save();
+
+        $this->hasFilter = $listResultSet->getFilters() != $listResultSet->getDefaultFilters() || $listResultSet->getIsEmptyFilter();
+
+        return view('categories.index-tw')
+            ->with(array_merge(
+                [
+                    'limit' => $listResultSet->getLimit(),
+                    'sort' => $listResultSet->getSort(),
+                    'direction' => $listResultSet->getSortDirection(),
+                    'hasFilter' => $this->hasFilter,
+                    'filters' => $listResultSet->getFilters()
+                ],
+                $this->getFilterOptions(),
+                $this->getListControlOptions()
+            ))
+            ->with(compact('categories'))
+            ->render();
+    }
+
+    /**
      * Display a listing of the resource.
      */
     public function filter(


### PR DESCRIPTION
## Sentry issue

[EVENTREPO-VX](https://sentry.io/organizations/geoff-maddock/issues/7545969786/) — `BadMethodCallException: Method App\Http\Controllers\CategoriesController::indexAll does not exist.` (last seen 2026-06-19).

- Transaction: `/categories/all`

No user feedback was attached to this issue.

## Root cause

`routes/web.php:457` registers:

```php
Route::get('categories/all', 'CategoriesController@indexAll');
```

but `CategoriesController` never defined an `indexAll` method (it has `index`, `filter`, `create`, `store`, …). Every request to `/categories/all` therefore resolved the route successfully and then threw `BadMethodCallException` when Laravel tried to invoke the missing action.

Every sibling `*/all` route points at an `indexAll` that **does** exist — `ForumsController@indexAll`, `ThreadsController@indexAll`, `PostsController@indexAll`, etc. `CategoriesController` was simply missing its counterpart.

## Change

`app/Http/Controllers/CategoriesController.php` — add an `indexAll` method that mirrors the controller's existing, working `index()` action (same `ThreadCategory` base query, session keys, default sort/limit, filter/control options, and `categories.index-tw` view). This makes `/categories/all` render the category listing like the other `*/all` routes rather than 500.

## Scope / verification

- `php -l` clean.
- The method body is a copy of the already-working `index()` action, so it reuses established, exercised code paths — no new query or view logic.
- Could not run PHPUnit/PHPStan here — this sandbox has no `vendor/` install or MySQL database (the project's `composer tests` requires both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9FntAMhibUwyVRzDaM2SB)_