### PR TITLE
SEO: robots.txt rules, date-corridor clamp, search/go fixes, 5xx guards (issue #2001, part 1)

### DIFF
--- a/app/Http/Controllers/ClickTrackController.php
+++ b/app/Http/Controllers/ClickTrackController.php
@@ -30,7 +30,8 @@ class ClickTrackController extends Controller
             if ($event) {
                 return redirect()->route('events.show', $event->id);
             }
-            return redirect()->route('home');
+            // a tracking link for a missing event is a dead URL, not the homepage
+            abort(404);
         }
 
         // Check if the request is from a bot/crawler
@@ -76,7 +77,8 @@ class ClickTrackController extends Controller
             if ($series) {
                 return redirect()->route('series.show', $series->slug);
             }
-            return redirect()->route('home');
+            // a tracking link for a missing series is a dead URL, not the homepage
+            abort(404);
         }
 
         // Check if the request is from a bot/crawler

--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -25,6 +25,7 @@ use App\Models\Thread;
 use App\Models\User;
 use App\Models\Visibility;
 use App\Notifications\EventPublished;
+use App\Services\EventDateRange;
 use App\Services\ImageHandler;
 use App\Services\RssFeed;
 use App\Services\SessionStore\ListParameterSessionStore;
@@ -944,6 +945,13 @@ class EventsController extends Controller
             abort(404);
         }
 
+        // dated variants outside the range of real event data are navigation
+        // state, not pages — 404 them so crawlers can't walk into empty decades
+        $dateRange = new EventDateRange();
+        if ($date !== '' && !$dateRange->contains($baseDate)) {
+            abort(404);
+        }
+
         // use the window to get the last date and set the criteria between
         $next_day = $baseDate->copy()->addDays(1);
         $next_day_window = $baseDate->copy()->addDays($this->defaultWindow);
@@ -970,6 +978,10 @@ class EventsController extends Controller
                         'next_day_window' => $next_day_window,
                         'prev_day' => $prev_day,
                         'prev_day_window' => $prev_day_window,
+                        'hasPrev' => $dateRange->contains($prev_day),
+                        'hasPrevWindow' => $dateRange->contains($prev_day_window),
+                        'hasNext' => $dateRange->contains($next_day),
+                        'hasNextWindow' => $dateRange->contains($next_day_window),
                     ])
                     ->render();
         }
@@ -982,6 +994,10 @@ class EventsController extends Controller
             'next_day_window' => $next_day_window,
             'prev_day' => $prev_day,
             'prev_day_window' => $prev_day_window,
+            'hasPrev' => $dateRange->contains($prev_day),
+            'hasPrevWindow' => $dateRange->contains($prev_day_window),
+            'hasNext' => $dateRange->contains($next_day),
+            'hasNextWindow' => $dateRange->contains($next_day_window),
         ]);
     }
 
@@ -1007,6 +1023,13 @@ class EventsController extends Controller
         try {
             $baseDate = $date === '' ? Carbon::now() : Carbon::parse($date);
         } catch (\Throwable $e) {
+            abort(404);
+        }
+
+        // dated variants outside the range of real event data are navigation
+        // state, not pages — 404 them so crawlers can't walk into empty decades
+        $dateRange = new EventDateRange();
+        if ($date !== '' && !$dateRange->contains($baseDate)) {
             abort(404);
         }
 
@@ -1036,6 +1059,7 @@ class EventsController extends Controller
                         'next_day_window' => $next_day_window,
                         'prev_day' => $prev_day,
                         'prev_day_window' => $prev_day_window,
+                        'hasNextWindow' => $dateRange->contains($next_day_window),
                     ])
                     ->render();
         }
@@ -1048,6 +1072,10 @@ class EventsController extends Controller
             'next_day_window' => $next_day_window,
             'prev_day' => $prev_day,
             'prev_day_window' => $prev_day_window,
