### PR TITLE
Fix: N+1 Query on entity show related-events card [EVENTREPO-TC]

### DIFF
--- a/app/Http/Controllers/EntitiesController.php
+++ b/app/Http/Controllers/EntitiesController.php
@@ -900,6 +900,7 @@ class EntitiesController extends Controller
                 'eventStatus',
                 'visibility',
                 'eventType',
+                'tags',
             ])
             ->where('start_at', '>=', $filterStartAt)
             ->orderBy('start_at', 'asc');


### PR DESCRIPTION
## Sentry issue

[EVENTREPO-TC](https://sentry.io/organizations/geoff-maddock/issues/7394381953/) — **N+1 Query** on `GET /entities/{entity}` (e.g. `/entities/zoanah`). 732 events, 2nd-most-frequent unresolved issue.

No user feedback attached.

## Error summary

The entity show page renders a grid of related upcoming events. Each event card (`resources/views/events/card-tw.blade.php`) reads `$event->tags` (lines 167-173) to render the tag pills. The `$relatedEvents` query in `EntitiesController::show` eager-loaded `photos`, `eventType`, `venue.*`, `entities.*`, `eventStatus`, and `visibility` — but **not** `tags`. That left one `select … from tags …` query per related event (up to 16), which Sentry flagged as an N+1 span.

The captured N+1 trace showed 16× `photos`, 16× `event_types`, and 16× `tags` queries. The `photos`/`eventType` legs were addressed by PR #1943, but that fix omitted `tags`, so the tags leg remained.

## Root cause

`tags` was missing from the `$relatedEvents` eager-load list. The sibling `$pastEvents` query in the same method already eager-loads `tags`; the two had drifted out of sync.

## What changed

`app/Http/Controllers/EntitiesController.php` — added `'tags'` to the `$relatedEvents` `->with([...])` array (one line). This matches the relations the card actually consumes and aligns `relatedEvents` with the existing `pastEvents` load. `cardFingerprint()` uses `relationLoaded()` and does not trigger its own query, so no other change is needed.

## Testing

Dependencies (`vendor/`) are not installed in the triage environment, so the PHPUnit/PHPStan suites could not be run here. The change is a one-line addition of an already-defined `Event::tags()` relation to an eager-load array (same pattern as the adjacent `pastEvents` load and the merged N+1 fixes); `php -l` passes. Recommend running `composer tests` in CI before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEtfyaqPdrDuJBzyqAzLnE)_