### PR TITLE
Fix: allow single-digit day in events by-date routes

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -264,7 +264,7 @@ Route::get('events/grid/tag/{slug}', 'EventsController@indexGridTags')->name('ev
 Route::get('events/grid/by-date/{year}/{month?}/{day?}', 'EventsController@indexGridByDate')->name('events.grid.byDate')
     ->where('year', '[1-9][0-9][0-9][0-9]')
     ->where('month', '(0?[1-9]|1[012])')
-    ->where('day', '[0-3][0-9]');
+    ->where('day', '(0?[1-9]|[12][0-9]|3[01])');
 Route::get('events/grid/related-to/{slug}', 'EventsController@indexGridRelatedTo')->name('events.grid.relatedto');
 Route::get('events/grid/type/{slug}', 'EventsController@indexGridTypes')->name('events.grid.type');
 Route::get('events/grid/series/{slug}', 'EventsController@indexGridSeries')->name('events.grid.series');
@@ -284,7 +284,7 @@ Route::get('events/{slug}/embeds', 'EventsController@loadEmbedsBySlug');
 Route::get('events/by-date/{year}/{month?}/{day?}', 'EventsController@indexByDate')
     ->where('year', '[1-9][0-9][0-9][0-9]')
     ->where('month', '(0?[1-9]|1[012])$')
-    ->where('day', '[0-3][0-9]');
+    ->where('day', '(0?[1-9]|[12][0-9]|3[01])');
 // Use this route for the front page to display a window of events
 Route::get('events/window/{year}/{month?}/{day?}', 'EventsController@indexWindow')
     ->where('year', '[1-9][0-9][0-9][0-9]')

--- a/tests/Feature/Web/EventsControllerSmokeTest.php
+++ b/tests/Feature/Web/EventsControllerSmokeTest.php
@@ -98,6 +98,11 @@ class EventsControllerSmokeTest extends TestCase
         $this->get('/events/by-date/2026/8/5')->assertOk();
     }
 
+    public function test_events_grid_by_date_single_digit_month_and_day_renders(): void
+    {
+        $this->get('/events/grid/by-date/2026/8/5')->assertOk();
+    }
+
     public function test_events_week_renders(): void
     {
         Event::factory()->create(['start_at' => Carbon::now()->setTime(20, 0)]);


### PR DESCRIPTION
## Summary

PR #1974 fixed `indexByDate` to build valid dates from single-digit month/day params, but its `/events/by-date/2026/8/5` smoke test never actually passed — that PR was merged with a failing build. The route's `day` constraint `[0-3][0-9]` requires exactly two digits, so single-digit days 404 at the routing layer before the controller fix is ever reached.

- Relaxes the `day` constraint to `(0?[1-9]|[12][0-9]|3[01])` on `events/by-date` and `events/grid/by-date` — both controllers already int-cast their params (`Carbon::create((int) $year, (int) $month, (int) $day)`), so single-digit days now render correctly.
- Side benefit: the new pattern rejects invalid days `00` and `32`–`39`, which the old one accepted.
- Adds a matching single-digit smoke test for the grid route.

Left untouched:
- `events/window/{year}/{month?}/{day?}` — it routes to `EventsController@indexWindow`, **which does not exist**; any request to it 500s regardless of constraints. That dead route needs its own decision (restore the method or remove the route).
- `calendar/by-date` — its controller ignores the `day` param entirely, so its constraint is inert.

## Testing

- `tests/Feature/Web/EventsControllerSmokeTest.php` passes in full, including the previously-failing `test_events_by_date_single_digit_month_and_day_renders` and the new grid test (18 tests).
- Route-level verification: `/events/by-date/2026/8/5` and `/events/grid/by-date/2026/8/5` now match; `/events/by-date/2026/8/32` correctly 404s.
- PHPStan clean.

This unblocks green CI for #1986 (newsletter), which currently inherits this failure from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)