### PR TITLE
SEO: default canonicals + filter-param noindex on all pages (issue #2001, part 3)

### DIFF
--- a/app/Services/SeoMeta.php
+++ b/app/Services/SeoMeta.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Http\Request;
+
+/**
+ * Central definition of the canonical URL and robots-meta rules used by the
+ * layout head. Listing pages reached with list-state query params (sort,
+ * filters, tabs, …) canonicalize to their clean path and are noindexed so
+ * the QueryFilter permutations don't bleed duplicates into the index.
+ */
+class SeoMeta
+{
+    /**
+     * Query params that represent list/navigation state rather than distinct
+     * content. Anything else (e.g. utm_*) is left indexable and consolidates
+     * through the canonical instead.
+     */
+    protected const NOINDEX_PARAMS = [
+        'sort',
+        'direction',
+        'limit',
+        'filters',
+        'keyword',
+        'tabs',
+        'day_offset',
+        'page',
+    ];
+
+    /**
+     * Canonical URL for the current request: the path on the configured app
+     * host, query string stripped. Built from config('app.url') rather than
+     * the request host so it can't drift from the canonical host.
+     */
+    public static function canonicalUrl(Request $request): string
+    {
+        $base = rtrim(config('app.url'), '/');
+        $path = trim($request->path(), '/');
+
+        return $path === '' ? $base : $base.'/'.$path;
+    }
+
+    /**
+     * Whether the current request carries list-state query params and should
+     * be noindexed (with follow, so link equity still flows).
+     */
+    public static function shouldNoindex(Request $request): bool
+    {
+        return count(array_intersect(array_keys($request->query()), self::NOINDEX_PARAMS)) > 0;
+    }
+}

--- a/resources/views/events/indexUserAttending-tw.blade.php
+++ b/resources/views/events/indexUserAttending-tw.blade.php
@@ -2,6 +2,10 @@
 
 @section('title', 'User Events Attending')
 
+@section('meta.robots')
+<meta name="robots" content="noindex, follow">
+@endsection
+
 @if (isset($past_events) && count($past_events) > 0)
     @php
         $first = $past_events[0];

--- a/resources/views/events/show-tw.blade.php
+++ b/resources/views/events/show-tw.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.app-tw')
 
+{{-- the id-based URL also resolves; the slug route is the canonical one --}}
+@section('canonical')
+<link rel="canonical" href="{{ url('/events/'.$event->slug) }}">
+@endsection
+
 @section('google.event.json')
 @if (config('app.spider_blacklist') !== null && $event->venue !== null)
 @if (strtolower($event->venue->name) !== strtolower(config('app.spider_blacklist')))

--- a/resources/views/layouts/app-tw.blade.php
+++ b/resources/views/layouts/app-tw.blade.php
@@ -4,15 +4,23 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<meta property="og:url" content="{{ Request::url() }}">
+	<meta property="og:url" content="{{ \App\Services\SeoMeta::canonicalUrl(request()) }}">
 	<meta property="og:type" content="@yield('og-type', 'website')">
 	<meta property="og:title" content="@yield('title', config('app.app_name'))">
 	<meta property="og:image" content="@yield('og-image', url('/').'/images/arcane-city-promo.jpg')">
 	<meta property="og:description" content="@yield('og-description', 'A calender of events, concerts, club nights, weekly and monthly events series, promoters, artists, producers, djs, venues and other entities.')">
 	<meta name="description" content="@yield('description', 'A calender of events, concerts, club nights, weekly and monthly events series, promoters, artists, producers, djs, venues and other entities.')">
 	<meta property="fb:app_id" content="{{ config('app.fb_app_id') }}">
+	@hasSection('canonical')
 	@yield('canonical')
+	@else
+	<link rel="canonical" href="{{ \App\Services\SeoMeta::canonicalUrl(request()) }}">
+	@endif
+	@hasSection('meta.robots')
 	@yield('meta.robots')
+	@elseif (($seoNoindex ?? false) || \App\Services\SeoMeta::shouldNoindex(request()))
+	<meta name="robots" content="noindex, follow">
+	@endif
 	@yield('facebook.meta')
 	@yield('google.event.json')
 	@yield('entity.json')

--- a/resources/views/series/show-tw.blade.php
+++ b/resources/views/series/show-tw.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.app-tw')
 
+{{-- the id-based URL also resolves; the slug route is the canonical one --}}
+@section('canonical')
+<link rel="canonical" href="{{ url('/series/'.$series->slug) }}">
+@endsection
+
 @section('title', $series->getTitleFormat())
 @section('og-description', $series->short)
 

--- a/resources/views/tags/show-tw.blade.php
+++ b/resources/views/tags/show-tw.blade.php
@@ -1,5 +1,12 @@
 @extends('layouts.app-tw')
 
+{{-- name-based links also resolve here; the slug form is the canonical one --}}
+@if (isset($tagObject) && $tagObject)
+@section('canonical')
+<link rel="canonical" href="{{ url('/tags/'.$tagObject->slug) }}">
+@endsection
+@endif
+
 @section('title')
 @if (isset($tag))
 {{ $tag }} • Tag

--- a/tests/Feature/SeoMetaLayoutTest.php
+++ b/tests/Feature/SeoMetaLayoutTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\Series;
+use App\Models\Tag;
+use App\Models\User;
+use App\Models\Visibility;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SeoMetaLayoutTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    protected function base(): string
+    {
+        return rtrim(config('app.url'), '/');
+    }
+
+    public function test_listing_page_gets_default_self_canonical_and_no_robots_meta(): void
+    {
+        $response = $this->get('/events');
+
+        $response->assertOk();
+        $response->assertSee('<link rel="canonical" href="'.$this->base().'/events">', false);
+        $response->assertDontSee('noindex', false);
+    }
+
+    public function test_listing_with_filter_params_gets_clean_canonical_and_noindex(): void
+    {
+        $response = $this->get('/events?sort=name&direction=desc');
+
+        $response->assertOk();
+        $response->assertSee('<link rel="canonical" href="'.$this->base().'/events">', false);
+        $response->assertSee('<meta name="robots" content="noindex, follow">', false);
+    }
+
+    public function test_listing_with_utm_params_is_not_noindexed(): void
+    {
+        $response = $this->get('/events?utm_source=newsletter');
+
+        $response->assertOk();
+        $response->assertDontSee('noindex', false);
+    }
+
+    public function test_event_show_canonicalizes_to_slug_route_even_by_id(): void
+    {
+        $event = Event::factory()->create(['visibility_id' => Visibility::VISIBILITY_PUBLIC]);
+
+        $response = $this->get('/events/'.$event->id);
+
+        $response->assertOk();
+        $response->assertSee('<link rel="canonical" href="'.$this->base().'/events/'.$event->slug.'">', false);
+    }
+
+    public function test_series_show_canonicalizes_to_slug_route(): void
+    {
+        $series = Series::factory()->create(['visibility_id' => Visibility::VISIBILITY_PUBLIC]);
+
+        $response = $this->get('/series/'.$series->slug);
+
+        $response->assertOk();
+        $response->assertSee('<link rel="canonical" href="'.$this->base().'/series/'.$series->slug.'">', false);
+    }
+
+    public function test_tag_show_canonicalizes_to_slug_route(): void
+    {
+        $tag = Tag::factory()->create(['name' => 'Canonical Probe', 'slug' => 'canonical-probe']);
+
+        $response = $this->get('/tags/canonical-probe');
+
+        $response->assertOk();
+        $response->assertSee('<link rel="canonical" href="'.$this->base().'/tags/canonical-probe">', false);
+    }
+
+    public function test_entity_show_keeps_its_existing_canonical_override(): void
+    {
+        $entity = \App\Models\Entity::factory()->create();
+
+        $response = $this->get('/entities/'.$entity->slug);
+
+        $response->assertOk();
+        $response->assertSee('rel="canonical"', false);
+    }
+
+    public function test_user_profile_is_noindexed(): void
+    {
+        $user = User::factory()->create();
+
+        // first hit creates a missing profile and redirects back to itself
+        $response = $this->followingRedirects()->get('/users/'.$user->id);
+
+        $response->assertOk();
+        $response->assertSee('noindex', false);
+    }
+
+    public function test_user_attending_page_is_noindexed(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->get('/users/'.$user->id.'/attending');
+
+        $response->assertOk();
+        $response->assertSee('noindex', false);
+    }
+
+    public function test_og_url_uses_canonical_host_without_query(): void
+    {
+        $response = $this->get('/events?sort=name');
+
+        $response->assertOk();
+        $response->assertSee('<meta property="og:url" content="'.$this->base().'/events">', false);
+    }
+}