+            'hasPrev' => $dateRange->contains($prev_day),
+            'hasPrevWindow' => $dateRange->contains($prev_day_window),
+            'hasNext' => $dateRange->contains($next_day),
+            'hasNextWindow' => $dateRange->contains($next_day_window),
         ]);
     }
 
@@ -1502,7 +1530,13 @@ class EventsController extends Controller
 
             return back();
         }
-        $day = Carbon::parse($day);
+
+        // route regex allows shapes like 2026-19-99 that still fail to parse
+        try {
+            $day = Carbon::parse($day);
+        } catch (\Throwable $e) {
+            abort(404);
+        }
 
         return view('events.day-tw')
             ->with([
@@ -2586,9 +2620,15 @@ class EventsController extends Controller
         // get the query builder
         $query = $listResultSet->getList();
 
-        $cdate = Carbon::parse($date);
-        $cdate_yesterday = Carbon::parse($date)->subDay();
-        $cdate_tomorrow = Carbon::parse($date)->addDay();
+        // $date is a user-supplied route param; crawlers hit this with non-date
+        // junk, which makes Carbon::parse() throw. Treat it as a missing page.
+        try {
+            $cdate = Carbon::parse($date);
+        } catch (\Throwable $e) {
+            abort(404);
+        }
+        $cdate_yesterday = $cdate->copy()->subDay();
+        $cdate_tomorrow = $cdate->copy()->addDay();
 
         $future_events = Event::where('events.start_at', '>', $cdate_yesterday->toDateString())
             ->with($this->cardEventEagerLoad())

--- a/app/Http/Controllers/PagesController.php
+++ b/app/Http/Controllers/PagesController.php
@@ -11,6 +11,7 @@ use App\Models\Series;
 use App\Models\Tag;
 use App\Models\Thread;
 use App\Models\User;
+use App\Services\EventDateRange;
 use App\Services\SearchService;
 use App\Services\SessionStore\ListParameterSessionStore;
 use Carbon\Carbon;
@@ -354,6 +355,8 @@ class PagesController extends Controller
         $prev_day = Carbon::parse($date)->subDays(1);
         $prev_day_window = Carbon::parse($date)->subDays($this->defaultWindow);
 
+        $dateRange = new EventDateRange();
+
         // handle the request if ajax
         if ($request->ajax()) {
             return view('events.4daysAjax-tw')
@@ -364,6 +367,10 @@ class PagesController extends Controller
                         'next_day_window' => $next_day_window,
                         'prev_day' => $prev_day,
                         'prev_day_window' => $prev_day_window,
+                        'hasPrev' => $dateRange->contains($prev_day),
+                        'hasPrevWindow' => $dateRange->contains($prev_day_window),
+                        'hasNext' => $dateRange->contains($next_day),
+                        'hasNextWindow' => $dateRange->contains($next_day_window),
                     ])
                     ->render();
         }
@@ -377,6 +384,10 @@ class PagesController extends Controller
                             'next_day_window' => $next_day_window,
                             'prev_day' => $prev_day,
                             'prev_day_window' => $prev_day_window,
+                            'hasPrev' => $dateRange->contains($prev_day),
+                            'hasPrevWindow' => $dateRange->contains($prev_day_window),
+                            'hasNext' => $dateRange->contains($next_day),
+                            'hasNextWindow' => $dateRange->contains($next_day_window),
                         ]
                     );
     }

