### PR TITLE
SEO: rebuild sitemap DB-driven, split by type (issue #2001, part 2)

### DIFF
--- a/app/Console/Commands/GenerateSitemap.php
+++ b/app/Console/Commands/GenerateSitemap.php
@@ -2,241 +2,249 @@
 
 namespace App\Console\Commands;
 
+use App\Models\Blog;
 use App\Models\Entity;
 use App\Models\Event;
 use App\Models\Series;
+use App\Models\Tag;
+use App\Models\Visibility;
+use Carbon\Carbon;
 use Illuminate\Console\Command;
-use Psr\Http\Message\UriInterface;
+use Illuminate\Database\Eloquent\Model;
 use Spatie\Sitemap\Sitemap;
-use Spatie\Sitemap\SitemapGenerator;
+use Spatie\Sitemap\SitemapIndex;
+use Spatie\Sitemap\Tags\Sitemap as SitemapTag;
 use Spatie\Sitemap\Tags\Url;
 
 class GenerateSitemap extends Command
 {
     /**
-     * The console command name.
+     * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'sitemap:generate';
+    protected $signature = 'sitemap:generate {--path= : Directory to write sitemap files into (defaults to public/)}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Generate the sitemap.';
+    protected $description = 'Generate a sitemap index and per-type sitemaps from the database';
 
     /**
-     * Execute the console command.
-     *
-     * @return mixed
+     * Sitemap spec allows 50k URLs per file; leave headroom.
      */
-    public function handle()
+    protected const MAX_URLS_PER_FILE = 45000;
+
+    /**
+     * Static landing pages worth indexing. Keep in sync with routes/web.php.
+     */
+    protected const PAGES = [
+        '/',
+        '/events',
+        '/entities',
+        '/series',
+        '/tags',
+        '/blogs',
+        '/calendar',
+    ];
+
+    protected string $baseUrl;
+
+    public function handle(): int
     {
-        $this->line('<fg=white;bg=black>Creating sitemap for: '.config('app.url').'</>');
-        $this->line('<fg=white;bg=green>Output to '.public_path('sitemap.xml').'</>');
-        // modify this to your own needs
-        $sitemap = SitemapGenerator::create(config('app.url'))
-            ->hasCrawled(function (Url $url) {
-                if (strpos($url->segment(1), 'email') !== false) {
-                    return;
-                }
+        $path = rtrim($this->option('path') ?: public_path(), '/');
+        $this->baseUrl = rtrim(config('app.url'), '/');
 
-                // skip the redirect page
-                if (strpos($url->segment(1), 'redirect') !== false) {
-                    return;
-                }
+        $this->info('Generating sitemaps for '.$this->baseUrl.' into '.$path);
 
-                // skip click tracking redirect links
-                if (strpos($url->segment(1), 'go') !== false) {
-                    return;
-                }
+        $index = SitemapIndex::create();
 
-                // skip user tabs
-                if (strpos($url->url, '?') !== false) {
-                    return;
-                }
+        $sections = [
+            'pages' => $this->pageUrls(),
+            'events' => $this->eventUrls(),
+            'entities' => $this->entityUrls(),
+            'series' => $this->seriesUrls(),
+            'tags' => $this->tagUrls(),
+            'blogs' => $this->blogUrls(),
+        ];
 
-                // skip event add links
-                if (strpos($url->path(), '/events/add') !== false) {
-                    return;
-                }               
-                                    
-                // skip create routes
-                if (strpos($url->path(), '/create') !== false) {
-                    return;
+        foreach ($sections as $name => $urls) {
+            foreach ($this->writeChunked($name, $urls, $path) as [$file, $count, $lastmod]) {
+                $entry = SitemapTag::create($this->baseUrl.'/'.$file);
+                if ($lastmod) {
+                    $entry->setLastModificationDate($lastmod);
                 }
+                $index->add($entry);
+                $this->info(sprintf('  %s: %d urls', $file, $count));
+            }
+        }
 
-                // skip edit links
-                if (strpos($url->path(), '/edit') !== false) {
-                    return;
+        $index->writeToFile($path.'/sitemap.xml');
+        $this->info('Wrote sitemap index to '.$path.'/sitemap.xml');
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Write a section's URLs into one or more sitemap files, splitting at
+     * MAX_URLS_PER_FILE. Returns [filename, url count, max lastmod] per file.
+     *
+     * @param iterable<Url> $urls
+     * @return array<array{0: string, 1: int, 2: Carbon|null}>
+     */
+    protected function writeChunked(string $name, iterable $urls, string $path): array
+    {
+        $files = [];
+        $sitemap = Sitemap::create();
+        $count = 0;
+        $chunk = 1;
+        $lastmod = null;
+
+        $flush = function () use (&$files, &$sitemap, &$count, &$chunk, &$lastmod, $name, $path) {
+            if ($count === 0) {
+                return;
+            }
+            $file = 'sitemap-'.$name.($chunk > 1 ? '-'.$chunk : '').'.xml';
+            $sitemap->writeToFile($path.'/'.$file);
+            $files[] = [$file, $count, $lastmod];
+            $sitemap = Sitemap::create();
+            $count = 0;
+            $chunk++;
+            $lastmod = null;
+        };
+
+        foreach ($urls as $url) {
+            $sitemap->add($url);
+            $count++;
+            // lastModificationDate is a typed property left uninitialized on
+            // URLs without a lastmod (e.g. static pages)
+            if (isset($url->lastModificationDate) && (!$lastmod || $url->lastModificationDate > $lastmod)) {
+                $lastmod = Carbon::instance($url->lastModificationDate);
+            }
+            if ($count >= self::MAX_URLS_PER_FILE) {
+                $flush();
+            }
+        }
+        $flush();
+
+        return $files;
+    }
+
+    /**
+     * @return iterable<Url>
+     */
+    protected function pageUrls(): iterable
+    {
+        foreach (self::PAGES as $page) {
+            yield Url::create($this->baseUrl.$page);
+        }
+    }
+
+    /**
+     * @return iterable<Url>
+     */
+    protected function eventUrls(): iterable
+    {
+        // deliberately NOT scopeVisible(null): that also matches proposal or
+        // private events with a null creator — the sitemap wants public only
+        $query = Event::query()
+            ->where('visibility_id', Visibility::VISIBILITY_PUBLIC)
+            ->select(['id', 'slug', 'updated_at']);
+
+        foreach ($this->slugUrls($query, 'events') as $url) {
+            yield $url;
+        }
+    }
+
+    /**
+     * @return iterable<Url>
+     */
+    protected function entityUrls(): iterable
+    {
+        $blacklist = array_filter(explode(',', (string) config('app.spider_blacklist')));
+
+        $query = Entity::query()->active()->select(['id', 'slug', 'updated_at']);
+
+        foreach ($this->slugUrls($query, 'entities') as $url) {
+            foreach ($blacklist as $item) {
+                if ($url->url === $this->baseUrl.'/entities/'.$item) {
+                    continue 2;
                 }
+            }
+            yield $url;
+        }
+    }
 
-                // skip upcoming events links
-                if (strpos($url->path(), '/events/upcoming') !== false) {
-                    return;
+    /**
+     * @return iterable<Url>
+     */
+    protected function seriesUrls(): iterable
+    {
+        $query = Series::query()
+            ->where('visibility_id', Visibility::VISIBILITY_PUBLIC)
+            ->select(['id', 'slug', 'updated_at']);
+
+        foreach ($this->slugUrls($query, 'series') as $url) {
+            yield $url;
+        }
+    }
+
+    /**
+     * @return iterable<Url>
+     */
+    protected function tagUrls(): iterable
+    {
+        $query = Tag::query()->hasContent()->select(['id', 'slug', 'updated_at']);
+
+        foreach ($this->slugUrls($query, 'tags') as $url) {
+            yield $url;
+        }
+    }
+
+    /**
+     * @return iterable<Url>
+     */
+    protected function blogUrls(): iterable
+    {
+        $query = Blog::query()
+            ->where('visibility_id', Visibility::VISIBILITY_PUBLIC)
+            ->select(['id', 'slug', 'updated_at']);
+
+        foreach ($this->slugUrls($query, 'blogs') as $url) {
+            yield $url;
+        }
+    }
+
+    /**
+     * Yield canonical slug URLs for a model query, chunked to keep memory flat.
+     * Skips rows whose slug is empty, purely numeric (route binding treats
+     * those as ids), or not a clean lowercase slug (junk data like URLs or
+     * names with spaces stored as slugs).
+     *
+     * @param \Illuminate\Database\Eloquent\Builder<covariant Model> $query
+     * @return iterable<Url>
+     */
+    protected function slugUrls($query, string $prefix): iterable
+    {
+        $urls = [];
+
+        $query->chunkById(1000, function ($models) use (&$urls, $prefix) {
+            foreach ($models as $model) {
+                $slug = strtolower((string) $model->getAttribute('slug'));
+                if ($slug === '' || ctype_digit($slug) || !preg_match('/^[a-z0-9-]+$/', $slug)) {
+                    continue;
                 }
-
-                // skip upcoming links
-                if (strpos($url->path(), '/upcoming') !== false) {
-                    return;
+                $url = Url::create($this->baseUrl.'/'.$prefix.'/'.$slug);
+                $updatedAt = $model->getAttribute('updated_at');
+                if ($updatedAt) {
+                    $url->setLastModificationDate($updatedAt);
                 }
+                $urls[] = $url;
+            }
+        });
 
-                // skip user links
-                if (strpos($url->path(), '/users') !== false) {
-                    return;
-                }
-
-                // skip follow links
-                if (strpos($url->path(), '/follow') !== false) {
-                    return;
-                }
-
-                // skip events/related-to pages - filtered list pages, not canonical content
-                if (strpos($url->path(), '/events/related-to') !== false) {
-                    return;
-                }
-
-                // skip day_offset urls
-                if (strpos($url->segment(1), '?day_offset') !== false) {
-                    return;
-                }
-
-                // skip day_offset urls
-                if (strpos($url->segment(1), '?day_offset') !== false) {
-                    return;
-                }
-
-                // skip some specific urls
-                if (strpos($url->segment(2), 'export') !== false) {
-                    return;
-                }
-
-                if (strpos($url->segment(2), 'ical') !== false) {
-                    return;
-                }
-
-                if (strpos($url->segment(2), 'rpp-reset') !== false) {
-                    return;
-                }
-            
-                if (strpos($url->segment(2), 'alias') !== false) {
-                    return;
-                }
-
-                // blacklist entities in the config
-                if ($blacklist = config('app.spider_blacklist')) {
-                    $blacklistArray = explode(',', $blacklist);
-                    foreach ($blacklistArray as $item) {
-                        if ($url->path() === '/entities/'.$item) {
-                            return;
-                        }
-                    }
-                }
-
-                // if an event, get the event's updated at time and use
-                if ($url->segment(1) === 'events' && is_numeric($url->segment(2))) {
-                    $event = Event::find($url->segment(2));
-                    $url->setLastModificationDate($event->updated_at);
-                }
-
-                // if an event, get the event's updated at time and use
-                if ($url->segment(1) === 'events' && gettype($url->segment(2)) === 'string' && $url->segment(2) !== 'related-to' && $url->segment(2) !== 'upcoming' && $url->segment(2) !== 'tag' && $url->segment(2) != 'role' && $url->segment(2) != 'type') {
-                    $slug = $url->segment(2);
-                    $event = Event::where('slug', '=', $slug)->first();
-                    if ($event) {
-                        $url->setLastModificationDate($event->updated_at);
-                    } else {
-                        if ($url->url !== null) {
-                            $this->line('<fg=yellow>Could not find event for URL: ' . $url->url . '</>');
-                        }
-                    }
-                    return $url;
-                }
-
-                // if a series, get the event's updated at time and use
-                if ($url->segment(1) === 'series' && gettype($url->segment(2)) === 'string' && $url->segment(2) !== 'tag' && $url->segment(2) != 'role') {
-                    $slug = $url->segment(2);
-                    $series = Series::where('slug', '=', $slug)->first();
-                    if ($series) {
-                        $url->setLastModificationDate($series->updated_at);
-                    } else {
-                        if ($url->url !== null) {
-                            $this->line('<fg=yellow>Could not find series for URL: ' . $url->url . '</>');
-                        }
-                    }
-                }
-
-                // if an entity, get the entities's updated at time and use
-                if ($url->segment(1) === 'entities' && gettype($url->segment(2)) === 'string' && $url->segment(2) !== 'tag' && $url->segment(2) != 'role') {
-                    $slug = $url->segment(2);
-                    $entity = Entity::where('slug', '=', $slug)->first();
-                    if ($entity) {
-                        $url->setLastModificationDate($entity->updated_at);
-                    } else {
-                        if ($url->url !== null) {
-                            $this->line('<fg=yellow>Could not find entity for URL: ' . $url->url . '</>');
-                        }
-                    }
-                }
-
-                return $url;
-            })
-            ->shouldCrawl(function (UriInterface $url) {
-                // Skip click tracking redirect links
-                if (strpos($url->getPath(), '/go/') !== false) {
-                    return false;
-                }
-
-                // Skip events/add links
-                if (strpos($url->getPath(), '/events/add') !== false) {
-                    return false;
-                }
-
-                // Skip events/upcoming links
-                if (strpos($url->getPath(), '/events/upcoming') !== false) {
-                    return false;
-                }
-
-                // Skip events by-date
-                if (strpos($url->getPath(), '/events/by-date') !== false) {
-                    return false;
-                }
-
-                // Skip events/related-to - filtered list pages, not canonical content
-                if (strpos($url->getPath(), '/events/related-to') !== false) {
-                    return false;
-                }
-
-                // Links present on the photos page won't be added to the
-                // sitemap unless they are present on a crawlable page.
-                if (strpos($url->getPath(), '/photos') !== false) {
-                    return false;
-                }
-
-                // blacklist entities in the config
-                // if ($blacklist = config('app.spider_blacklist')) {
-                //     $blacklistArray = explode(',', $blacklist);
-                //     foreach ($blacklistArray as $item) {
-                //         if ($url->getPath() === '/entities/'.$item) {
-                //             return;
-                //         }
-                //     }
-                // }
-
-                return strpos($url->getPath(), '/storage') === false;
-            })
-            ->maxTagsPerSitemap(10000)
-            ->setMaximumCrawlCount(10000)
-            ->getSitemap();
-        
-        // Explicitly add important pages that might be missed by the crawler
-        $sitemap->add(Url::create(config('app.url') . '/events')
-            ->setPriority(0.9)
-            ->setChangeFrequency(Url::CHANGE_FREQUENCY_DAILY));
-        
-        // Write the sitemap to file
-        $sitemap->writeToFile(public_path('sitemap.xml'));
+        return $urls;
     }
 }

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -78,6 +78,25 @@ class Tag extends Eloquent
     }
 
     /**
+     * Limit to tags attached to at least one publicly visible piece of content
+     * (public event, active entity, or non-cancelled series). Used by the
+     * sitemap generator and anywhere an empty tag page shouldn't be surfaced.
+     */
+    public function scopeHasContent(Builder $query): Builder
+    {
+        return $query->where(function (Builder $q) {
+            $q->whereHas('events', function (Builder $event) {
+                $event->where('events.visibility_id', Visibility::VISIBILITY_PUBLIC);
+            })->orWhereHas('entities', function (Builder $entity) {
+                /* @phpstan-ignore-next-line */
+                $entity->active();
+            })->orWhereHas('series', function (Builder $series) {
+                $series->where('series.visibility_id', Visibility::VISIBILITY_PUBLIC);
+            });
+        });
+    }
+
+    /**
      * Adds a grid_thumbnail subquery select — returns the thumbnail path of the most recent
      * public event photo, falling back to the most recently created entity photo.
      */

--- a/tests/Feature/Console/GenerateSitemapCommandTest.php
+++ b/tests/Feature/Console/GenerateSitemapCommandTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use App\Models\Event;
+use App\Models\Series;
+use App\Models\Tag;
+use App\Models\Visibility;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GenerateSitemapCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected string $outputPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->outputPath = sys_get_temp_dir().'/sitemap-test-'.uniqid();
+        mkdir($this->outputPath, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->outputPath.'/*.xml') ?: [] as $file) {
+            unlink($file);
+        }
+        @rmdir($this->outputPath);
+
+        parent::tearDown();
+    }
+
+    protected function generate(): string
+    {
+        $this->artisan('sitemap:generate', ['--path' => $this->outputPath])->assertSuccessful();
+
+        $all = '';
+        foreach (glob($this->outputPath.'/sitemap-*.xml') ?: [] as $file) {
+            $all .= file_get_contents($file);
+        }
+
+        return $all;
+    }
+
+    public function test_generates_index_and_per_type_sitemaps(): void
+    {
+        $this->artisan('sitemap:generate', ['--path' => $this->outputPath])->assertSuccessful();
+
+        $this->assertFileExists($this->outputPath.'/sitemap.xml');
+
+        $index = simplexml_load_file($this->outputPath.'/sitemap.xml');
+        $this->assertNotFalse($index);
+        $this->assertSame('sitemapindex', $index->getName());
+
+        $indexContent = (string) file_get_contents($this->outputPath.'/sitemap.xml');
+        $this->assertStringContainsString('sitemap-pages.xml', $indexContent);
+
+        foreach (glob($this->outputPath.'/sitemap-*.xml') ?: [] as $file) {
+            $xml = simplexml_load_file($file);
+            $this->assertNotFalse($xml, $file.' is not valid XML');
+            $this->assertSame('urlset', $xml->getName());
+        }
+    }
+
+    public function test_includes_public_content_and_excludes_non_public(): void
+    {
+        $public = Event::factory()->create([
+            'slug' => 'sitemap-public-event',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+        Event::factory()->create([
+            'slug' => 'sitemap-private-event',
+            'visibility_id' => Visibility::VISIBILITY_PRIVATE,
+        ]);
+        Series::factory()->create([
+            'slug' => 'sitemap-cancelled-series',
+            'visibility_id' => Visibility::VISIBILITY_CANCELLED,
+        ]);
+
+        $tagWithContent = Tag::factory()->create(['name' => 'Sitemap Tag', 'slug' => 'sitemap-tag']);
+        $public->tags()->attach($tagWithContent->id);
+        Tag::factory()->create(['name' => 'Sitemap Orphan', 'slug' => 'sitemap-orphan-tag']);
+
+        $content = $this->generate();
+
+        $base = rtrim(config('app.url'), '/');
+        $this->assertStringContainsString($base.'/events/sitemap-public-event', $content);
+        $this->assertStringNotContainsString('sitemap-private-event', $content);
+        $this->assertStringNotContainsString('sitemap-cancelled-series', $content);
+        $this->assertStringContainsString($base.'/tags/sitemap-tag', $content);
+        $this->assertStringNotContainsString('sitemap-orphan-tag', $content);
+    }
+
+    public function test_skips_junk_and_numeric_slugs(): void
+    {
+        Event::factory()->create([
+            'slug' => 'www.junk-url.com',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+
+        $content = $this->generate();
+
+        $this->assertStringNotContainsString('www.junk-url.com', $content);
+    }
+
+    public function test_no_url_matches_exclusion_patterns(): void
+    {
+        Event::factory()->create([
+            'slug' => 'sitemap-clean-event',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+
+        $content = $this->generate();
+
+        preg_match_all('#<loc>(.*?)</loc>#', $content, $matches);
+        $this->assertNotEmpty($matches[1]);
+
+        $base = preg_quote(rtrim(config('app.url'), '/'), '#');
+        $forbidden = '#(\?|%20|/go/|/search|/users|/events/add|/grid|/rpp-reset|/reset$|/alias|/export|/ical|/feed|/create|/edit|/login|/register|/password)#';
+
+        foreach ($matches[1] as $loc) {
+            $this->assertMatchesRegularExpression('#^'.$base.'#', $loc, 'URL not on canonical host: '.$loc);
+            $this->assertDoesNotMatchRegularExpression($forbidden, $loc, 'Excluded pattern in sitemap: '.$loc);
+            $path = parse_url($loc, PHP_URL_PATH) ?? '';
+            $this->assertSame(strtolower($path), $path, 'Non-lowercase URL in sitemap: '.$loc);
+        }
+    }
+
+    public function test_lastmod_uses_updated_at(): void
+    {
+        $event = Event::factory()->create([
+            'slug' => 'sitemap-lastmod-event',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+
+        $content = $this->generate();
+
+        $this->assertMatchesRegularExpression(
+            '#<loc>[^<]*/events/sitemap-lastmod-event</loc>\s*<lastmod>'.$event->updated_at->format('Y-m-d').'#s',
+            $content
+        );
+    }
+}


### PR DESCRIPTION
Part 2 of #2001 (priority item 3). The live sitemap audit in the issue showed the crawler-generated sitemap was the mechanism actively submitting junk to Google: auth pages, state-changing reset endpoints, alias redirects, case/encoding-duplicated taxonomy URLs, the `by-date` corridor back to 1996, and identical `priority`/`changefreq` on every URL — all on the wrong host.

## Changes

**`GenerateSitemap` rewritten** from Spatie's crawler (`SitemapGenerator` + skip-lists, capped at 10k URLs) to DB-driven generation (`Sitemap::create()` + `SitemapIndex`):

| File | Contents |
|---|---|
| `sitemap-pages.xml` | homepage + real landing pages |
| `sitemap-events.xml` | public events, slug route only |
| `sitemap-entities.xml` | active entities, slug only, honors `SPIDER_BLACKLIST` |
| `sitemap-series.xml` | public series |
| `sitemap-tags.xml` | one canonical `/tags/{slug}` per tag with public content |
| `sitemap-blogs.xml` | public blogs |

Rules enforced by the generator:
- Only canonical slug routes — skips empty, purely-numeric (Event/Series route binding treats numerics as ids), and junk slugs (stored URLs, spaces, uppercase). No aliases, no role URLs, no listings.
- Events use `visibility_id = PUBLIC` directly rather than `scopeVisible(null)`, which also matches proposal/private rows with a null creator.
- Real `<lastmod>` from `updated_at`; `priority`/`changefreq` omitted entirely (uniform values are a discarded signal).
- Absolute URLs from `config('app.url')` so the sitemap host can't drift from the canonical host.
- `chunkById(1000)` queries; files split at 45k URLs (spec limit 50k) with `sitemap-{type}-2.xml` continuation naming.

**New `Tag::scopeHasContent`** — tags attached to ≥1 public event, active entity, or public series. Reused later by the empty-cross-listing work (issue item 4d).

**`--path=` option** (defaults to `public/`) so tests generate into a scratch directory. The `sitemap:generate` signature and weekly schedule in `Kernel.php` are unchanged.

## Tests

New `tests/Feature/Console/GenerateSitemapCommandTest.php` (5 tests, 43 assertions): index + per-type structure and XML validity, public-vs-private/cancelled inclusion rules, tag-with-content vs orphan tag, junk-slug skipping, `lastmod` from `updated_at`, and the issue-required assertion that no generated `<loc>` matches the exclusion patterns (query strings, `/go/`, `/search`, `/users`, `/events/add`, grid, reset endpoints, aliases, exports, uppercase, non-canonical host).

PHPStan level 3 clean; all console tests green.

Refs #2001

🤖 Generated with [Claude Code](https://claude.com/claude-code)