### PR TITLE
Fix: Could not parse '2026801' on /events/by-date [EVENTREPO-WG]

### DIFF
--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -273,17 +273,19 @@ class EventsController extends Controller
         $dateFilterDescription = $this->formatDateFilterDescription($year, $month, $day);
 
         // set the start_at from and to dates based on the passed params
+        // Cast the route params to integers so single-digit months/days (e.g. /events/by-date/2026/8)
+        // produce a valid date instead of an unparseable string like "2026801" (EVENTREPO-WG).
         if ($year && !$month && !$day) {
-            $start_at_from = $year.'0101';
-            $start_at_to = $year.'1231';
+            $start_at_from = Carbon::create((int) $year, 1, 1)->startOfDay();
+            $start_at_to = Carbon::create((int) $year, 12, 31)->startOfDay();
             $slug = $dateFilterDescription;
         } elseif (!$day) {
-            $start_at_from = Carbon::parse($year.$month.'01');
-            $start_at_to = Carbon::parse($start_at_from)->endOfMonth();
+            $start_at_from = Carbon::create((int) $year, (int) $month, 1)->startOfDay();
+            $start_at_to = $start_at_from->copy()->endOfMonth();
             $slug = $dateFilterDescription;
         } else {
-            $start_at_from = Carbon::parse($year.$month.$day);
-            $start_at_to = Carbon::parse($start_at_from)->addDay();
+            $start_at_from = Carbon::create((int) $year, (int) $month, (int) $day)->startOfDay();
+            $start_at_to = $start_at_from->copy()->addDay();
             $slug = $dateFilterDescription;
         }
 

--- a/tests/Feature/Web/EventsControllerSmokeTest.php
+++ b/tests/Feature/Web/EventsControllerSmokeTest.php
@@ -86,6 +86,18 @@ class EventsControllerSmokeTest extends TestCase
         $this->get('/events/by-date/'.$year)->assertOk();
     }
 
+    public function test_events_by_date_single_digit_month_renders(): void
+    {
+        // A single-digit month previously built the unparseable string "2026801"
+        // and threw a Carbon InvalidFormatException (EVENTREPO-WG).
+        $this->get('/events/by-date/2026/8')->assertOk();
+    }
+
+    public function test_events_by_date_single_digit_month_and_day_renders(): void
+    {
+        $this->get('/events/by-date/2026/8/5')->assertOk();
+    }
+
     public function test_events_week_renders(): void
     {
         Event::factory()->create(['start_at' => Carbon::now()->setTime(20, 0)]);


### PR DESCRIPTION
## Sentry issue

[EVENTREPO-WG](https://sentry.io/organizations/geoff-maddock/issues/7617395307/) — `Carbon\Exceptions\InvalidFormatException: Could not parse '2026801': Failed to parse time string (2026801) at position 4 (8): Unexpected character`

- **Route:** `/events/by-date/{year}/{month?}/{day?}` → `EventsController::indexByDate`
- **Reproducing URL from Sentry:** `GET https://arcane.city/events/by-date/2026/8`
- **User feedback:** none attached.

## Root cause

`indexByDate` built the `start_at` date range by **string-concatenating the raw route params**:

```php
$start_at_from = Carbon::parse($year.$month.'01');   // "2026" . "8" . "01" = "2026801"
```

A single-digit month (or day) is not zero-padded, so `2026` + `8` + `01` yields `"2026801"`, which Carbon cannot parse — throwing `InvalidFormatException` and surfacing as a 500. Two-digit months (`/events/by-date/2026/08`) happened to work, which is why this only fired intermittently.

## Change

`app/Http/Controllers/EventsController.php` — build the range with `Carbon::create()` and integer-cast params instead of string concatenation:

```php
$start_at_from = Carbon::create((int) $year, (int) $month, 1)->startOfDay();
$start_at_to   = $start_at_from->copy()->endOfMonth();
```

This mirrors the controller's existing `formatDateFilterDescription()` helper, which already uses `Carbon::create((int) $year, (int) $month, ...)` and handles single-digit components correctly. Downstream `where('start_at', ...)` semantics are preserved (year → whole year, month → whole month, day → that day through the next).

## Tests

Added two smoke tests in `tests/Feature/Web/EventsControllerSmokeTest.php`, alongside the existing year-only test:

- `test_events_by_date_single_digit_month_renders` — `GET /events/by-date/2026/8` returns 200 (previously 500).
- `test_events_by_date_single_digit_month_and_day_renders` — `GET /events/by-date/2026/8/5` returns 200.

> Note: the full `composer tests` pipeline (MySQL migrate + seed + phpunit) was not runnable in the triage sandbox (no `vendor/`/DB); `php -l` passes on both changed files and the fix matches an existing proven pattern in the same controller. CI will exercise the new tests.

## Scope

Single controller method + tests. No migrations, seeders, or frontend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuFN9buvEGW5Un7kq5Yyww

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuFN9buvEGW5Un7kq5Yyww)_