### PR TITLE
SEO: 404 unknown taxonomy terms, noindex empty cross-listings (issue #2001, part 4)

### DIFF
--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -626,6 +626,9 @@ class EventsController extends Controller
         ListEntityResultBuilder $listEntityResultBuilder,
         string $slug
     ): string {
+        // unknown types are a 404, not an empty 200 (GSC soft-404)
+        EventType::where('slug', '=', $slug)->orWhere('name', '=', $slug)->firstOrFail();
+
         return $this->indexGridFiltered(
             $listParamSessionStore,
             $listEntityResultBuilder,
@@ -644,6 +647,9 @@ class EventsController extends Controller
         ListEntityResultBuilder $listEntityResultBuilder,
         string $slug
     ): string {
+        // unknown series are a 404, not an empty 200 (GSC soft-404)
+        Series::where('slug', '=', $slug)->orWhere('name', '=', Str::title(str_replace('-', ' ', $slug)))->firstOrFail();
+
         return $this->indexGridFiltered(
             $listParamSessionStore,
             $listEntityResultBuilder,
@@ -2484,6 +2490,7 @@ class EventsController extends Controller
                         'direction' => $listResultSet->getSortDirection(),
                         'hasFilter' => $this->hasFilter,
                         'filters' => $listResultSet->getFilters(),
+                        'seoNoindex' => $events->total() === 0,
                     ],
                     $this->getFilterOptions(),
                     $this->getListControlOptions()
@@ -2547,6 +2554,7 @@ class EventsController extends Controller
                         'direction' => $listResultSet->getSortDirection(),
                         'hasFilter' => $this->hasFilter,
                         'filters' => $listResultSet->getFilters(),
+                        'seoNoindex' => $events->total() === 0,
                     ],
                     $this->getFilterOptions(),
                     $this->getListControlOptions()
@@ -2689,6 +2697,7 @@ class EventsController extends Controller
                         'direction' => $listResultSet->getSortDirection(),
                         'hasFilter' => $this->hasFilter,
                         'filters' => $listResultSet->getFilters(),
+                        'seoNoindex' => $future_events->total() === 0 && $past_events->total() === 0,
                     ],
                     $this->getFilterOptions(),
                     $this->getListControlOptions()
@@ -2710,6 +2719,10 @@ class EventsController extends Controller
         ListEntityResultBuilder $listEntityResultBuilder,
         string $type
     ) {
+        // unknown types are a 404, not an empty 200 (GSC soft-404); links may
+        // carry either the slug or the display name
+        EventType::where('slug', '=', $type)->orWhere('name', '=', $type)->firstOrFail();
+
         $listParamSessionStore->setBaseIndex('internal_event');
         $listParamSessionStore->setKeyPrefix('internal_event_types');
 
@@ -2750,6 +2763,7 @@ class EventsController extends Controller
                         'direction' => $listResultSet->getSortDirection(),
                         'hasFilter' => $this->hasFilter,
                         'filters' => $listResultSet->getFilters(),
+                        'seoNoindex' => $events->total() === 0,
                     ],
                     $this->getFilterOptions(),
                     $this->getListControlOptions()
@@ -2770,7 +2784,11 @@ class EventsController extends Controller
         ListEntityResultBuilder $listEntityResultBuilder,
         string $slug
     ) {
-        $slug = Str::title(str_replace('-', ' ', $slug));
+        // unknown series are a 404, not an empty 200 (GSC soft-404); the
+        // filter matches on the title-cased name derived from the slug
+        $name = Str::title(str_replace('-', ' ', $slug));
+        Series::where('slug', '=', $slug)->orWhere('name', '=', $name)->firstOrFail();
+        $slug = $name;
 
         $listParamSessionStore->setBaseIndex('internal_event');
         $listParamSessionStore->setKeyPrefix('internal_event_series');
@@ -2823,6 +2841,7 @@ class EventsController extends Controller
                         'direction' => $listResultSet->getSortDirection(),
                         'hasFilter' => $this->hasFilter,
                         'filters' => $listResultSet->getFilters(),
+                        'seoNoindex' => $future_events->total() === 0 && $past_events->total() === 0,
                     ],
                     $this->getFilterOptions(),
                     $this->getListControlOptions()

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -293,6 +293,10 @@ class PostsController extends Controller
         // convert the slug to name
         $tag = $stringHelper->SlugToName($slug);
 