--- a/app/Services/EventDateRange.php
+++ b/app/Services/EventDateRange.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Event;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Provides the date range covered by real event data, used to clamp
+ * date-navigable listings (/events/upcoming/{date}, /events/add/{date})
+ * so crawlers can't walk day-by-day into decades with no events.
+ */
+class EventDateRange
+{
+    protected const CACHE_KEY = 'event-date-range';
+    protected const CACHE_TTL = 3600;
+
+    /**
+     * @return array{min: Carbon, max: Carbon}
+     */
+    public function bounds(): array
+    {
+        $bounds = Cache::remember(self::CACHE_KEY, self::CACHE_TTL, function (): array {
+            $row = Event::query()
+                ->selectRaw('MIN(start_at) as min_start, MAX(start_at) as max_start')
+                ->toBase()
+                ->first();
+
+            return [
+                'min' => $row && $row->min_start ? (string) $row->min_start : null,
+                'max' => $row && $row->max_start ? (string) $row->max_start : null,
+            ];
+        });
+
+        return [
+            'min' => $bounds['min'] ? Carbon::parse($bounds['min']) : Carbon::now(),
+            'max' => $bounds['max'] ? Carbon::parse($bounds['max']) : Carbon::now(),
+        ];
+    }
+
+    public function contains(Carbon $date): bool
+    {
+        $bounds = $this->bounds();
+
+        return $date->between($bounds['min']->copy()->startOfDay(), $bounds['max']->copy()->endOfDay());
+    }
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,17 @@
 User-agent: MJ12bot
 Disallow: /
+
+User-agent: *
+Disallow: /*?sort=
+Disallow: /*?direction=
+Disallow: /*?limit=
+Disallow: /*?filters
+Disallow: /search
+Disallow: /go/
+Disallow: /users/
+Disallow: /events/add/
+Disallow: /events/grid
+Disallow: /*/rpp-reset
+Disallow: /*/reset
+
+Sitemap: https://arcane.city/sitemap.xml

--- a/resources/views/events/4days-tw.blade.php
+++ b/resources/views/events/4days-tw.blade.php
@@ -3,14 +3,22 @@
     <div class="flex flex-wrap items-stretch justify-center sm:justify-between gap-1 sm:gap-2 bg-card p-2 sm:p-4 rounded-lg border border-border shadow-sm min-w-0">
         <!-- Past Controls -->
         <div class="flex gap-1 sm:gap-2 flex-1 sm:flex-initial">
+            @if ($hasPrevWindow ?? true)
             {!! link_to_route('events.upcoming', '< Past Week', ['date' => $prev_day_window->format('Ymd')], ['class' => 'flex-1 sm:flex-initial px-2 sm:px-3 py-1.5 sm:py-2 text-xs sm:text-sm font-medium text-muted-foreground bg-card border border-border rounded-lg hover:bg-accent hover:text-foreground transition-colors whitespace-nowrap text-center']) !!}
+            @endif
+            @if ($hasPrev ?? true)
             {!! link_to_route('events.upcoming', '< Past Day', ['date' => $prev_day->format('Ymd')], ['class' => 'flex-1 sm:flex-initial px-2 sm:px-3 py-1.5 sm:py-2 text-xs sm:text-sm font-medium text-muted-foreground bg-card border border-border rounded-lg hover:bg-accent hover:text-foreground transition-colors whitespace-nowrap text-center']) !!}
+            @endif
         </div>
 
         <!-- Future Controls -->
         <div class="flex gap-1 sm:gap-2 flex-1 sm:flex-initial">
+            @if ($hasNext ?? true)
             {!! link_to_route('events.upcoming', 'Future Day >', ['date' => $next_day->format('Ymd')], ['class' => 'flex-1 sm:flex-initial px-2 sm:px-3 py-1.5 sm:py-2 text-xs sm:text-sm font-medium text-muted-foreground bg-card border border-border rounded-lg hover:bg-accent hover:text-foreground transition-colors whitespace-nowrap text-center']) !!}
+            @endif
+            @if ($hasNextWindow ?? true)
             {!! link_to_route('events.upcoming', 'Future Week >', ['date' => $next_day_window->format('Ymd')], ['class' => 'flex-1 sm:flex-initial px-2 sm:px-3 py-1.5 sm:py-2 text-xs sm:text-sm font-medium text-muted-foreground bg-card border border-border rounded-lg hover:bg-accent hover:text-foreground transition-colors whitespace-nowrap text-center']) !!}
+            @endif
         </div>
     </div>
 
@@ -25,7 +33,9 @@
     </div>
 
     <!-- Next Events Button -->
+    @if ($hasNextWindow ?? true)
     <div class="flex justify-center mt-4 sm:mt-6" id="next-events">
         {!! link_to_route('events.add', 'Load Next Events', ['date' => $next_day_window->format('Ymd')], ['id' => 'add-event', 'class' => 'px-4 sm:px-6 py-2.5 sm:py-3 bg-accent text-foreground border-2 border-primary font-semibold text-sm sm:text-base rounded-lg hover:bg-accent/80 transition-colors shadow-lg next-events whitespace-nowrap']) !!}
     </div>
+    @endif
 </div>

--- a/resources/views/events/4daysAjax-tw.blade.php
+++ b/resources/views/events/4daysAjax-tw.blade.php
@@ -3,14 +3,22 @@
     <div class="flex flex-wrap items-center justify-between gap-4 bg-card p-4 rounded-lg border border-border shadow-sm">
         <!-- Past Controls -->
         <div class="flex gap-2">
+            @if ($hasPrevWindow ?? true)
             {!! link_to_route('events.upcoming', '< Past Week', ['date' => $prev_day_window->format('Ymd')], ['class' => 'px-3 py-2 text-sm font-medium text-muted-foreground bg-card border border-border rounded-lg hover:bg-accent hover:text-foreground transition-colors whitespace-nowrap']) !!}
+            @endif
+            @if ($hasPrev ?? true)
             {!! link_to_route('events.upcoming', '< Past Day', ['date' => $prev_day->format('Ymd')], ['class' => 'px-3 py-2 text-sm font-medium text-muted-foreground bg-card border border-border rounded-lg hover:bg-accent hover:text-foreground transition-colors whitespace-nowrap']) !!}
+            @endif
         </div>
 
         <!-- Future Controls -->
         <div class="flex gap-2">
+            @if ($hasNext ?? true)
             {!! link_to_route('events.upcoming', 'Future Day >', ['date' => $next_day->format('Ymd')], ['class' => 'px-3 py-2 text-sm font-medium text-muted-foreground bg-card border border-border rounded-lg hover:bg-accent hover:text-foreground transition-colors whitespace-nowrap']) !!}
+            @endif
+            @if ($hasNextWindow ?? true)
             {!! link_to_route('events.upcoming', 'Future Week >', ['date' => $next_day_window->format('Ymd')], ['class' => 'px-3 py-2 text-sm font-medium text-muted-foreground bg-card border border-border rounded-lg hover:bg-accent hover:text-foreground transition-colors whitespace-nowrap']) !!}
+            @endif
         </div>
     </div>
 
@@ -25,9 +33,11 @@
     </div>
 
     <!-- Next Events Button -->
+    @if ($hasNextWindow ?? true)
     <div class="flex justify-center" id="next-events">
         {!! link_to_route('events.add', 'Load Next Events', ['date' => $next_day_window->format('Ymd')], ['id' => 'add-event', 'class' => 'px-6 py-3 bg-accent text-foreground border-2 border-primary font-semibold rounded-lg hover:bg-accent/80 transition-colors shadow-lg next-events whitespace-nowrap']) !!}
     </div>
+    @endif
 
     <script type="text/javascript">
         // init app module on document load

--- a/resources/views/events/addDays-tw.blade.php
+++ b/resources/views/events/addDays-tw.blade.php
@@ -9,6 +9,8 @@
 </div>
 
 <!-- Next Events Button -->
+@if ($hasNextWindow ?? true)
 <div class="flex justify-center mt-6" id="next-events">
 	{!! link_to_route('events.add', 'Load Next Events', ['date' => $next_day_window->format('Ymd')], ['id' => 'add-event', 'class' => 'px-6 py-3 bg-accent text-foreground border-2 border-primary font-semibold rounded-lg hover:bg-accent/80 transition-colors shadow-lg next-events whitespace-nowrap']) !!}
 </div>
+@endif

--- a/resources/views/events/upcoming-tw.blade.php
+++ b/resources/views/events/upcoming-tw.blade.php
@@ -2,6 +2,16 @@
 
 @section('title'){{ config('app.tagline')}}@endsection
 
+{{-- dated variants are navigation state, not distinct pages --}}
+@if (($date ?? '') !== '')
+@section('canonical')
+<link rel="canonical" href="{{ url('/events/upcoming') }}">
+@endsection
+@section('meta.robots')
+<meta name="robots" content="noindex, follow">
+@endsection
+@endif
+
 @section('content')
 
 <!-- Hero Section -->

--- a/resources/views/pages/search.blade.php
+++ b/resources/views/pages/search.blade.php
@@ -2,6 +2,10 @@
 
 @section('title','Search Results')
 
+@section('meta.robots')
+<meta name="robots" content="noindex, follow">
+@endsection
+
 @section('content')
 
 <!-- Page Header -->

--- a/routes/web.php
+++ b/routes/web.php
@@ -276,7 +276,8 @@ Route::get('events/add/{date?}', 'EventsController@indexAdd')->name('events.add'
     ->where('date', '[1-2][0-9][0-9][0-9][0-3][0-9][0-9][0-9]');    
 Route::get('events/past', 'EventsController@indexPast');
 Route::get('events/week', 'EventsController@indexWeek')->name('events.week');
-Route::get('events/starting/{date}', 'EventsController@indexStarting');
+Route::get('events/starting/{date}', 'EventsController@indexStarting')
+    ->where('date', '[0-9]{8}|[0-9]{4}-[0-9]{2}-[0-9]{2}');
 Route::get('events/{id}/load-embeds', 'EventsController@loadEmbeds');
 Route::get('events/{id}/load-minimal-embeds', 'EventsController@loadMinimalEmbeds');
 Route::get('events/{slug}/minimal-embeds', 'EventsController@loadMinimalEmbedsBySlug');
@@ -285,14 +286,9 @@ Route::get('events/by-date/{year}/{month?}/{day?}', 'EventsController@indexByDat
     ->where('year', '[1-9][0-9][0-9][0-9]')
     ->where('month', '(0?[1-9]|1[012])$')
     ->where('day', '(0?[1-9]|[12][0-9]|3[01])');
-// Use this route for the front page to display a window of events
-Route::get('events/window/{year}/{month?}/{day?}', 'EventsController@indexWindow')
-    ->where('year', '[1-9][0-9][0-9][0-9]')
-    ->where('month', '(0?[1-9]|1[012])$')
-    ->where('day', '[0-3][0-9]');
 Route::get('events/daily', 'EventsController@daily');
 Route::get('events/day/{day}', 'EventsController@day')->name('events.day')
-    ->where('day', '[1-2][0-9][0-9][0-9]-[0-3][0-9]-[0-9][0-9]');    
+    ->where('day', '[12][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])');
 Route::match(['get', 'post'], 'events/attending', 'EventsController@indexAttending')->name('events.attending');
 Route::match(['get', 'post'], 'events/filter', ['as' => 'events.filter', 'uses' => 'EventsController@filter']);
 Route::get('events/apply-filter', ['as' => 'events.applyFilterFromUrl', 'uses' => 'EventsController@applyFilterFromUrl']);

--- a/tests/Feature/ClickTrackingTest.php
+++ b/tests/Feature/ClickTrackingTest.php
@@ -59,13 +59,15 @@ class ClickTrackingTest extends TestCase
     }
 
     /** @test */
-    public function nonexistent_event_redirects_to_home()
+    public function nonexistent_event_returns_not_found()
     {
+        $this->withExceptionHandling();
+
         // Visit the tracking URL for non-existent event
         $response = $this->get('/go/evt-99999');
 
-        // Assert redirect to home
-        $response->assertRedirect(route('home'));
+        // A tracking link for a missing event is a dead URL, not a redirect
+        $response->assertNotFound();
 
         // Assert no click was tracked
         $this->assertEquals(0, ClickTrack::count());

--- a/tests/Feature/SeoGuardsTest.php
+++ b/tests/Feature/SeoGuardsTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\User;
+use App\Models\Visibility;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class SeoGuardsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withExceptionHandling();
+
+        // the date-range clamp caches MIN/MAX(start_at); keep runs isolated
+        Cache::forget('event-date-range');
+    }
+
+    protected function createEventOn(string $date): Event
+    {
+        return Event::factory()->create([
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => $date . ' 20:00:00',
+            'created_by' => User::factory()->create()->id,
+        ]);
+    }
+
+    public function test_upcoming_with_date_outside_event_range_returns_404(): void
+    {
+        $this->createEventOn(now()->format('Y-m-d'));
+
+        $this->get('/events/upcoming/20990101')->assertNotFound();
+        $this->get('/events/upcoming/19900101')->assertNotFound();
+    }
+
+    public function test_upcoming_with_date_inside_event_range_returns_200(): void
+    {
+        $this->createEventOn(now()->subDay()->format('Y-m-d'));
+        $this->createEventOn(now()->addDays(10)->format('Y-m-d'));
+
+        $this->get('/events/upcoming/' . now()->format('Ymd'))->assertOk();
+    }
+
+    public function test_dated_upcoming_page_is_noindexed_and_canonicalized(): void
+    {
+        $this->createEventOn(now()->format('Y-m-d'));
+
+        $response = $this->get('/events/upcoming/' . now()->format('Ymd'));
+
+        $response->assertOk();
+        $response->assertSee('noindex, follow', false);
+        $response->assertSee('<link rel="canonical" href="' . url('/events/upcoming') . '">', false);
+    }
+
+    public function test_undated_upcoming_page_is_not_noindexed(): void
+    {
+        $this->createEventOn(now()->format('Y-m-d'));
+
+        $this->get('/events/upcoming')->assertOk()->assertDontSee('noindex', false);
+    }
+
+    public function test_add_with_date_outside_event_range_returns_404(): void
+    {
+        $this->createEventOn(now()->format('Y-m-d'));
+
+        $this->get('/events/add/20990101')->assertNotFound();
+    }
+
+    public function test_upcoming_with_unparseable_date_returns_404(): void
+    {
+        $this->get('/events/upcoming/www.example.com')->assertNotFound();
+    }
+
+    public function test_starting_with_junk_date_returns_404(): void
+    {
+        $this->get('/events/starting/junk')->assertNotFound();
+        $this->get('/events/starting/2026-99-99')->assertNotFound();
+    }
+
+    public function test_starting_with_valid_date_returns_200(): void
+    {
+        $this->createEventOn(now()->format('Y-m-d'));
+
+        $this->get('/events/starting/' . now()->format('Y-m-d'))->assertOk();
+    }
+
+    public function test_day_route_rejects_invalid_dates(): void
+    {
+        $this->get('/events/day/2026-19-99')->assertNotFound();
+    }
+
+    public function test_day_route_accepts_valid_date(): void
+    {
+        $this->get('/events/day/' . now()->format('Y-m-d'))->assertOk();
+    }
+
+    public function test_window_route_is_removed(): void
+    {
+        $this->get('/events/window/2026')->assertNotFound();
+    }
+
+    public function test_go_route_with_missing_event_returns_404(): void
+    {
+        $this->get('/go/evt-999999')->assertNotFound();
+        $this->get('/go/ser-999999')->assertNotFound();
+    }
+
+    public function test_search_page_is_noindexed(): void
+    {
+        $this->get('/search?keyword=test')->assertOk()->assertSee('noindex, follow', false);
+    }
+
+    public function test_robots_txt_blocks_crawl_waste_paths(): void
+    {
+        $robots = file_get_contents(public_path('robots.txt'));
+
+        foreach ([
+            'Disallow: /search',
+            'Disallow: /go/',
+            'Disallow: /users/',
+            'Disallow: /events/add/',
+            'Disallow: /events/grid',
+            'Disallow: /*/rpp-reset',
+            'Disallow: /*?sort=',
+        ] as $line) {
+            $this->assertStringContainsString($line, $robots);
+        }
+
+        $this->assertStringContainsString('Sitemap:', $robots);
+    }
+}

