### PR TITLE
Fix: prevent event slugs from starting with a digit

### DIFF
--- a/app/Console/Commands/FixNumericEventSlugs.php
+++ b/app/Console/Commands/FixNumericEventSlugs.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Event;
+use Illuminate\Console\Command;
+
+class FixNumericEventSlugs extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'events:fix-numeric-slugs
+                            {--dry-run : Show what would be changed without saving}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Prepend a dash to event slugs that start with a digit so routes resolve by slug instead of id';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle(): int
+    {
+        $dryRun = $this->option('dry-run');
+
+        $this->info('Fixing event slugs that start with a digit...');
+
+        if ($dryRun) {
+            $this->warn('DRY RUN MODE - No changes will be made');
+        }
+
+        $events = Event::whereRaw("slug REGEXP '^[0-9]'")->orderBy('id')->get();
+
+        if ($events->isEmpty()) {
+            $this->info('No event slugs start with a digit.');
+
+            return Command::SUCCESS;
+        }
+
+        $this->info("Found {$events->count()} event(s) with a digit-leading slug.");
+
+        $fixedCount = 0;
+        $collisionCount = 0;
+        $skippedCount = 0;
+
+        foreach ($events as $event) {
+            $newSlug = '-'.$event->slug;
+
+            // no unique index on events.slug, so guard against collisions here
+            if (Event::where('slug', $newSlug)->where('id', '!=', $event->id)->exists()) {
+                $newSlug = '-'.$event->slug.'-'.$event->id;
+                if (Event::where('slug', $newSlug)->where('id', '!=', $event->id)->exists()) {
+                    $skippedCount++;
+                    $this->warn("  ⊘ Event #{$event->id}: '{$event->slug}' - both '-{$event->slug}' and '{$newSlug}' already exist - skipping");
+                    continue;
+                }
+                $collisionCount++;
+                $this->warn("  ! Event #{$event->id}: '-{$event->slug}' already taken, using '{$newSlug}'");
+            } else {
+                $fixedCount++;
+            }
+
+            if ($dryRun) {
+                $this->line("  Would rename event #{$event->id}: '{$event->slug}' -> '{$newSlug}'");
+                continue;
+            }
+
+            $event->slug = $newSlug;
+            $event->save();
+            $this->info("  ✓ Event #{$event->id}: '{$newSlug}'");
+        }
+
+        $this->newLine();
+        $this->info('Summary:');
+        $this->info("  Fixed: {$fixedCount}");
+        $this->info("  Renamed with id suffix (collision): {$collisionCount}");
+        $this->info("  Skipped: {$skippedCount}");
+
+        if ($dryRun) {
+            $this->newLine();
+            $this->warn('DRY RUN MODE - Run without --dry-run to apply changes');
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Http/Requests/EventPatchRequest.php
+++ b/app/Http/Requests/EventPatchRequest.php
@@ -12,6 +12,19 @@ class EventPatchRequest extends Request
     }
 
     /**
+     * Prepend a dash to digit-leading slugs before validation so the
+     * unique rule checks the value that will actually be stored.
+     */
+    protected function prepareForValidation(): void
+    {
+        $slug = $this->input('slug');
+
+        if (is_string($slug) && '' !== $slug && ctype_digit($slug[0])) {
+            $this->merge(['slug' => '-'.$slug]);
+        }
+    }
+
+    /**
      * PATCH semantics: every rule is `sometimes`, so only fields present in
      * the request body are validated. Constraints themselves match EventRequest.
      */

--- a/app/Http/Requests/EventRequest.php
+++ b/app/Http/Requests/EventRequest.php
@@ -18,6 +18,19 @@ class EventRequest extends Request
     }
 
     /**
+     * Prepend a dash to digit-leading slugs before validation so the
+     * unique rule checks the value that will actually be stored.
+     */
+    protected function prepareForValidation(): void
+    {
+        $slug = $this->input('slug');
+
+        if (is_string($slug) && '' !== $slug && ctype_digit($slug[0])) {
+            $this->merge(['slug' => '-'.$slug]);
+        }
+    }
+
+    /**
      * Get the validation rules that apply to the request.
      *
      * @return array

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -180,7 +180,9 @@ class Event extends Model
 
     public function resolveRouteBinding($value, $field = null)
     {
-        return $this->where('slug', $value)->orWhere('id', $value)->firstOrFail();
+        return is_numeric($value)
+            ? $this->where('id', $value)->firstOrFail()
+            : $this->where('slug', $value)->firstOrFail();
     }
 
 
@@ -873,10 +875,15 @@ class Event extends Model
     {
         // grab the title and slugify it
         if ('' === $value) {
-            $this->attributes['slug'] = Str::slug($this->name);
-        } else {
-            $this->attributes['slug'] = $value;
+            $value = Str::slug($this->name);
         }
+
+        // slugs starting with a digit are ambiguous with id-based lookups
+        if (is_string($value) && '' !== $value && ctype_digit($value[0])) {
+            $value = '-'.$value;
+        }
+
+        $this->attributes['slug'] = $value;
     }
 
     public function getGoogleCalendarLink(): ?string

--- a/tests/Feature/ApiEventsCrudTest.php
+++ b/tests/Feature/ApiEventsCrudTest.php
@@ -55,6 +55,18 @@ class ApiEventsCrudTest extends TestCase
         $this->assertSame($this->user->id, $event->created_by);
     }
 
+    public function test_store_prepends_dash_to_digit_leading_slug(): void
+    {
+        $response = $this->postJson('/api/events', $this->validPayload([
+            'name' => 'ZZ-Numeric-Slug-Event',
+            'slug' => '1984-zz-numeric-slug',
+        ]));
+
+        $response->assertOk();
+        $this->assertDatabaseHas('events', ['slug' => '-1984-zz-numeric-slug']);
+        $this->assertDatabaseMissing('events', ['slug' => '1984-zz-numeric-slug']);
+    }
+
     public function test_store_rejects_invalid_payload(): void
     {
         $response = $this->postJson('/api/events', ['name' => 'x']);
@@ -108,6 +120,21 @@ class ApiEventsCrudTest extends TestCase
 
         $response->assertOk();
         $this->assertSame('ZZ-Patched-Only-Name', $event->fresh()->name);
+    }
+
+    public function test_patch_prepends_dash_to_digit_leading_slug(): void
+    {
+        $event = Event::factory()->create([
+            'created_by' => $this->user->id,
+            'slug' => 'zz-patch-slug-event-'.uniqid(),
+        ]);
+
+        $response = $this->patchJson('/api/events/'.$event->slug, [
+            'slug' => '1984-zz-patched-slug',
+        ]);
+
+        $response->assertOk();
+        $this->assertSame('-1984-zz-patched-slug', $event->fresh()->slug);
     }
 
     public function test_destroy_deletes_event_for_creator(): void

--- a/tests/Feature/Console/FixNumericEventSlugsCommandTest.php
+++ b/tests/Feature/Console/FixNumericEventSlugsCommandTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use App\Models\Event;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class FixNumericEventSlugsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    /**
+     * The slug mutator now blocks digit-leading slugs on Eloquent writes,
+     * so legacy rows have to be seeded with a raw update.
+     */
+    private function eventWithRawSlug(string $slug): Event
+    {
+        $event = Event::factory()->create();
+        DB::table('events')->where('id', $event->id)->update(['slug' => $slug]);
+
+        return $event->fresh();
+    }
+
+    public function test_digit_leading_slug_gets_dash_prepended(): void
+    {
+        $event = $this->eventWithRawSlug('123-zz-legacy');
+
+        $this->artisan('events:fix-numeric-slugs')->assertExitCode(0);
+
+        $this->assertSame('-123-zz-legacy', $event->fresh()->slug);
+    }
+
+    public function test_fully_numeric_slug_gets_dash_prepended(): void
+    {
+        $event = $this->eventWithRawSlug('987654321');
+
+        $this->artisan('events:fix-numeric-slugs')->assertExitCode(0);
+
+        $this->assertSame('-987654321', $event->fresh()->slug);
+    }
+
+    public function test_dry_run_does_not_change_anything(): void
+    {
+        $event = $this->eventWithRawSlug('123-zz-legacy');
+
+        $this->artisan('events:fix-numeric-slugs', ['--dry-run' => true])->assertExitCode(0);
+
+        $this->assertSame('123-zz-legacy', $event->fresh()->slug);
+    }
+
+    public function test_collision_falls_back_to_id_suffixed_slug(): void
+    {
+        Event::factory()->create(['slug' => '-123-zz-legacy']);
+        $event = $this->eventWithRawSlug('123-zz-legacy');
+
+        $this->artisan('events:fix-numeric-slugs')->assertExitCode(0);
+
+        $this->assertSame('-123-zz-legacy-'.$event->id, $event->fresh()->slug);
+    }
+
+    public function test_clean_slugs_are_untouched(): void
+    {
+        $event = Event::factory()->create(['slug' => 'zz-clean-slug-123']);
+
+        $this->artisan('events:fix-numeric-slugs')->assertExitCode(0);
+
+        $this->assertSame('zz-clean-slug-123', $event->fresh()->slug);
+    }
+}

