### PR TITLE
Fix: attribute uploaded photos to the uploader

### DIFF
--- a/app/Services/ImageHandler.php
+++ b/app/Services/ImageHandler.php
@@ -24,11 +24,15 @@ class ImageHandler
 
         // from here, this file has been stored publicly under it's unique name and original format
         $filePath = $file->storePubliclyAs('photos', $fileName, 'external');
-        
+
         // sets all the photo private name and path values
         $photo = Photo::named($fileName);
 
-        // make a webp version of the image 
+        // attribute the photo to the uploader; without this the column keeps
+        // its DB default of 1 and photo management breaks for everyone else
+        $photo->created_by = auth()->id() ?? 1;
+
+        // make a webp version of the image
         $webp = $photo->makeWebp();
 
         return $photo->makeThumbnail();

--- a/tests/Feature/ApiPhotoManagementTest.php
+++ b/tests/Feature/ApiPhotoManagementTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\Photo;
+use App\Models\User;
+use App\Models\UserStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Storage;
+use Intervention\Image\Facades\Image;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * Photo attribution and management (issue #1989): uploads must set
+ * created_by to the uploader — previously the column kept its DB default
+ * of 1, so set-primary/unset-primary/destroy (which require strict creator
+ * equality) failed for everyone except user 1.
+ */
+class ApiPhotoManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private User $owner;
+    private User $attacker;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+        Storage::fake('external');
+        $this->owner = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $this->attacker = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    /**
+     * Replace Intervention's Image facade with a self-chained mock (same
+     * pattern as ImageHandlerTest) so the upload pipeline runs without real
+     * image processing against the fake external disk.
+     */
+    private function stubImageFacade(): void
+    {
+        $mock = Mockery::mock();
+        $mock->shouldReceive('fit')->andReturnSelf();
+        $mock->shouldReceive('encode')->andReturnSelf();
+        $mock->shouldReceive('save')->andReturnSelf();
+        $mock->shouldReceive('destroy')->andReturnNull();
+        $mock->shouldReceive('basePath')->andReturnUsing(function () {
+            return tempnam(sys_get_temp_dir(), 'photomgmt-');
+        });
+
+        Image::shouldReceive('make')->andReturn($mock);
+    }
+
+    private function seedPhotoOwnedBy(User $user): Photo
+    {
+        return Photo::factory()->create([
+            'name' => 'seeded.webp',
+            'path' => 'photos/seeded.webp',
+            'thumbnail' => 'photos/tn-seeded.webp',
+            'is_primary' => 0,
+            'created_by' => $user->id,
+            'updated_by' => null,
+        ]);
+    }
+
+    /** @test */
+    public function uploaded_photo_is_attributed_to_the_uploader(): void
+    {
+        $this->stubImageFacade();
+        Mail::fake();
+
+        $event = Event::factory()->create(['created_by' => $this->owner->id]);
+
+        $this->actingAs($this->owner, 'sanctum');
+        $this->post('/api/events/'.$event->id.'/photos',
+            ['file' => UploadedFile::fake()->image('flyer.jpg')],
+            ['Accept' => 'application/json'])
+            ->assertStatus(201);
+
+        $photo = $event->photos()->first();
+        $this->assertNotNull($photo);
+        $this->assertSame($this->owner->id, $photo->created_by,
+            'Uploaded photo must be attributed to the uploader, not the DB default of 1.');
+    }
+
+    /** @test */
+    public function uploader_can_manage_their_own_photo(): void
+    {
+        $photo = $this->seedPhotoOwnedBy($this->owner);
+
+        $this->actingAs($this->owner, 'sanctum');
+
+        $this->postJson('/api/photos/'.$photo->id.'/set-primary')
+            ->assertStatus(200);
+        $this->assertSame(1, $photo->fresh()->is_primary);
+
+        $this->postJson('/api/photos/'.$photo->id.'/unset-primary')
+            ->assertStatus(200);
+        $this->assertSame(0, $photo->fresh()->is_primary);
+
+        $this->deleteJson('/api/photos/'.$photo->id)
+            ->assertStatus(204);
+        $this->assertDatabaseMissing('photos', ['id' => $photo->id]);
+    }
+
+    /** @test */
+    public function make_photo_falls_back_to_user_one_when_unauthenticated(): void
+    {
+        $this->stubImageFacade();
+
+        // No actingAs: console/queued contexts keep the legacy attribution.
+        $photo = (new \App\Services\ImageHandler())->makePhoto(
+            UploadedFile::fake()->image('anon.png'));
+
+        $this->assertSame(1, $photo->created_by);
+    }
+
+    /** @test */
+    public function other_users_cannot_manage_anothers_photo(): void
+    {
+        $photo = $this->seedPhotoOwnedBy($this->owner);
+
+        $this->actingAs($this->attacker, 'sanctum');
+
+        $this->postJson('/api/photos/'.$photo->id.'/set-primary')
+            ->assertStatus(403)
+            ->assertJson(['status' => 'Permission Denied']);
+
+        $this->postJson('/api/photos/'.$photo->id.'/unset-primary')
+            ->assertStatus(403);
+
+        $this->deleteJson('/api/photos/'.$photo->id)
+            ->assertStatus(403);
+
+        $this->assertDatabaseHas('photos', ['id' => $photo->id]);
+        $this->assertSame(0, $photo->fresh()->is_primary);
+    }
+}


### PR DESCRIPTION
Fixes #1989.

## Problem
`ImageHandler::makePhoto()` never set `created_by`, so every uploaded photo kept the column's DB default of `1`. The photo management endpoints in `Api\PhotosController` (`set-primary`, `unset-primary`, `destroy`) gate on strict creator equality (`$photo->created_by !== $this->user->id`), which meant:

- no user except user 1 could manage photos they uploaded (403 on their own photos), and
- user 1 accidentally had management rights over **every** photo in the system.

## Fix
One assignment in `ImageHandler::makePhoto()`:

```php
$photo->created_by = auth()->id() ?? 1;
```

Placing it in the service covers all **ten** upload call sites (API + web controllers for events, entities, series, users, blogs) in one place. The `?? 1` fallback preserves legacy attribution for any unauthenticated context (console/queued). The photo model is not yet saved at this point — callers persist it — so this is purely an in-memory attribute set.

## Not in scope (per the issue)
- **Backfill**: existing rows are all `created_by = 1` and the true uploader is unrecoverable in general — documented decision, no migration.
- **Admin override** for photo management is a separate enhancement; note this fix *closes* the accidental "user 1 manages everything" loophole.

## Tests
New `tests/Feature/ApiPhotoManagementTest.php` (4 tests, using the established `Storage::fake('external')` + Intervention stub pattern from `ImageHandlerTest`):
- end-to-end upload via `POST /api/events/{id}/photos` attributes the photo to the uploader — **fails on the unfixed code** (asserts 1 vs uploader id; verified by stashing the fix)
- uploader can set-primary → unset-primary → destroy their own photo
- another user gets 403 `{"status":"Permission Denied"}` on all three
- anonymous service-level fallback stays `1`

`composer phpstan` clean; `ApiPhotoAuthTest`, `ImageHandlerTest`, `ApiPhotoManagementTest`, `ApiEntitiesHappyPathTest`, `ApiSeriesHappyPathTest` all green (23 tests).

Heads-up: the CI `build` check will show the pre-existing composer-audit failure until #1993 (or equivalent) lands — test results are the real signal here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)