--- a/tests/Unit/SeoMetaTest.php
+++ b/tests/Unit/SeoMetaTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\SeoMeta;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class SeoMetaTest extends TestCase
+{
+    public function test_canonical_url_strips_query_and_uses_app_url(): void
+    {
+        $request = Request::create('https://some-other-host.example/events?sort=name&direction=desc');
+
+        $this->assertSame(
+            rtrim(config('app.url'), '/').'/events',
+            SeoMeta::canonicalUrl($request)
+        );
+    }
+
+    public function test_canonical_url_for_root_is_bare_app_url(): void
+    {
+        $request = Request::create('/');
+
+        $this->assertSame(rtrim(config('app.url'), '/'), SeoMeta::canonicalUrl($request));
+    }
+
+    public function test_should_noindex_on_list_state_params(): void
+    {
+        foreach (['sort=name', 'direction=desc', 'limit=100', 'filters[tag]=x', 'keyword=x', 'tabs[events]=created', 'page=2'] as $query) {
+            $this->assertTrue(
+                SeoMeta::shouldNoindex(Request::create('/events?'.$query)),
+                'Expected noindex for ?'.$query
+            );
+        }
+    }
+
+    public function test_should_not_noindex_without_list_state_params(): void
+    {
+        $this->assertFalse(SeoMeta::shouldNoindex(Request::create('/events')));
+        $this->assertFalse(SeoMeta::shouldNoindex(Request::create('/events?utm_source=newsletter')));
+    }
+}


