### PR TITLE
Fix: N+1 query on /popular tags grid [EVENTREPO-WV]

### DIFF
--- a/app/Http/Controllers/PagesController.php
+++ b/app/Http/Controllers/PagesController.php
@@ -318,8 +318,18 @@ class PagesController extends Controller
             ->take(12)
             ->get();
 
-        // Get popular tags - tags with most events
+        // Get popular tags - tags with most events.
+        // Eager-load each tag's visible events (newest first) plus their photos so the
+        // view can pick the latest event + its primary photo without issuing a fresh
+        // query per tag. Previously popular-tw.blade.php ran
+        // `$tag->events()->visible()->latest()->first()` (+ a primary-photo lookup)
+        // inside the tag loop, an N+1 flagged as EVENTREPO-WV.
         $popularTags = Tag::withCount('events')
+            ->with(['events' => function ($query) use ($user) {
+                $query->visible($user)
+                    ->latest('start_at')
+                    ->with('photos');
+            }])
             ->orderBy('events_count', 'desc')
             ->take(24)
             ->get();
@@ -327,7 +337,8 @@ class PagesController extends Controller
         return view('pages.popular-tw', compact(
             'popularEvents',
             'popularEntities',
-            'popularTags'
+            'popularTags',
+            'user'
         ));
     }
 

--- a/resources/views/pages/popular-tw.blade.php
+++ b/resources/views/pages/popular-tw.blade.php
@@ -97,7 +97,11 @@
             <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
                 @foreach ($popularTags as $tag)
                     @php
-                        $event = $tag->events()->visible($user ?? null)->latest('start_at')->first();
+                        // Events (visible, newest first) and their photos are eager-loaded
+                        // in PagesController::popular() to avoid a per-tag N+1 (EVENTREPO-WV).
+                        $event = $tag->relationLoaded('events')
+                            ? $tag->events->first()
+                            : $tag->events()->visible($user ?? null)->latest('start_at')->first();
                         $photo = $event ? $event->getPrimaryPhoto() : null;
                     @endphp
                     <a href="/tags/{{ $tag->slug }}" class="group block">


### PR DESCRIPTION
> **Draft** — root cause is confirmed, but the fix could not be run against the test suite / DB in the triage sandbox (`vendor/` is unavailable), and the eager-loading approach has a volume trade-off worth reviewing before merge. See notes below.

## Sentry issue

[EVENTREPO-WV](https://geoff-maddock.sentry.io/issues/7633845833/) — `N+1 Query` on `GET /popular`. First seen 2026-07-26. No user feedback attached.

## The error

The **Popular Tags** grid in `resources/views/pages/popular-tw.blade.php` loops over up to 24 popular tags and, for each one, issues fresh queries inside the loop:

```php
@foreach ($popularTags as $tag)
    @php
        $event = $tag->events()->visible($user ?? null)->latest('start_at')->first();
        $photo = $event ? $event->getPrimaryPhoto() : null;
    @endphp
```

- `$tag->events()->…->first()` → one query **per tag** for the latest visible event.
- `$event->getPrimaryPhoto()` → a further `photos` query per event, since `Event::getPrimaryPhoto()` only uses the relation when it's already eager-loaded.

`PagesController::popular()` loaded the tags with `Tag::withCount('events')->take(24)->get()` but did **not** eager-load their events or photos, so the page fired up to ~48 extra queries — the N+1 Sentry flagged.

## Change

`app/Http/Controllers/PagesController.php` — eager-load each tag's visible events (newest first) and their photos:

```php
$popularTags = Tag::withCount('events')
    ->with(['events' => function ($query) use ($user) {
        $query->visible($user)
            ->latest('start_at')
            ->with('photos');
    }])
    ->orderBy('events_count', 'desc')
    ->take(24)
    ->get();
```

`resources/views/pages/popular-tw.blade.php` — read the latest event from the loaded collection (falling back to the original query if the relation isn't loaded, so the view is safe if called from elsewhere):

```php
$event = $tag->relationLoaded('events')
    ? $tag->events->first()
    : $tag->events()->visible($user ?? null)->latest('start_at')->first();
$photo = $event ? $event->getPrimaryPhoto() : null;
```

The controller now also passes `$user` to the view. Previously `$user` was never passed, so `$user ?? null` always resolved to guest visibility even for logged-in users — this change makes the visibility scope use the authenticated user (a small correctness improvement; worth confirming it matches intended behavior).

## Trade-off to review before merge

Laravel's constrained eager-loading has no per-parent `LIMIT`, so `with(['events' => …latest()])` loads **all** visible events for each of the 24 tags (with their photos), even though the view only uses the newest one. For very popular tags that could be a lot of rows — potentially trading the N+1 for a heavy single load.

If a volume check shows that's a problem, prefer resolving the newest event per tag in **one** query, e.g. a window function over the `event_tag` pivot:

```sql
ROW_NUMBER() OVER (PARTITION BY event_tag.tag_id ORDER BY events.start_at DESC)
```

then hydrate only those event ids (with photos). Happy to switch to that approach.

## Testing

⚠️ Not yet executed — `vendor/` is unavailable in the triage sandbox, so PHPUnit/PHPStan could not run. `app/Http/Controllers/PagesController.php` passes `php -l`. Please run `composer tests` in CI and spot-check `/popular` (guest and logged-in) before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_017SaiDoqZKfxowcRF3CoHCk)_