### PR TITLE
Fix: Rotate logs to prevent disk exhaustion / log-write failures [EVENTREPO-SP]

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -35,7 +35,12 @@ return [
     'channels' => [
         'stack' => [
             'driver' => 'stack',
-            'channels' => ['single'],
+            // Use the rotating "daily" channel (7-day retention) by default rather
+            // than the unbounded "single" laravel.log, which grows without limit and
+            // fills the disk over time (Sentry EVENTREPO-SP / EVENTREPO-SN:
+            // "Writing to the log file failed ... No space left on device").
+            // LOG_STACK can override the channel list per environment without a deploy.
+            'channels' => explode(',', env('LOG_STACK', 'daily')),
         ],
 
         'single' => [


### PR DESCRIPTION
## Sentry issues

- [EVENTREPO-SP](https://sentry.io/organizations/geoff-maddock/issues/7259820989/) — `UnexpectedValueException: Writing to the log file failed: Write of N bytes failed with errno=28 No space left on device` — **755 events**, last seen 2026-07-18.
- [EVENTREPO-SN](https://sentry.io/organizations/geoff-maddock/issues/7259820966/) — same error, **699 events**, last seen 2026-07-18. (Duplicate manifestation of the same root cause; this PR covers both.)

These are the two **highest-frequency** unresolved issues in the project (~1,450 combined events). No user feedback attached.

## Error summary

Every attempt to write a log line fails because the host disk is full (`errno=28 No space left on device`). The same disk-full condition is also surfacing as a cascade of related unresolved issues on the host — `file_put_contents()` write failures (EVENTREPO-W9/WQ/WR) and MySQL `Error writing file '/tmp/MYfd=…'` failures (EVENTREPO-VE/WK/WA/W8/WP).

## Root cause

The default `stack` log channel was configured to write only to the `single` channel:

```php
'stack' => [
    'driver' => 'stack',
    'channels' => ['single'],   // -> storage_path('logs/laravel.log'), never rotated
],
```

`single` writes to one `laravel.log` file that **grows without bound** — there is no rotation or retention. Over time it consumes all available disk, at which point *every* subsequent log write throws the `UnexpectedValueException` above. A `daily` channel with 7-day retention already existed in the same config file but was unused by the stack.

## What changed

`config/logging.php` — point the `stack` channel at the rotating `daily` channel (7-day retention) instead of the unbounded `single` channel:

```php
'channels' => explode(',', env('LOG_STACK', 'daily')),
```

- Logs now rotate daily and files older than 7 days are pruned, bounding disk growth.
- The `single` and `daily` channel definitions are unchanged, so anything referencing them directly still works.
- `LOG_STACK` allows per-environment override (e.g. `LOG_STACK=single,slack`) without a code change.

## Scope / notes

- One-line functional change to a config file; no schema, migration, model, controller, or view changes.
- `php -l config/logging.php` passes.
- **This bounds future log growth but does not by itself free the currently-full disk.** The immediate incident still needs an ops step: clear the exhausted disk (rotate/remove the oversized `storage/logs/laravel.log`) and, separately, review why the host filled up (log growth was a major contributor; MySQL `/tmp` sort-file usage on deep-pagination queries is another — already mitigated by #1956). After the disk is cleared, this change prevents the log file from re-filling it.
- The full `composer tests` pipeline (MySQL migrate + seed + phpunit) needs `vendor/` and a database, neither available in this triage environment, so it was not run here — CI will exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7rMX9PN3FHK2jYEAuxaKr)_