### PR TITLE
Fix: Preserve underlying cause on Instagram post failures [EVENTREPO-VB]

### DIFF
--- a/app/Services/Integrations/InstagramEventPoster.php
+++ b/app/Services/Integrations/InstagramEventPoster.php
@@ -36,6 +36,27 @@ class InstagramEventPoster
     }
 
     /**
+     * Wrap a thrown SDK/HTTP exception from an upload/create call.
+     *
+     * These call-sites previously threw a hardcoded "Please try again." message
+     * and logged the real cause only at info level, so every distinct Instagram
+     * failure (rate limit, rejected image, expired token, …) collapsed into one
+     * opaque Sentry issue (EVENTREPO-VB). Surfacing the underlying message and
+     * chaining the original exception lets Sentry group by actual cause and
+     * preserves the full stack trace for triage.
+     */
+    private function uploadFailure(string $stage, Exception $e): RuntimeException
+    {
+        Log::error('Instagram '.$stage.' failed: '.$e->getMessage());
+
+        return new RuntimeException(
+            'There was an error posting to Instagram during '.$stage.'. '.$e->getMessage(),
+            0,
+            $e
+        );
+    }
+
+    /**
      * Post a single event photo to the Instagram feed.
      */
     public function postSingle(Event $event, ?int $userId): int
@@ -48,8 +69,7 @@ class InstagramEventPoster
         try {
             $igContainerId = $this->instagram->uploadPhoto($imageUrl, $caption);
         } catch (Exception $e) {
-            Log::info('Instagram single post upload error: ' . $e->getMessage());
-            throw new RuntimeException('There was an error posting to Instagram. Please try again.');
+            throw $this->uploadFailure('single photo upload', $e);
         }
 
         if ($this->instagram->checkStatus($igContainerId) === false) {
@@ -81,8 +101,7 @@ class InstagramEventPoster
         try {
             $igContainerIds[] = $this->instagram->uploadCarouselPhoto($imageUrl);
         } catch (Exception $e) {
-            Log::info('Carousel photo error: ' . $e->getMessage());
-            throw new RuntimeException('There was an error posting to Instagram. Please try again.');
+            throw $this->uploadFailure('carousel photo upload', $e);
         }
 
         // Additional photos directly attached to the event.
@@ -95,8 +114,7 @@ class InstagramEventPoster
             try {
                 $igContainerIds[] = $this->instagram->uploadCarouselPhoto($otherUrl);
             } catch (Exception $e) {
-                Log::info('Carousel photo error: ' . $e->getMessage());
-                throw new RuntimeException('There was an error posting to Instagram. Please try again.');
+                throw $this->uploadFailure('carousel photo upload', $e);
             }
         }
 
@@ -127,8 +145,7 @@ class InstagramEventPoster
         try {
             $igCarouselId = $this->instagram->createCarousel($igContainerIds, $caption);
         } catch (Exception $e) {
-            Log::info('Error creating carousel: ' . $e->getMessage());
-            throw new RuntimeException('There was an error posting carousel to Instagram. Please try again.');
+            throw $this->uploadFailure('carousel creation', $e);
         }
 
         if ($this->instagram->checkStatus($igCarouselId) === false) {
@@ -159,8 +176,7 @@ class InstagramEventPoster
         try {
             $igContainerId = $this->instagram->uploadStoryPhoto($imageUrl, $caption, $eventUrl);
         } catch (Exception $e) {
-            Log::info('Story photo upload error: ' . $e->getMessage());
-            throw new RuntimeException('There was an error posting to Instagram. Please try again.');
+            throw $this->uploadFailure('story photo upload', $e);
         }
 
         if ($this->instagram->checkStatus($igContainerId) === false) {

--- a/tests/Feature/QueuedInstagramPostTest.php
+++ b/tests/Feature/QueuedInstagramPostTest.php
@@ -193,6 +193,38 @@ class QueuedInstagramPostTest extends TestCase
         ]);
     }
 
