### PR TITLE
SEO: tags:cleanup command for junk taxonomy rows (issue #2001, part 5)

### DIFF
--- a/app/Console/Commands/CleanupJunkTags.php
+++ b/app/Console/Commands/CleanupJunkTags.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Tag;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class CleanupJunkTags extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'tags:cleanup {--dry-run : Report what would be deleted without changing anything}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Delete junk tag rows (numeric names, URLs stored as tags, empty slugs) and report junk event types';
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+
+        $junk = Tag::query()
+            ->where(function ($query) {
+                $query->whereRaw("name REGEXP '^[0-9]+$'")
+                    ->orWhere('name', 'like', 'http://%')
+                    ->orWhere('name', 'like', 'https://%')
+                    ->orWhere('name', 'like', 'www.%')
+                    ->orWhereRaw("name REGEXP '\\\\.(com|net|org|io|co)(/|$)'")
+                    ->orWhere('slug', '');
+            })
+            ->orderBy('name')
+            ->get();
+
+        if ($junk->isEmpty()) {
+            $this->info('No junk tags found.');
+        } else {
+            $this->table(
+                ['id', 'name', 'slug', 'events', 'entities', 'series', 'threads'],
+                $junk->map(fn (Tag $tag) => [
+                    $tag->id,
+                    $tag->name,
+                    $tag->slug,
+                    $tag->events()->count(),
+                    $tag->entities()->count(),
+                    $tag->series()->count(),
+                    $tag->threads()->count(),
+                ])
+            );
+
+            if ($dryRun) {
+                $this->warn(sprintf('[dry-run] Would delete %d tags. Re-run without --dry-run to apply.', $junk->count()));
+            } else {
+                foreach ($junk as $tag) {
+                    $tag->events()->detach();
+                    $tag->entities()->detach();
+                    $tag->series()->detach();
+                    $tag->threads()->detach();
+                    $tag->delete();
+                }
+                $this->info(sprintf('Deleted %d junk tags and their pivot rows.', $junk->count()));
+            }
+        }
+
+        // Report-only: event types share the same garbage-in problem, but rows
+        // are referenced by events.event_type_id, so deletion needs a manual
+        // decision about re-pointing. Emit suggestions instead of acting.
+        $junkTypes = DB::table('event_types')
+            ->where(function ($query) {
+                $query->whereRaw("name REGEXP '^[0-9]+$'")
+                    ->orWhere('name', 'like', 'http://%')
+                    ->orWhere('name', 'like', 'https://%')
+                    ->orWhere('name', 'like', 'www.%')
+                    ->orWhereRaw("name REGEXP '\\\\.(com|net|org|io|co)(/|$)'");
+            })
+            ->orderBy('name')
+            ->get();
+
+        if ($junkTypes->isEmpty()) {
+            $this->info('No junk event types found.');
+        } else {
+            $this->warn('Junk event_types rows found (not deleted — events reference them):');
+            foreach ($junkTypes as $type) {
+                $count = DB::table('events')->where('event_type_id', $type->id)->count();
+                $this->line(sprintf('  id=%d name="%s" (%d events)', $type->id, $type->name, $count));
+                $this->line(sprintf('    -- UPDATE events SET event_type_id = <target> WHERE event_type_id = %d; DELETE FROM event_types WHERE id = %d;', $type->id, $type->id));
+            }
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/tests/Feature/Console/CleanupJunkTagsCommandTest.php
+++ b/tests/Feature/Console/CleanupJunkTagsCommandTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use App\Models\Event;
+use App\Models\Tag;
+use App\Models\Visibility;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CleanupJunkTagsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    public function test_deletes_junk_tags_and_pivots(): void
+    {
+        $numeric = Tag::factory()->create(['name' => '483', 'slug' => '483']);
+        $urlTag = Tag::factory()->create(['name' => 'www.parktildark.com', 'slug' => 'wwwparktildarkcom']);
+        $real = Tag::factory()->create(['name' => 'Techno', 'slug' => 'techno']);
+
+        $event = Event::factory()->create(['visibility_id' => Visibility::VISIBILITY_PUBLIC]);
+        $event->tags()->attach([$numeric->id, $real->id]);
+
+        $this->artisan('tags:cleanup')->assertSuccessful();
+
+        $this->assertDatabaseMissing('tags', ['id' => $numeric->id]);
+        $this->assertDatabaseMissing('tags', ['id' => $urlTag->id]);
+        $this->assertDatabaseMissing('event_tag', ['tag_id' => $numeric->id]);
+        $this->assertDatabaseHas('tags', ['id' => $real->id]);
+        $this->assertDatabaseHas('event_tag', ['tag_id' => $real->id]);
+    }
+
+    public function test_dry_run_deletes_nothing(): void
+    {
+        $numeric = Tag::factory()->create(['name' => '117', 'slug' => '117']);
+
+        $this->artisan('tags:cleanup', ['--dry-run' => true])->assertSuccessful();
+
+        $this->assertDatabaseHas('tags', ['id' => $numeric->id]);
+    }
+
+    public function test_reports_junk_event_types_without_deleting(): void
+    {
+        $typeId = \Illuminate\Support\Facades\DB::table('event_types')->insertGetId([
+            'name' => 'liveafterdeathshow.com',
+            'slug' => 'liveafterdeathshowcom',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->artisan('tags:cleanup')
+            ->expectsOutputToContain('liveafterdeathshow.com')
+            ->assertSuccessful();
+
+        $this->assertDatabaseHas('event_types', ['id' => $typeId]);
+    }
+}


### PR DESCRIPTION
Part 5 of #2001 (item 4c, the data-cleanup half — the tag-link view bug ships in #2010).

GSC's soft-404 drill-down exposed junk rows in the `tags` table that generate crawlable URLs: numeric tag names (`/tags/483`, `/tags/117`), URLs stored as tags (`/tags/www.parktildark.com`, `/tags/Filmpittsburgh.org`). Each bad row mints up to seven URLs across the `/tags/`, `/events/tag/`, `/entities/tag/`, `/series/tag/`, `/threads/tag/`, `/calendar/tag/`, `/posts/tag/` families, so cleaning one row removes several junk URLs at once.

## The command

`php artisan tags:cleanup --dry-run` (dry-run first, then run without the flag):

- **Tags**: selects rows whose name is purely numeric, URL-shaped (`http://`, `https://`, `www.`, or a bare `.com/.net/.org/.io/.co` domain), or whose slug is empty. Prints a review table with per-relation usage counts, then detaches event/entity/series/thread pivots and deletes the rows. `--dry-run` only reports.
- **Event types**: the same garbage-in problem exists in `event_types` (`liveafterdeathshow.com`, venue names stored as types), but events reference `event_type_id`, so deletion needs a manual re-pointing decision. The command reports those rows with affected-event counts and emits suggested SQL instead of acting.

Not scheduled — intended as a one-off production run, kept in the repo for reuse.

## Tests

`tests/Feature/Console/CleanupJunkTagsCommandTest.php`: numeric + URL tags deleted with their pivots while a real tag and its pivots survive; `--dry-run` deletes nothing; junk event type is reported but not deleted. PHPStan level 3 clean.

Refs #2001

🤖 Generated with [Claude Code](https://claude.com/claude-code)