### PR TITLE
Fix: order-by on unjoined users.name in threads listings [EVENTREPO-W2]

### DIFF
--- a/app/Http/Controllers/ThreadsController.php
+++ b/app/Http/Controllers/ThreadsController.php
@@ -169,7 +169,10 @@ class ThreadsController extends Controller
         $listParamSessionStore->setIndexTab(action([ThreadsController::class, 'index']));
 
         // create the base query including any required joins; needs select to make sure only event entities are returned
+        // leftJoin users so the shared 'internal_thread_index' session sort by users.name
+        // resolves here too (same class of error as EVENTREPO-W2).
         $baseQuery = Thread::join('follows', 'threads.id', '=', 'follows.object_id')
+        ->leftJoin('users', 'threads.created_by', '=', 'users.id')
         ->where('follows.object_type', '=', 'thread')
         ->where('follows.user_id', '=', $this->user->id)
         ->orderBy('follows.created_at', 'desc')
@@ -341,7 +344,11 @@ class ThreadsController extends Controller
         $listParamSessionStore->setIndexTab(action([ThreadsController::class, 'index']));
 
         // create the base query including any required joins; needs select to make sure only event entities are returned
+        // leftJoin users so the shared 'internal_thread_index' session sort by users.name
+        // (offered on the main threads index) resolves here instead of throwing
+        // "Unknown column 'users.name' in order clause" (EVENTREPO-W2).
         $baseQuery = Thread::query()
+        ->leftJoin('users', 'threads.created_by', '=', 'users.id')
         ->select('threads.*');
 
         $listEntityResultBuilder


### PR DESCRIPTION
## Sentry issue

[EVENTREPO-W2](https://sentry.io/organizations/geoff-maddock/issues/7558424001/) — `Illuminate\Database\QueryException: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'users.name' in 'order clause'` on `GET /threads/all`.

No user feedback is attached to this issue.

## The error

```
select `threads`.*, (select count(*) from `posts` where `threads`.`id` = `posts`.`thread_id`) as `posts_count`
from `threads`
where (`visibility_id` ...) order by `users`.`name` ...
```

`ThreadsController::indexAll()` (`/threads/all`) built its base query as a bare `Thread::query()->select('threads.*')` with **no join to `users`**, so ordering by `users.name` blew up at the database with a 500.

## Root cause

The main threads index (`ThreadsController::index()`, `/threads`) joins `users` (`threads.created_by → users.id`) and exposes `users.name` (**"User"**) as a sort option (`getListControlOptions()`). Every thread list action shares the same `internal_thread_index` session sort key, so once a visitor sorts the main index by **User**, that `users.name` sort persists in the session and is **replayed** against sibling actions whose queries don't join `users` — surfacing as the SQLSTATE 42S22 above.

`ListEntityResultBuilder::isValidSortField()` only validates the *format* of the sort field (an anti-injection regex), so a well-formed `table.column` like `users.name` passes the guard and reaches `orderBy()` against a table that isn't in the query.

This is the same class of bug fixed for `event_types.name` in #1960 (EVENTREPO-VE) and for `users.start_at` in #1957 (EVENTREPO-WC).

## Change

`app/Http/Controllers/ThreadsController.php` — add `->leftJoin('users', 'threads.created_by', '=', 'users.id')` (keeping `->select('threads.*')`) to the two actions that share the `internal_thread_index` key but lacked the join:

- `indexAll()` — the action in the Sentry report (`/threads/all`).
- `indexFollowing()` — `/threads/following`, the same latent bug via the shared session sort key.

This matches the exact join already used by `index()` and the sibling thread listings, so the shared session sort resolves against a valid column instead of throwing.

## Scope

- Two one-line `leftJoin` additions; no new sort options, no behavior change for existing valid sorts, no migrations, seeders, or frontend changes.
- Mirrors the established pattern (#1957, #1960); complements the centralized invalid-sort handling proposed in the still-open #1954 by fixing this occurrence at the source.

## Testing

`php -l` passes on the changed file. The project's PHPUnit/PHPStan suite could not be run in this ephemeral environment (Composer dependencies aren't installed and the feature tests require a live MySQL database), so please let CI exercise `tests/Feature/ThreadsTest.php` and `ApiThreadsCrudTest.php`. Manual repro: on `/threads`, sort by **User**, then visit `/threads/all` — before this change that 500s; after, it renders in `users.name` order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015e851gXgUTpuPh4ZSX4YCg)_