+        // unknown terms are a 404, not an empty 200 (GSC soft-404); links may
+        // carry either the slug or the display name
+        Tag::where('slug', '=', $slug)->orWhere('name', '=', $tag)->firstOrFail();
+
         // initialized listParamSessionStore with baseindex key
         // list entity result builder
         $listParamSessionStore->setBaseIndex('internal_post');
@@ -340,6 +344,7 @@ class PostsController extends Controller
                 'direction' => $listResultSet->getSortDirection(),
                 'hasFilter' => $this->hasFilter,
                 'filters' => $listResultSet->getFilters(),
+                'seoNoindex' => $posts->total() === 0,
             ],
             $this->getFilterOptions(),
             $this->getListControlOptions()

--- a/app/Http/Controllers/TagsController.php
+++ b/app/Http/Controllers/TagsController.php
@@ -255,7 +255,9 @@ class TagsController extends Controller
      */
     public function show(string $slug, StringHelper $stringHelper): View
     {
-        $tagObject = Tag::where('slug', '=', $slug)->first();
+        // name-based links also land here, so match either form; unknown
+        // terms are a 404, not an empty 200 (GSC reports those as soft-404s)
+        $tagObject = Tag::where('slug', '=', $slug)->orWhere('name', '=', $slug)->firstOrFail();
 
         // convert the slug to name?
         $tag = $stringHelper->SlugToName($slug);
@@ -300,7 +302,10 @@ class TagsController extends Controller
         // Get related tags based on co-occurrence with events
         $relatedTags = $tagObject ? $tagObject->relatedTags() : [];
 
-        return view('tags.show-tw', compact('series', 'entities', 'events', 'slug', 'tag', 'tagObject', 'tags', 'relatedTags'));
+        // a real term with nothing attached shouldn't enter the index
+        $seoNoindex = $series->isEmpty() && $events->isEmpty() && $entities->isEmpty();
+
+        return view('tags.show-tw', compact('series', 'entities', 'events', 'slug', 'tag', 'tagObject', 'tags', 'relatedTags', 'seoNoindex'));
     }
 
     /**

--- a/app/Http/Controllers/ThreadsController.php
+++ b/app/Http/Controllers/ThreadsController.php
@@ -404,6 +404,11 @@ class ThreadsController extends Controller
         string $tag
     ): string {
         $tag = urldecode($tag);
+
+        // unknown terms are a 404, not an empty 200 (GSC soft-404); links may
+        // carry either the slug or the display name
+        $tagObject = Tag::where('slug', '=', $tag)->orWhere('name', '=', $tag)->firstOrFail();
+
         // initialized listParamSessionStore with baseindex key
         // list entity result builder
         $listParamSessionStore->setBaseIndex('internal_thread');
@@ -420,7 +425,7 @@ class ThreadsController extends Controller
             ->setFilter($this->filter)
             ->setQueryBuilder($baseQuery)
             ->setDefaultSort(['threads.created_at' => 'desc'])
-            ->setParentFilter(['tag' => ucfirst($tag)]);
+            ->setParentFilter(['tag' => $tagObject->name]);
 
         // get the result set from the builder
         $listResultSet = $listEntityResultBuilder->listResultSetFactory();
@@ -447,6 +452,7 @@ class ThreadsController extends Controller
                 'direction' => $listResultSet->getSortDirection(),
                 'hasFilter' => $this->hasFilter,
                 'filters' => $listResultSet->getFilters(),
+                'seoNoindex' => $threads->total() === 0,
             ],
             $this->getFilterOptions(),
             $this->getListControlOptions()

--- a/resources/views/threads/briefFirst.blade.php
+++ b/resources/views/threads/briefFirst.blade.php
@@ -57,8 +57,8 @@
         @unless ($thread->tags->isEmpty())
             Tags:
             @foreach ($thread->tags as $tag)
-                <span class="badge rounded-pill bg-dark"><a href="/threads/tag/{{ urlencode($tag->name) }}">{{ $tag->name }}</a>
-                            <a href="{!! route('tags.show', ['tag' => $tag->name]) !!}" title="Show this tag."><i class="bi bi-link-45deg text-info"></i></a>
+                <span class="badge rounded-pill bg-dark"><a href="/threads/tag/{{ $tag->slug }}">{{ $tag->name }}</a>
+                            <a href="{!! route('tags.show', ['tag' => $tag->slug]) !!}" title="Show this tag."><i class="bi bi-link-45deg text-info"></i></a>
                         </span>
             @endforeach
         @endunless

--- a/tests/Feature/EmptyListingSeoTest.php
+++ b/tests/Feature/EmptyListingSeoTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\EventType;
+use App\Models\Series;
+use App\Models\Tag;
+use App\Models\Thread;
+use App\Models\Visibility;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EmptyListingSeoTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    public function test_unknown_taxonomy_terms_return_404(): void
+    {
+        $this->get('/threads/tag/definitely-not-a-tag')->assertNotFound();
+        $this->get('/posts/tag/definitely-not-a-tag')->assertNotFound();
+        $this->get('/tags/definitely-not-a-tag')->assertNotFound();
+        $this->get('/events/type/definitely-not-a-type')->assertNotFound();
+        $this->get('/events/series/definitely-not-a-series')->assertNotFound();
+        $this->get('/events/grid/type/definitely-not-a-type')->assertNotFound();
+        $this->get('/events/grid/series/definitely-not-a-series')->assertNotFound();
+    }
+
+    public function test_existing_but_empty_tag_page_is_noindexed(): void
+    {
+        Tag::factory()->create(['name' => 'Empty Probe', 'slug' => 'empty-probe']);
+
+        $response = $this->get('/tags/empty-probe');
+
+        $response->assertOk();
+        $response->assertSee('<meta name="robots" content="noindex, follow">', false);
+    }
+
+    public function test_tag_with_content_is_indexable(): void
+    {
+        $tag = Tag::factory()->create(['name' => 'Full Probe', 'slug' => 'full-probe']);
+        $event = Event::factory()->create([
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => now()->addWeek(),
+        ]);
+        $event->tags()->attach($tag);
+
+        $response = $this->get('/tags/full-probe');
+
+        $response->assertOk();
+        $response->assertDontSee('noindex', false);
+    }
+
+    public function test_empty_thread_tag_listing_is_noindexed(): void
+    {
+        Tag::factory()->create(['name' => 'Threadless', 'slug' => 'threadless']);
+
+        $response = $this->get('/threads/tag/threadless');
+
+        $response->assertOk();
+        $response->assertSee('<meta name="robots" content="noindex, follow">', false);
+    }
+
+    public function test_empty_event_type_listing_is_noindexed(): void
+    {
+        EventType::factory()->create(['name' => 'Ghost Type', 'slug' => 'ghost-type']);
+
+        $response = $this->get('/events/type/ghost-type');
+
+        $response->assertOk();
+        $response->assertSee('<meta name="robots" content="noindex, follow">', false);
+    }
+
+    public function test_event_tag_listing_with_events_is_indexable(): void
+    {
+        $tag = Tag::factory()->create(['name' => 'Busy Tag', 'slug' => 'busy-tag']);
+        $event = Event::factory()->create([
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => now()->addWeek(),
+        ]);
+        $event->tags()->attach($tag);
+
+        $response = $this->get('/events/tag/busy-tag');
+
+        $response->assertOk();
+        $response->assertDontSee('noindex', false);
+    }
+
+    public function test_thread_brief_renders_tag_links_from_slug(): void
+    {
+        $tag = Tag::factory()->create(['name' => 'Hip Hop', 'slug' => 'hip-hop']);
+        $thread = Thread::factory()->create(['visibility_id' => Visibility::VISIBILITY_PUBLIC]);
+        $thread->tags()->attach($tag);
+
+        $response = $this->get('/threads/'.$thread->id);
+
+        $response->assertOk();
+        $response->assertDontSee('/tags/Hip%20Hop', false);
+        $response->assertDontSee('/threads/tag/Hip+Hop', false);
+    }
+}

--- a/tests/Feature/EventsTest.php
+++ b/tests/Feature/EventsTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\Entity;
 use App\Models\Event;
+use App\Models\EventType;
 use App\Models\Tag;
 use App\Models\User;
 use App\Models\UserStatus;
@@ -166,6 +167,9 @@ class EventsTest extends TestCase
 
     public function testGridTypeRouteDisplaysParentFilterBreadcrumb()
     {
+        // unknown types 404, so the breadcrumb needs a real one
+        EventType::factory()->create(['name' => 'Grid-filter-type', 'slug' => 'grid-filter-type']);
+
         $this->get(route('events.grid.type', ['slug' => 'grid-filter-type']))
             ->assertOk()
             ->assertSee('Grid-filter-type');


### PR DESCRIPTION
Part 4 of #2001 (item 4d + the tag-link bug from 4c). **Stacked on #2009** (needs its `$seoNoindex` layout hook) — merge that first, then re-target this to `main`.

## Problem

`/{type}/tag/{slug}`, `/{type}/related-to/{slug}`, `/events/type/{slug}`, `/events/series/{slug}` form a cross-product of every taxonomy term against every content type. Most combinations are empty (no threads tagged `pop`, no series tagged `sculpture`) and returned a 200 with an empty list — reported by GSC as soft-404s. Several of these also accepted terms that don't exist at all.

## Changes

**Unknown terms now 404** (matching what events/entities/series/photos `indexTags` already did):
- `ThreadsController@indexTags`, `PostsController@indexTags` — no existence check at all before.
- `TagsController@show` — used `->first()` and silently rendered an empty page for any junk term.
- `EventsController@indexTypes`, `@indexSeries`, `indexGridTypes`, `indexGridSeries`.

Lookups match slug OR display name, since existing links carry both forms — so currently-working name links keep working (and now canonicalize to the slug URL via part 3).

**Bonus fix:** `ThreadsController@indexTags` filtered by `ucfirst($tag)`, so slug-form links (`hip-hop`) never matched multiword tags (`Hip Hop`). It now filters by the resolved tag's actual name.

**Real-but-empty listings emit `noindex, follow`** via the `$seoNoindex` view flag consumed by part 3's layout: events tag/related-to/venue/type/series listings, thread and post tag listings, and the tag show page. Populated listings stay fully indexable.

**Tag-link bug (from 4c):** `threads/briefFirst.blade.php` built tag links from `$tag->name`, minting `/tags/Hip%20Hop`-style URLs that rendered as empty 200 pages. Now uses `$tag->slug`.

## Tests

New `EmptyListingSeoTest` (7 tests): unknown-term 404s across all fixed routes, empty-tag noindex vs populated-tag indexable, thread/type listing variants, and the slug-link rendering fix. One existing test (`EventsTest::testGridTypeRouteDisplaysParentFilterBreadcrumb`) hit a nonexistent type and expected 200 — updated to create the type. Full suite 1009 tests green; PHPStan level 3 clean.

Refs #2001

🤖 Generated with [Claude Code](https://claude.com/claude-code)