--- a/tests/Feature/Web/EventsControllerTest.php
+++ b/tests/Feature/Web/EventsControllerTest.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use App\Models\UserStatus;
 use App\Models\Visibility;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
@@ -56,7 +57,11 @@ class EventsControllerTest extends TestCase
 
     public function test_index_upcoming_with_valid_date_loads(): void
     {
-        $this->get('/events/upcoming/2026-06-16')->assertOk();
+        // dated variants only resolve inside the range of real event data
+        Event::factory()->create(['start_at' => now()]);
+        Cache::forget('event-date-range');
+
+        $this->get('/events/upcoming/'.now()->format('Ymd'))->assertOk();
     }
 
     public function test_index_upcoming_with_invalid_date_returns_404(): void


### PR DESCRIPTION
Part 1 of #2001 (priority items 4a, 4e, 4f, 5 + robots.txt) — the highest-impact application-side sources of soft-404s and crawl waste.

## Changes

**robots.txt** — adds a `User-agent: *` block disallowing filter-param URL permutations (`?sort=`, `?direction=`, `?limit=`, `?filters`), `/search`, `/go/`, `/users/`, `/events/add/`, `/events/grid`, and all `*/reset` + `*/rpp-reset` endpoints, plus a `Sitemap:` line. Note: `/*/reset` also matches `/password/reset` — intentional, auth pages shouldn't be crawled.