+    public function test_carousel_upload_failure_preserves_underlying_cause(): void
+    {
+        $user = User::factory()->create(['user_status_id' => 1]);
+        $event = $this->eventWithPhoto($user);
+
+        Storage::shouldReceive('disk')->with('external')->andReturnSelf()->byDefault();
+        Storage::shouldReceive('url')->andReturn('http://example.com/test.jpg')->byDefault();
+
+        $instagram = Mockery::mock(Instagram::class);
+        $instagram->shouldReceive('getIgUserId')->andReturn(123);
+        $instagram->shouldReceive('getPageAccessToken')->andReturn('token');
+        $instagram->shouldReceive('uploadCarouselPhoto')
+            ->andThrow(new RuntimeException('IG API 400: media aspect ratio not supported'));
+
+        $poster = new InstagramEventPoster($instagram);
+
+        try {
+            $poster->postCarousel($event, $user->id);
+            $this->fail('Expected a RuntimeException to be thrown.');
+        } catch (RuntimeException $e) {
+            // The underlying cause is surfaced in the message so Sentry groups by
+            // actual failure instead of one opaque "Please try again." bucket...
+            $this->assertStringContainsString('media aspect ratio not supported', $e->getMessage());
+            // ...and the original exception is chained so the stack trace survives.
+            $this->assertNotNull($e->getPrevious());
+            $this->assertSame(
+                'IG API 400: media aspect ratio not supported',
+                $e->getPrevious()->getMessage()
+            );
+        }
+    }
+
     public function test_job_status_show_endpoint_returns_json_for_owner(): void
     {
         $user = User::factory()->create(['user_status_id' => 1]);


### PR DESCRIPTION
## Sentry issue

[EVENTREPO-VB](https://sentry.io/organizations/geoff-maddock/issues/7502113651/) — `RuntimeException: There was an error posting to Instagram. Please try again.`
- Culprit: `App\Services\Integrations\InstagramEventPoster::postCarousel` (via the `PostEventToInstagram` queued job)
- Still active (last seen on the day this PR was opened); no user feedback attached.

## The error

When an Instagram upload/create call fails, `InstagramEventPoster` caught the SDK/HTTP exception, logged the real cause only at **`info`** level, and re-threw a **hardcoded** message:

```php
} catch (Exception $e) {
    Log::info('Carousel photo error: ' . $e->getMessage());
    throw new RuntimeException('There was an error posting to Instagram. Please try again.');
}
```

## Root cause

This is fundamentally an **external** failure (Instagram's Graph API rejecting the upload — rate limits, unsupported image aspect ratio/size, an expired page token, etc.), so the post genuinely can't succeed. The code deficiency is in **how the failure is surfaced**:

- The original exception was **not chained**, so its stack trace and type were discarded.
- The actual message was only at `info` log level.
- Every distinct cause collapsed into a **single opaque Sentry issue** with the same generic title, making it impossible to tell rate-limiting from a bad image from an auth problem.

Notably the file already had a `failureMessage()` helper that surfaces `getLastError()` detail at `error` level for the *status-check/publish* stages — the *initial upload/create* throw-sites were simply inconsistent with it.

## What changed

`app/Services/Integrations/InstagramEventPoster.php`
- Added a private `uploadFailure(string $stage, Exception $e)` helper (mirroring the existing `failureMessage()` pattern) that logs the cause at **`error`** level, includes it in the thrown message, and **chains the original exception** (`new RuntimeException($msg, 0, $e)`).
- Routed the four generic re-throw sites through it: single-photo upload, carousel-photo upload, carousel creation, and story-photo upload.

**No control-flow change** — the same call-sites still throw `RuntimeException`, and the queued job (`tries = 3`, backoff) still retries and ultimately fails exactly as before. This only improves the fidelity of what reaches Sentry and the job-status message.

### Scope / honesty
This does **not** stop Instagram from rejecting posts (that's external and out of our control). It makes the still-active issue **diagnosable** so the real failure modes can be triaged and, if any turn out to be our fault (e.g. always sending an unsupported aspect ratio), fixed as a follow-up. After this deploys, expect EVENTREPO-VB to split into cause-specific Sentry issues.

## Tests

Added `test_carousel_upload_failure_preserves_underlying_cause` to `tests/Feature/QueuedInstagramPostTest.php`: mocks `uploadCarouselPhoto` to throw, then asserts the surfaced message contains the underlying cause and that the original exception is chained via `getPrevious()`.

> Note: the local sandbox for this run couldn't install Composer dependencies (GitHub auth) or reach a MySQL DB, so PHPStan/PHPUnit were not run locally — `php -l` passes on both files and the change relies on CI to run the full `composer tests` + `phpstan` pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMnXTHyRzPVX5Wq8tQiCrC)_