### PR DESCRIPTION
Part 3 of #2001 (items 1 & 2, plus the meta half of 4b). Canonical tags previously existed on exactly one view (`entities/show-tw`), so the `?sort=`/`?direction=`/`?limit=`/`filters[...]` permutations from the QueryFilter system generated most of the 4,876 "duplicate without user-selected canonical" pages in GSC.

## Approach: layout-level default, per-view override

Rather than editing 113 views, `layouts/app-tw` now emits:
- a **default self-canonical** built by the new `SeoMeta` service — path on `config('app.url')` with the query string stripped, so it also can't drift from the canonical host regardless of which hostname served the request;
- a **`noindex, follow` robots meta** whenever the request carries list-state params (`sort`, `direction`, `limit`, `filters`, `keyword`, `tabs`, `day_offset`, `page`) or a controller passes `$seoNoindex` to the view (the hook part 4 will use for empty listings).

Existing `@section('canonical')` / `@section('meta.robots')` overrides keep working unchanged. The param list is a deliberate allowlist: `utm_*`-style params stay indexable and consolidate through the canonical instead of vanishing from the index. `og:url` now uses the same canonical value instead of `Request::url()`.

## Explicit slug canonicals on show pages

Event, series, and tag show pages declare their slug URL as canonical (pattern copied from the entity view) — `Event`/`Series` route binding also accepts numeric ids and tag pages are reachable via name-based links, so those duplicate URL surfaces now all point at the slug route. This also covers the entity role-alias routes, since they render the entity view whose canonical is built from `$entity->slug`.

## User pages (4b, meta half)

`/users/{id}/attending` is now noindexed (`users/show-tw` already was), and the layout param rule covers the `?tabs[events]=&tabs[following]=` permutations that made up 77 of 142 sampled user-page soft-404s. robots.txt `Disallow: /users/` shipped in part 1; moving the GET reset endpoints to POST is deferred to its own issue.

`layouts/app.blade.php` was left alone — its only consumer (`HomeController@index`) is unrouted dead code.

## Tests

- New `tests/Unit/SeoMetaTest.php` and `tests/Feature/SeoMetaLayoutTest.php`: clean/self canonical on listings, clean canonical + noindex under filter params, no noindex under utm params, id→slug canonicalization on event show, series/tag canonicals, entity override intact, user profile + attending noindexed, og:url host/query behavior.
- Full suite: 1002 tests green. PHPStan level 3 clean.

Refs #2001

🤖 Generated with [Claude Code](https://claude.com/claude-code)