### PR TITLE
Fix: N+1 Query [EVENTREPO-WF]

### DIFF
--- a/app/Http/Controllers/TagsController.php
+++ b/app/Http/Controllers/TagsController.php
@@ -285,7 +285,7 @@ class TagsController extends Controller
 
         // get limited entities linked to the tag (8 for preview)
         $entities = Entity::getByTag($slug)
-            ->with('tags', 'events','entityType','locations','entityStatus','user')
+            ->with('tags', 'events','entityType','locations','entityStatus','user','photos')
             ->where(function ($query) {
                 /* @phpstan-ignore-next-line */
                 $query->active();


### PR DESCRIPTION
## Sentry issue
[EVENTREPO-WF](https://sentry.io/organizations/geoff-maddock/issues/7596106486/) — N+1 Query on `/tags/{tag}`.

## Error summary
The tag show page lists up to 8 entities linked to the tag, and each entity card resolves its avatar through `Entity::getPrimaryPhoto()`. The entities query didn't eager-load `photos`, so every entity issued its own `entity_photo` lookup. Sentry's performance monitor flagged the offending span:

```
db - select `photos`.* ... from `photos` inner join `entity_photo` ...
```

## Root cause
`Entity::getPrimaryPhoto()` already prefers an eager-loaded `photos` relation when one is present, but `TagsController::show()` loaded the tagged entities with `->with('tags','events','entityType','locations','entityStatus','user')` — no `photos` — so each card fell back to a per-entity query.

## What changed
- **`app/Http/Controllers/TagsController.php`** — add `photos` to the eager-load list on the tagged-entities query so `getPrimaryPhoto()` resolves from memory instead of per row.

## Scope / notes
- One-word, additive change — no schema, migration, or view changes.
- Verification: `php -l` passes. The full `composer tests` pipeline (PHPUnit + PHPStan) requires `vendor/` and a MySQL database, neither of which is available in this ephemeral triage environment, so it was not run here — CI will exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J454HthHup2QZvayoez9eg)_