### PR TITLE
Fix: N+1 photo/promoter lookup on events iCal feed [EVENTREPO-T5]

### DIFF
--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -241,9 +241,13 @@ class EventsController extends Controller
         $query = $listResultSet->getList();
 
         // get the events
+        // Eager-load the relations ICalBuilder reads per event: venue, the
+        // promoter and its contacts (organizer lookup), and photos for
+        // getPrimaryPhoto(). Without photos/promoter.contacts each event
+        // triggers its own query while rendering the feed (EVENTREPO-T5).
         /* @phpstan-ignore-next-line */
         $events = $query->visible($this->user)
-            ->with('visibility', 'venue')
+            ->with('visibility', 'venue', 'promoter.contacts', 'photos')
             ->paginate($listResultSet->getLimit());
 
         // create a calendar object


### PR DESCRIPTION
## Sentry issue
[EVENTREPO-T5](https://sentry.io/organizations/geoff-maddock/issues/7318565810/) — N+1 Query on `GET /events/ical` (`EventsController@indexIcal`). ~4 occurrences, last seen 2026-06-18. No user feedback attached.

## Error / root cause
The iCal feed query eager-loaded only `visibility` and `venue`:

```php
$events = $query->visible($this->user)
    ->with('visibility', 'venue')
    ->paginate(...);
```

But `App\Services\Calendar\ICalBuilder` reads two more relations for **every** event while building the feed:

- `$event->promoter->contacts` — to pick an organizer email
- `$event->getPrimaryPhoto()` — which reads the `photos` relation for the primary image attachment

Neither `promoter.contacts` nor `photos` was eager-loaded, so each event triggered its own queries. Sentry's offending span was the per-event primary-photo lookup:

```sql
select `photos`.* ... from `photos`
inner join `event_photo` on `photos`.`id` = `event_photo`.`photo_id`
where `event_photo`.`event_id` = ? and `photos`.`is_primary` = ? limit 1
```

## What changed
`app/Http/Controllers/EventsController.php` — add `promoter.contacts` and `photos` to the eager load in `indexIcal`:

```php
->with('visibility', 'venue', 'promoter.contacts', 'photos')
```

This mirrors the fix already applied to the sibling feed `indexUserInterestedIcal` (EVENTREPO-T6), which loads `['venue', 'promoter.contacts', 'photos']`. `Event::getPrimaryPhoto()` already prefers the loaded `photos` collection via `relationLoaded('photos')`, so the change collapses the per-event queries into two batched eager loads.

## Scope / testing
- One-line change to an existing `->with()` call; all four relations (`venue`, `promoter`, `promoter.contacts`, `photos`) are confirmed to exist on the models.
- `php -l` passes. Larastan/PHPUnit were not run here because Composer dependencies aren't installed in this environment; the change is a targeted eager-load addition with no signature or logic changes.
- No migrations, seeder, or frontend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8J5YPbLaCeyqqF5XXoiri)_