### PR TITLE
Fix: N+1 Query [EVENTREPO-WE]

### DIFF
--- a/app/Http/Controllers/ThreadsController.php
+++ b/app/Http/Controllers/ThreadsController.php
@@ -188,7 +188,7 @@ class ThreadsController extends Controller
 
         /* @phpstan-ignore-next-line */
         $threads = $query->visible($this->user)
-            ->with('visibility', 'entities', 'tags', 'event', 'series', 'user', 'lastPost.user')
+            ->with('visibility', 'entities', 'tags', 'event', 'series', 'user.photos', 'lastPost.user')
             ->withCount('posts')
             ->paginate($listResultSet->getLimit());
 
@@ -254,7 +254,7 @@ class ThreadsController extends Controller
 
         /* @phpstan-ignore-next-line */
         $threads = $query->visible($this->user)
-            ->with('visibility', 'entities', 'tags', 'event', 'series', 'user', 'lastPost.user')
+            ->with('visibility', 'entities', 'tags', 'event', 'series', 'user.photos', 'lastPost.user')
             ->withCount('posts')
             ->paginate($listResultSet->getLimit());
 
@@ -357,7 +357,7 @@ class ThreadsController extends Controller
 
         /* @phpstan-ignore-next-line */
         $threads = $query->visible($this->user)
-            ->with('visibility', 'entities', 'tags', 'event', 'series', 'user', 'lastPost.user')
+            ->with('visibility', 'entities', 'tags', 'event', 'series', 'user.photos', 'lastPost.user')
             ->withCount('posts')
             ->paginate($listResultSet->getLimit());
 
@@ -423,7 +423,7 @@ class ThreadsController extends Controller
 
         /* @phpstan-ignore-next-line */
         $threads = $query->visible($this->user)
-            ->with('visibility', 'entities', 'tags', 'event', 'series', 'user', 'lastPost.user')
+            ->with('visibility', 'entities', 'tags', 'event', 'series', 'user.photos', 'lastPost.user')
             ->withCount('posts')
             ->paginate($listResultSet->getLimit());
 
@@ -483,7 +483,7 @@ class ThreadsController extends Controller
 
         /* @phpstan-ignore-next-line */
         $threads = $query->visible($this->user)
-            ->with('visibility', 'entities', 'tags', 'event', 'series', 'user', 'lastPost.user')
+            ->with('visibility', 'entities', 'tags', 'event', 'series', 'user.photos', 'lastPost.user')
             ->withCount('posts')
             ->paginate($listResultSet->getLimit());
 
@@ -545,7 +545,7 @@ class ThreadsController extends Controller
 
         /* @phpstan-ignore-next-line */
         $threads = $query->visible($this->user)
-            ->with('visibility', 'entities', 'tags', 'event', 'series', 'user', 'lastPost.user')
+            ->with('visibility', 'entities', 'tags', 'event', 'series', 'user.photos', 'lastPost.user')
             ->withCount('posts')
             ->paginate($listResultSet->getLimit());
 
@@ -607,7 +607,7 @@ class ThreadsController extends Controller
 
         /* @phpstan-ignore-next-line */
         $threads = $query->visible($this->user)
-            ->with('visibility', 'entities', 'tags', 'event', 'series', 'user', 'lastPost.user')
+            ->with('visibility', 'entities', 'tags', 'event', 'series', 'user.photos', 'lastPost.user')
             ->withCount('posts')
             ->paginate($listResultSet->getLimit());
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -229,10 +229,13 @@ class User extends Authenticatable implements AuthorizableContract, CanResetPass
      **/
     public function getPrimaryPhoto(): ?Photo
     {
-        // get a list of events that start on the passed date
-        $primary = $this->photos()->where('photos.is_primary', '=', '1')->first();
+        // Use the eager-loaded photos when available to avoid an N+1 query when
+        // rendering many users' avatars in a list (EVENTREPO-WE).
+        if ($this->relationLoaded('photos')) {
+            return $this->photos->firstWhere('is_primary', 1);
+        }
 
-        return $primary;
+        return $this->photos()->where('photos.is_primary', '=', '1')->first();
     }
 
     /**


### PR DESCRIPTION
## Sentry issue
[EVENTREPO-WE](https://sentry.io/organizations/geoff-maddock/issues/7594600408/) — N+1 Query on `/threads/all` (also affects the other thread-listing endpoints).

## Error summary
Thread listing pages render each thread author's avatar via `resources/views/users/avatar.blade.php`, which calls `User::getPrimaryPhoto()`. That method issued a fresh `photos` query on every call, so a page of N threads fired N extra `photo_user` lookups. Sentry's performance monitor flagged the offending span:

```
db - select `photos`.* ... from `photos` inner join `photo_user` ...
```

## Root cause
Unlike `Event`, `Entity`, `Series`, and `Blog` — all of whose `getPrimaryPhoto()` already short-circuit to an eager-loaded `photos` relation — `User::getPrimaryPhoto()` always ran `$this->photos()->where('photos.is_primary', 1)->first()`, a per-row query. The thread-list controllers also eager-loaded only `user` (not `user.photos`), so there was nothing loaded to read from.

## What changed
- **`app/Models/User.php`** — `getPrimaryPhoto()` now returns from the eager-loaded `photos` collection when it's loaded (`relationLoaded('photos')` → `firstWhere('is_primary', 1)`), falling back to the original query otherwise. This mirrors the existing guard in `Event`/`Entity`/`Series`/`Blog`.
- **`app/Http/Controllers/ThreadsController.php`** — eager-load `user.photos` (was `user`) on the thread-list queries so the guarded lookup resolves from memory. Applied uniformly to the thread-listing methods since they share the identical avatar render.

## Scope / notes
- Minimal, additive change — no schema, migration, or view changes.
- The `getPrimaryPhoto()` behavior is unchanged for un-eager-loaded callers (same fallback query).
- Verification: `php -l` passes on both files. The full `composer tests` pipeline (PHPUnit + PHPStan) requires `vendor/` and a MySQL database, neither of which is available in this ephemeral triage environment, so it was not run here — CI will exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J454HthHup2QZvayoez9eg)_