### PR TITLE
Ignore two non-actionable composer audit advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,9 @@
 		},
 		"audit": {
 			"ignore": {
-				"PKSA-mdq4-51ck-6kdq": "Laravel CRLF injection in default email validation rule. Patched only in Laravel 12.60+/13.10+ (all 10.x AND 11.x are affected), so it cannot be resolved without the deferred framework-upgrade track. Accepted/known risk; revisit when upgrading the framework."
+				"PKSA-mdq4-51ck-6kdq": "Laravel CRLF injection in default email validation rule. Patched only in Laravel 12.60+/13.10+ (all 10.x AND 11.x are affected), so it cannot be resolved without the deferred framework-upgrade track. Accepted/known risk; revisit when upgrading the framework.",
+				"PKSA-3r5d-mb8f-1qw9": "Duplicate GitHub-advisory record of GHSA-5vg9-5847-vvmq, the same CRLF-injection issue already ignored as PKSA-mdq4-51ck-6kdq. Patched only in Laravel 12.60+/13.10+; resolved by the Laravel 12 upgrade track.",
+				"PKSA-m5cs-t1y6-qpcs": "Temporary signed URL path confusion (GHSA-crmm-hgp2-wgrp). The vulnerable code path (LocalFilesystemAdapter::temporaryUrl serving) was introduced in Laravel 11+ and does not exist in Laravel 10; this app never calls Storage::temporaryUrl on the local disk. Not applicable; resolved by upgrade to 12.61.1+."
 			}
 		}
 	},

--- a/tests/Feature/SeoGuardsTest.php
+++ b/tests/Feature/SeoGuardsTest.php
@@ -130,7 +130,12 @@ class SeoGuardsTest extends TestCase
             'Disallow: /events/add/',
             'Disallow: /events/grid',
             'Disallow: /*/rpp-reset',
-            'Disallow: /*?sort=',
+            // d4423d36 broadened the param rules from /*?sort= so they also
+            // match sort= appearing after & — keep the test in sync
+            'Disallow: /*sort=',
+            'Disallow: /*direction=',
+            'Disallow: /*limit=',
+            'Disallow: /*filters',
         ] as $line) {
             $this->assertStringContainsString($line, $robots);
         }


### PR DESCRIPTION
Closes #2016.

CI fails on `composer audit` because of two advisories against `laravel/framework` 10.50.2. Neither is actionable on Laravel 10, so this adds documented ignores to `config.audit.ignore` in `composer.json`:

- **PKSA-3r5d-mb8f-1qw9** (CRLF injection in default email rule, high) — a **duplicate record** of GHSA-5vg9-5847-vvmq, the same issue already ignored as `PKSA-mdq4-51ck-6kdq`. Composer treats the Packagist and GitHub advisory-database records as distinct IDs, so the existing ignore doesn't cover it. Patched only in Laravel 12.60+/13.10+.
- **PKSA-m5cs-t1y6-qpcs** (Temporary Signed URL Path Confusion, medium / GHSA-crmm-hgp2-wgrp) — traced the fix PRs (laravel/framework #60137, #60230, #60350): the vulnerability is in `LocalFilesystemAdapter::temporaryUrl()` serving, a **Laravel 11+ feature that does not exist in Laravel 10** (the local driver here throws "This driver does not support creating temporary URLs"), and the app never calls `Storage::temporaryUrl()` or `buildTemporaryUrlsUsing()`. Our `URL::temporarySignedRoute()` usage is a different code path not covered by the advisory. Documented false positive.

**Also fixes the second pre-existing CI breakage on main**: `SeoGuardsTest::test_robots_txt_blocks_crawl_waste_paths` was left stale by d4423d36, which broadened the robots.txt param rules from `/*?sort=` to `/*sort=`. The test now asserts all four broadened rules.

The two abandoned packages in the audit output (`php-http/message-factory` transitive, `vinkla/shield`) do not fail CI (`--abandoned=report`); `vinkla/shield` removal is #2019.

Both advisories are resolved for real by upgrading to Laravel ≥12.60 — scoped as the staged series #2018–#2022, with the framework bump to follow once those merge. All three ignores get removed in the bump PR.

**Note on the other PRs' CI**: #2018–#2022 branch from main, so their checks stay red on the audit/robots failures until this PR merges; re-running their checks afterwards picks up the fix via the merge ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)