--- a/tests/Feature/EventsTest.php
+++ b/tests/Feature/EventsTest.php
@@ -7,6 +7,7 @@ use App\Models\Event;
 use App\Models\Tag;
 use App\Models\User;
 use App\Models\UserStatus;
+use App\Models\Visibility;
 use App\Models\Events;
 use Carbon\Carbon;
 use Laravel\Dusk\Dusk;
@@ -64,6 +65,58 @@ class EventsTest extends TestCase
 
         $response->assertRedirect();
         $this->assertSame($user->id, (int) $event->fresh()->created_by);
+    }
+
+    public function testShowResolvesEventBySlugAndById()
+    {
+        $event = Event::factory()->create([
+            'slug' => 'zz-binding-test',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+
+        $this->get('/events/'.$event->slug)->assertOk();
+        $this->get('/events/'.$event->id)->assertOk();
+    }
+
+    public function testShowReturns404ForIdPrefixedNonexistentSlug()
+    {
+        $this->withExceptionHandling();
+        $event = Event::factory()->create(['visibility_id' => Visibility::VISIBILITY_PUBLIC]);
+
+        // The old orWhere('id', ...) binding let MySQL cast '<id>-no-such-slug'
+        // to the id and wrongly serve that event (issue #1964).
+        $this->get('/events/'.$event->id.'-no-such-slug')->assertNotFound();
+    }
+
+    public function testStorePrependsDashToDigitLeadingSlug()
+    {
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        $this->actingAs($user)->post('/events', [
+            'name' => '1984 Test Party',
+            'slug' => '1984-test-party',
+            'start_at' => '2026-08-01 20:00:00',
+            'event_type_id' => 1,
+            'visibility_id' => 1,
+        ])->assertRedirect();
+
+        $this->assertDatabaseHas('events', ['slug' => '-1984-test-party']);
+        $this->assertDatabaseMissing('events', ['slug' => '1984-test-party']);
+    }
+
+    public function testStoreRejectsDigitLeadingSlugCollidingWithDashPrefixedSlug()
+    {
+        $this->withExceptionHandling();
+        Event::factory()->create(['slug' => '-1984-test-party']);
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        $this->actingAs($user)->post('/events', [
+            'name' => '1984 Test Party',
+            'slug' => '1984-test-party',
+            'start_at' => '2026-08-01 20:00:00',
+            'event_type_id' => 1,
+            'visibility_id' => 1,
+        ])->assertSessionHasErrors('slug');
     }
 
     /**

--- a/tests/Unit/Models/EventModelTest.php
+++ b/tests/Unit/Models/EventModelTest.php
@@ -248,4 +248,40 @@ class EventModelTest extends TestCase
 
         $this->assertNull($event->getEventResponse($user));
     }
+
+    public function test_slug_starting_with_digit_gets_dash_prepended(): void
+    {
+        $event = Event::factory()->create(['slug' => '123-zz-numeric-slug']);
+
+        $this->assertSame('-123-zz-numeric-slug', $event->slug);
+    }
+
+    public function test_fully_numeric_slug_gets_dash_prepended(): void
+    {
+        $event = Event::factory()->create(['slug' => '987654321']);
+
+        $this->assertSame('-987654321', $event->slug);
+    }
+
+    public function test_slug_generated_from_digit_leading_name_gets_dash_prepended(): void
+    {
+        $event = Event::factory()->make(['name' => '1984 Zz Party', 'slug' => 'placeholder']);
+        $event->slug = '';
+
+        $this->assertSame('-1984-zz-party', $event->slug);
+    }
+
+    public function test_slug_not_starting_with_digit_is_unchanged(): void
+    {
+        $event = Event::factory()->create(['slug' => 'zz-foo-123']);
+
+        $this->assertSame('zz-foo-123', $event->slug);
+    }
+
+    public function test_slug_already_dash_prefixed_is_unchanged(): void
+    {
+        $event = Event::factory()->create(['slug' => '-123-zz-already-prefixed']);
+
+        $this->assertSame('-123-zz-already-prefixed', $event->slug);
+    }
 }


### PR DESCRIPTION
Fixes #1964

## Problem

Digit-leading event slugs broke event pages: `Event::resolveRouteBinding` used `where('slug', $value)->orWhere('id', $value)`, and MySQL loosely casts a string like `123-foo` to `123` against the int `id` column — so the route could resolve to the wrong event by id instead of by slug.

## Changes

- **`Event::setSlugAttribute`** — prepends `-` to any slug that starts with a digit, including slugs auto-generated from the event name (`"1984 Party"` → `-1984-party`). This is the backstop for every Eloquent write path (web store/update, API store/update/patch, commands, factories).
- **`Event::resolveRouteBinding`** — now mirrors the existing `Series` pattern: numeric values resolve by id, everything else strictly by slug. `/events/{id}-no-such-slug` now 404s instead of serving event `{id}`.
- **`EventRequest` / `EventPatchRequest`** — `prepareForValidation()` normalizes digit-leading slug input before validation so `Rule::unique` checks the value that will actually be stored (`events.slug` has no unique index, so this closes a silent-duplicate window).
- **New `events:fix-numeric-slugs` command** — renames existing digit-leading slugs (`--dry-run` supported). On collision with an existing dash-prefixed slug it falls back to `-slug-{id}`; if that is also taken it skips with a warning. Prints fixed/collision/skipped summary.

## Tests

- Mutator unit cases (digit-leading, fully numeric, generated-from-name, idempotence) in `EventModelTest`
- Route-binding regression + web store normalization + uniqueness-collision tests in `EventsTest`
- API create/PATCH normalization in `ApiEventsCrudTest`
- New `FixNumericEventSlugsCommandTest` (fix, fully-numeric, dry-run, collision, untouched)

`composer phpstan` clean; all targeted suites green.

## Deploy notes

- Run `php artisan events:fix-numeric-slugs` when deploying (after the code is live) — with the new binding, a purely numeric slug is unreachable until renamed.
- Renamed slugs change URLs: previously shared digit-leading links will 404 (accepted), so regenerate the sitemap afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)