### PR TITLE
CI: unblock builds — ignore republished laravel/framework advisories with documented reasons

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,9 @@
 		},
 		"audit": {
 			"ignore": {
-				"PKSA-mdq4-51ck-6kdq": "Laravel CRLF injection in default email validation rule. Patched only in Laravel 12.60+/13.10+ (all 10.x AND 11.x are affected), so it cannot be resolved without the deferred framework-upgrade track. Accepted/known risk; revisit when upgrading the framework."
+				"PKSA-mdq4-51ck-6kdq": "Laravel CRLF injection in default email validation rule. Patched only in Laravel 12.60+/13.10+ (all 10.x AND 11.x are affected), so it cannot be resolved without the deferred framework-upgrade track. Accepted/known risk; revisit when upgrading the framework.",
+				"PKSA-3r5d-mb8f-1qw9": "Same CRLF email-rule vulnerability (GHSA-5vg9-5847-vvmq) republished under a new advisory ID with affected range <12.60.0. Identical accepted/known risk as PKSA-mdq4-51ck-6kdq above; revisit when upgrading the framework.",
+				"PKSA-m5cs-t1y6-qpcs": "Temporary signed URL path confusion in the local filesystem driver (GHSA-crmm-hgp2-wgrp), patched only in 12.61.1+/13.12+. Not exploitable here: the app never calls Storage::temporaryUrl (verified 2026-07-22, no usages in app/ routes/ config/ views). Revisit when upgrading the framework or if temporary URLs are introduced."
 			}
 		}
 	},


### PR DESCRIPTION
## Problem
The `Composer security audit` CI step has failed on **main and every PR since 2026-07-21** — e.g. it is currently blocking #1992. Two advisories were republished for `laravel/framework` under new advisory IDs on 2026-06-17 and started tripping the audit:

| Advisory | Severity | What it is |
|---|---|---|
| `PKSA-3r5d-mb8f-1qw9` | high | **The same CRLF email-rule vulnerability** ([GHSA-5vg9-5847-vvmq](https://github.com/advisories/GHSA-5vg9-5847-vvmq)) already accepted and ignored in composer.json as `PKSA-mdq4-51ck-6kdq` — republished under a new ID with a tightened affected range. No new risk; extending the existing documented decision. |
| `PKSA-m5cs-t1y6-qpcs` | medium (CVSS 4.2) | Temporary signed URL path confusion in the **local filesystem driver** ([GHSA-crmm-hgp2-wgrp](https://github.com/advisories/GHSA-crmm-hgp2-wgrp)), patched only in Laravel 12.61.1+/13.12+ — unfixable on the 10.x line without the deferred framework upgrade. **Not exploitable in this app:** there are zero usages of `Storage::temporaryUrl` / `temporaryUploadUrl` in `app/`, `routes/`, `config/`, or views (verified 2026-07-22). |

## Change
Adds both IDs to the existing `config.audit.ignore` block in `composer.json`, each with a documented reason and a revisit-on-framework-upgrade note, matching the established pattern.

## Verification
`composer audit --locked --abandoned=report` exits 0 with these entries (3 ignored advisories reported, none failing).

Once this merges, rebasing/rerunning open PRs (e.g. #1992) should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)