### PR TITLE
Fix: GET /api/threads/{id}/posts 500 — order by posts.created_at

### DIFF
--- a/app/Http/Controllers/Api/ThreadsController.php
+++ b/app/Http/Controllers/Api/ThreadsController.php
@@ -536,11 +536,13 @@ class ThreadsController extends Controller
         $baseQuery = Post::where('thread_id', $threadId)
             ->select('posts.*');
 
+        // Sort by the posts table, not the controller-wide thread default —
+        // the base query has no threads join to order by.
         $listEntityResultBuilder
             ->setFilter($postFilter)
             ->setQueryBuilder($baseQuery)
             ->setDefaultLimit($this->defaultLimit)
-            ->setDefaultSort($this->defaultSortCriteria);
+            ->setDefaultSort(['posts.created_at' => 'desc']);
 
         // Get the result set from the builder
         $listResultSet = $listEntityResultBuilder->listResultSetFactory();

--- a/tests/Feature/ApiThreadsCrudTest.php
+++ b/tests/Feature/ApiThreadsCrudTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Feature;
 
 use App\Models\Forum;
+use App\Models\Group;
+use App\Models\Post;
 use App\Models\Thread;
 use App\Models\User;
 use App\Models\UserStatus;
@@ -95,5 +97,71 @@ class ApiThreadsCrudTest extends TestCase
             ->assertStatus(200);
 
         $this->assertSame('Patched ZZ', $thread->fresh()->name);
+    }
+
+    private function actingAsAdmin(): User
+    {
+        $admin = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $adminGroup = Group::where('name', 'admin')->first()
+            ?? Group::factory()->create(['name' => 'admin']);
+        $admin->groups()->attach($adminGroup->id);
+        $this->actingAs($admin, 'sanctum');
+
+        return $admin;
+    }
+
+    public function test_posts_lists_thread_posts_newest_first(): void
+    {
+        // Regression for issue #1988: the posts sub-list previously ordered
+        // by threads.created_at (not in the query) and 500ed on any thread
+        // that actually had posts.
+        $this->actingAsAdmin();
+
+        $thread = Thread::factory()->create();
+        $older = Post::factory()->create([
+            'thread_id' => $thread->id,
+            'created_at' => now()->subDay(),
+        ]);
+        $newer = Post::factory()->create([
+            'thread_id' => $thread->id,
+            'created_at' => now(),
+        ]);
+
+        $response = $this->getJson('/api/threads/'.$thread->id.'/posts')
+            ->assertStatus(200)
+            ->assertJsonPath('total', 2);
+
+        $ids = array_column($response->json('data'), 'id');
+        $this->assertSame([$newer->id, $older->id], $ids);
+    }
+
+    public function test_posts_returns_empty_page_for_thread_without_posts(): void
+    {
+        $this->actingAsAdmin();
+
+        $thread = Thread::factory()->create();
+
+        $this->getJson('/api/threads/'.$thread->id.'/posts')
+            ->assertStatus(200)
+            ->assertJsonPath('total', 0)
+            ->assertJsonPath('data', []);
+    }
+
+    public function test_posts_returns_404_for_missing_thread(): void
+    {
+        $this->actingAsAdmin();
+
+        $this->getJson('/api/threads/99999999/posts')
+            ->assertStatus(404);
+    }
+
+    public function test_posts_denied_without_show_post_gate(): void
+    {
+        // setUp's plain user has no admin group, so show_post denies.
+        $thread = Thread::factory()->create();
+        Post::factory()->create(['thread_id' => $thread->id]);
+
+        $this->getJson('/api/threads/'.$thread->id.'/posts')
+            ->assertStatus(403);
     }
 }


### PR DESCRIPTION
Fixes #1988.

## Problem
`ThreadsController::posts()` passed the controller-wide thread default sort (`['threads.created_at' => 'desc']`, set in the constructor for thread listings) into a **Post** base query that has no `threads` join. The resulting `ORDER BY threads.created_at` threw SQLSTATE 42S22 — a 500 for any thread that actually had posts. Threads with zero posts appeared to work only because the paginator skips the ORDER BY when the count is 0.

## Fix
One line: `posts()` now sets its own default sort, `['posts.created_at' => 'desc']`, matching the `select('posts.*')` base query. `PostFilters` sort/direction overrides still apply as before.

## Tests
New feature coverage in `ApiThreadsCrudTest`:
- thread with posts returns 200, newest first (fails with a 500 on the unfixed code — verified)
- post-less thread still returns an empty 200 page
- missing thread returns 404
- non-admin (show_post gate) returns 403

`composer phpstan` clean; `ApiThreadsCrudTest`, `ApiThreadsUnhappyPathTest`, `ApiPostsCrudTest`, `ApiPostsUnhappyPathTest` all green (23 tests).

## Follow-up (separate repo)
The events-api-go contract suite currently skips this endpoint citing the PHP 500; once this merges and deploys, that skip gets removed and the parity sweep rerun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)