### PR TITLE
Fix: N+1 Query on /threads index [EVENTREPO-WE]

### DIFF
--- a/app/Http/Controllers/ThreadsController.php
+++ b/app/Http/Controllers/ThreadsController.php
@@ -122,7 +122,7 @@ class ThreadsController extends Controller
 
         /* @phpstan-ignore-next-line */
         $threads = $query->visible($this->user)
-            ->with('visibility','entities','tags','posts','event','user')
+            ->with('visibility', 'entities', 'tags', 'event', 'series', 'user.photos', 'lastPost.user')
             ->paginate($listResultSet->getLimit());
 
         // saves the updated session


### PR DESCRIPTION
## Sentry issue
[EVENTREPO-WE](https://sentry.io/organizations/geoff-maddock/issues/7594600408/) — N+1 Query. Still firing on **`/threads`** (latest event 2026-07-18), the `ThreadsController::index()` route.

## Error summary
The threads grid renders each thread author's avatar via `resources/views/users/avatar.blade.php`, which calls `User::getPrimaryPhoto()`. When the user's `photos` relation isn't eager-loaded, that fires one query per row:

```
select `photos`.* from `photos`
  inner join `photo_user` on `photos`.`id` = `photo_user`.`photo_id`
  where `photo_user`.`user_id` = ? and `photos`.`is_primary` = ? limit 1
```

Sentry captured **18 repeating spans** per request under `view.render - threads.index-tw`.

## Root cause
A previous fix — [#1967](https://github.com/geoff-maddock/events-tracker/pull/1967) — added the `relationLoaded('photos')` guard to `User::getPrimaryPhoto()` and switched the seven **sibling** thread-listing methods (`indexFollowing`, `indexAll`, `indexTags`, `indexCategories`, `indexSeries`, `indexRelatedTo`, …) to eager-load `user.photos`. But it **did not touch `index()`**, which was still on an older eager-load set:

```php
->with('visibility','entities','tags','posts','event','user')   // index() — missed
->with('visibility', 'entities', 'tags', 'event', 'series', 'user.photos', 'lastPost.user')  // every sibling
```

Because `index()` only loaded `user` (not `user.photos`), the guarded `getPrimaryPhoto()` had nothing in memory to read and fell back to the per-row query — so `/threads` kept N+1-ing while `/threads/all` and the others were fixed.

## What changed
`app/Http/Controllers/ThreadsController.php` — align `index()`'s eager loads with its sibling methods:

- add `user.photos` so the guarded `getPrimaryPhoto()` resolves from memory (fixes the avatar N+1);
- add `lastPost.user` (`card-tw` reads `$thread->lastPost->user->name`) and `series` (`card-tw` reads `$thread->series->isNotEmpty()`), preventing two further N+1s the older set was missing;
- drop the unused `posts` eager-load — the card reads `$thread->posts_count`, not the `posts` relation (the siblings already omit it).

## Scope / notes
- One-line change to a single controller method; no schema, migration, model, or view changes.
- Behavior is unchanged — this is purely eager-loading. `User::getPrimaryPhoto()`'s guard already shipped in #1967.
- The existing `threads_browsable` test (`GET /threads`, `tests/Feature/ThreadsTest.php`) exercises this render path; CI will run it.
- Verification: `php -l` passes. The full `composer tests` pipeline (PHPUnit + PHPStan) needs `vendor/` and a MySQL database, neither available in this ephemeral triage environment, so it was not run here — CI will exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0176UCS93FmaVEcE5KHcb5Vt)_