**Date-corridor clamp (issue item 4a — ~49% of sampled prod soft-404s).** GSC shows Googlebot has walked the unbounded prev/next day links on `/events/upcoming/{date}` and `/events/add/{date}` from 2003 to 2043. Now:
- New `EventDateRange` service caches `MIN/MAX(events.start_at)` (1h TTL).
- Dated requests outside that range 404.
- Prev/next day/week nav links are suppressed at the data boundary (`events/4days-tw`, `4daysAjax-tw`, `addDays-tw`; booleans default to visible for unmodified callers).
- Dated `/events/upcoming/{date}` variants emit `noindex,follow` + canonical to `/events/upcoming` — the undated page is the one worth indexing.

**Search (4e)** — `/search` results page emits `noindex,follow` (robots.txt also blocks it).

**Click-tracking (4f)** — `/go/evt-{id}` / `/go/ser-{id}` for nonexistent records now 404 instead of 302ing to the homepage (GSC reported these as soft-404s). Existing-record behavior unchanged.

**5xx guards (item 5)**
- Removed the `events/window/...` route — it mapped to `EventsController@indexWindow`, which has never existed in the repo's history (fatal `BadMethodCallException` on every hit).
- `events/starting/{date}`: added a route date constraint and a try/catch → 404 around the previously unguarded `Carbon::parse`.
- `events/day/{day}`: fixed the malformed date regex (previously accepted `2026-39-99` shapes) and guarded its `Carbon::parse`.

## Tests

- New `tests/Feature/SeoGuardsTest.php` (14 tests) covering the clamp bounds, noindex/canonical emission, junk-date 404s, removed route, `/go/` 404s, and robots.txt content.
- `ClickTrackingTest::nonexistent_event_redirects_to_home` updated to expect 404 (intentional behavior change).
- `EventsControllerTest::test_index_upcoming_with_valid_date_loads` updated: it hard-coded a date that falls outside the seeded event range under the new clamp; it now creates an event on the requested date.
- Full suite: 1002 tests green; PHPStan level 3 clean, no new baseline entries.

Refs #2001

🤖 Generated with [Claude Code](https://claude.com/claude-code)