### PR TITLE
Pre-upgrade: convert string route actions to array syntax, consolidate Auth::routes()

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -33,7 +33,7 @@ Route::middleware('auth:sanctum')->get('tokens/test', function (Request $request
 });
 
 // Public typeahead search. Visibility scoping uses the optionally-authenticated user.
-Route::get('search', ['as' => 'api.search', 'uses' => 'Api\SearchController@index']);
+Route::get('search', ['as' => 'api.search', 'uses' => '\App\Http\Controllers\Api\SearchController@index']);
 
 Route::middleware('auth:sanctum')->get('auth/me', function (Request $request) {
     // $user = $request->user()->load(['groups.permissions']);
@@ -57,193 +57,193 @@ Route::middleware('auth.basic')->name('api.')->group(function () {
 
 Route::middleware('auth.either')->name('api.')->group(function () {
 
-    Route::match(['get', 'post'], 'activities/filter', ['as' => 'activities.filter', 'uses' => 'Api\ActivityController@filter']);
-    Route::get('activities/reset', ['as' => 'activities.reset', 'uses' => 'Api\ActivityController@reset']);
-    Route::get('activities/rpp-reset', ['as' => 'activities.rppReset', 'uses' => 'Api\ActivityController@rppReset']);
+    Route::match(['get', 'post'], 'activities/filter', ['as' => 'activities.filter', 'uses' => '\App\Http\Controllers\Api\ActivityController@filter']);
+    Route::get('activities/reset', ['as' => 'activities.reset', 'uses' => '\App\Http\Controllers\Api\ActivityController@reset']);
+    Route::get('activities/rpp-reset', ['as' => 'activities.rppReset', 'uses' => '\App\Http\Controllers\Api\ActivityController@rppReset']);
     Route::resource('activities', 'Api\ActivityController');
 
-    Route::match(['get', 'post'], 'blogs/filter', ['as' => 'blogs.filter', 'uses' => 'Api\BlogsController@filter']);
-    Route::get('blogs/reset', ['as' => 'blogs.reset', 'uses' => 'Api\BlogsController@reset']);
-    Route::get('blogs/rpp-reset', ['as' => 'blogs.rppReset', 'uses' => 'Api\BlogsController@rppReset']);
-    Route::put('blogs/{blog}', 'Api\BlogsController@update')->name('blogs.update');
-    Route::patch('blogs/{blog}', 'Api\BlogsController@patch')->name('blogs.patch');
+    Route::match(['get', 'post'], 'blogs/filter', ['as' => 'blogs.filter', 'uses' => '\App\Http\Controllers\Api\BlogsController@filter']);
+    Route::get('blogs/reset', ['as' => 'blogs.reset', 'uses' => '\App\Http\Controllers\Api\BlogsController@reset']);
+    Route::get('blogs/rpp-reset', ['as' => 'blogs.rppReset', 'uses' => '\App\Http\Controllers\Api\BlogsController@rppReset']);
+    Route::put('blogs/{blog}', [\App\Http\Controllers\Api\BlogsController::class, 'update'])->name('blogs.update');
+    Route::patch('blogs/{blog}', [\App\Http\Controllers\Api\BlogsController::class, 'patch'])->name('blogs.patch');
     Route::apiResource('blogs', 'Api\BlogsController')->except(['update']);
 
-    Route::get('events/attending', ['as' => 'events.attending', 'uses' => 'Api\EventsController@indexAttending']);
-    Route::get('events/recommended', ['as' => 'events.recommended', 'uses' => 'Api\EventsController@indexRecommended'])->middleware('auth:sanctum');
-    Route::get('events/popular', ['as' => 'events.popular', 'uses' => 'Api\EventsController@popular']);
-    Route::get('events/by-date/{year}/{month?}/{day?}', 'Api\EventsController@indexByDate')
+    Route::get('events/attending', ['as' => 'events.attending', 'uses' => '\App\Http\Controllers\Api\EventsController@indexAttending']);
+    Route::get('events/recommended', ['as' => 'events.recommended', 'uses' => '\App\Http\Controllers\Api\EventsController@indexRecommended'])->middleware('auth:sanctum');
+    Route::get('events/popular', ['as' => 'events.popular', 'uses' => '\App\Http\Controllers\Api\EventsController@popular']);
+    Route::get('events/by-date/{year}/{month?}/{day?}', [\App\Http\Controllers\Api\EventsController::class, 'indexByDate'])
     ->where('year', '[1-9][0-9][0-9][0-9]')
     ->where('month', '(0?[1-9]|1[012])')
     ->where('day', '(0?[1-9]|[12][0-9]|3[01])');
     
-    Route::get('events/reset', ['as' => 'events.reset', 'uses' => 'Api\EventsController@reset']);
-    Route::get('events/rpp-reset', ['as' => 'events.rppReset', 'uses' => 'Api\EventsController@rppReset']);
+    Route::get('events/reset', ['as' => 'events.reset', 'uses' => '\App\Http\Controllers\Api\EventsController@reset']);
+    Route::get('events/rpp-reset', ['as' => 'events.rppReset', 'uses' => '\App\Http\Controllers\Api\EventsController@rppReset']);
     
-    Route::get('events/{event}/photos', ['as' => 'events.photos', 'uses' => 'Api\EventsController@photos']);
-    Route::get('events/{event}/all-photos', ['as' => 'events.allPhotos', 'uses' => 'Api\EventsController@allPhotos']);
-    Route::post('events/{id}/photos', 'Api\EventsController@addPhoto');
-    Route::post('events/{id}/instagram-post', 'Api\\EventInstagramController@postCarouselToInstagramApi');
-    Route::get('events/{event}/embeds', ['as' => 'events.embeds', 'uses' => 'Api\EventsController@embeds']);
-    Route::get('events/{event}/minimal-embeds', ['as' => 'events.minimalEmbeds', 'uses' => 'Api\EventsController@minimalEmbeds']);
+    Route::get('events/{event}/photos', ['as' => 'events.photos', 'uses' => '\App\Http\Controllers\Api\EventsController@photos']);
+    Route::get('events/{event}/all-photos', ['as' => 'events.allPhotos', 'uses' => '\App\Http\Controllers\Api\EventsController@allPhotos']);
+    Route::post('events/{id}/photos', [\App\Http\Controllers\Api\EventsController::class, 'addPhoto']);
+    Route::post('events/{id}/instagram-post', [\App\Http\Controllers\Api\EventInstagramController::class, 'postCarouselToInstagramApi']);
+    Route::get('events/{event}/embeds', ['as' => 'events.embeds', 'uses' => '\App\Http\Controllers\Api\EventsController@embeds']);
+    Route::get('events/{event}/minimal-embeds', ['as' => 'events.minimalEmbeds', 'uses' => '\App\Http\Controllers\Api\EventsController@minimalEmbeds']);
 
-    Route::post('events/{event}/attend', 'Api\EventsController@attendJson');
-    Route::delete('events/{event}/attend', 'Api\EventsController@unattendJson');
+    Route::post('events/{event}/attend', [\App\Http\Controllers\Api\EventsController::class, 'attendJson']);
+    Route::delete('events/{event}/attend', [\App\Http\Controllers\Api\EventsController::class, 'unattendJson']);
 
-    Route::put('events/{event}', 'Api\EventsController@update')->name('events.update');
-    Route::patch('events/{event}', 'Api\EventsController@patch')->name('events.patch');
+    Route::put('events/{event}', [\App\Http\Controllers\Api\EventsController::class, 'update'])->name('events.update');
+    Route::patch('events/{event}', [\App\Http\Controllers\Api\EventsController::class, 'patch'])->name('events.patch');
     Route::resource('events', 'Api\EventsController')->except(['update']);
 
-    Route::get('entities/{entity}/photos', ['as' => 'entities.photos', 'uses' => 'Api\EntitiesController@photos']);
-    Route::get('entities/{entity}/links', ['as' => 'entities.links', 'uses' => 'Api\EntitiesController@links']);
-    Route::get('entities/{entity}/locations', ['as' => 'entities.locations', 'uses' => 'Api\EntitiesController@locations']);
-    Route::get('entities/{entity}/contacts', ['as' => 'entities.contacts', 'uses' => 'Api\EntitiesController@contacts']);
-    Route::get('entities/{entity}/embeds', ['as' => 'entities.embeds', 'uses' => 'Api\EntitiesController@embeds']);
-    Route::get('entities/{entity}/minimal-embeds', ['as' => 'entities.minimalEmbeds', 'uses' => 'Api\EntitiesController@minimalEmbeds']);
-    Route::post('entities/{id}/photos', 'Api\EntitiesController@addPhoto');
-    Route::post('entities/{id}/links', 'Api\EntitiesController@addLink');
-    Route::post('entities/{id}/locations', 'Api\EntitiesController@addLocation');
-    Route::post('entities/{id}/contacts', 'Api\EntitiesController@addContact');
-    Route::put('entities/{id}/links/{linkId}', 'Api\EntitiesController@updateLink');
-    Route::patch('entities/{id}/links/{linkId}', 'Api\EntitiesController@patchLink');
-    Route::put('entities/{id}/locations/{locationId}', 'Api\EntitiesController@updateLocation');
-    Route::patch('entities/{id}/locations/{locationId}', 'Api\EntitiesController@patchLocation');
-    Route::put('entities/{id}/contacts/{contactId}', 'Api\EntitiesController@updateContact');
-    Route::patch('entities/{id}/contacts/{contactId}', 'Api\EntitiesController@patchContact');
-    Route::delete('entities/{id}/links/{linkId}', 'Api\EntitiesController@deleteLink');
-    Route::delete('entities/{id}/locations/{locationId}', 'Api\EntitiesController@deleteLocation');
-    Route::delete('entities/{id}/contacts/{contactId}', 'Api\EntitiesController@deleteContact');
-    Route::post('entities/{entity}/follow', 'Api\EntitiesController@followJson')->middleware('auth:sanctum');
-    Route::post('entities/{entity}/unfollow', 'Api\EntitiesController@unfollowJson')->middleware('auth:sanctum');
-    Route::get('entities/popular', ['as' => 'entities.popular', 'uses' => 'Api\EntitiesController@popular']);
-    Route::get('entities/following', ['as' => 'entities.following', 'uses' => 'Api\EntitiesController@indexFollowingJson'])->middleware('auth:sanctum');
+    Route::get('entities/{entity}/photos', ['as' => 'entities.photos', 'uses' => '\App\Http\Controllers\Api\EntitiesController@photos']);
+    Route::get('entities/{entity}/links', ['as' => 'entities.links', 'uses' => '\App\Http\Controllers\Api\EntitiesController@links']);
+    Route::get('entities/{entity}/locations', ['as' => 'entities.locations', 'uses' => '\App\Http\Controllers\Api\EntitiesController@locations']);
+    Route::get('entities/{entity}/contacts', ['as' => 'entities.contacts', 'uses' => '\App\Http\Controllers\Api\EntitiesController@contacts']);
+    Route::get('entities/{entity}/embeds', ['as' => 'entities.embeds', 'uses' => '\App\Http\Controllers\Api\EntitiesController@embeds']);
+    Route::get('entities/{entity}/minimal-embeds', ['as' => 'entities.minimalEmbeds', 'uses' => '\App\Http\Controllers\Api\EntitiesController@minimalEmbeds']);
+    Route::post('entities/{id}/photos', [\App\Http\Controllers\Api\EntitiesController::class, 'addPhoto']);
+    Route::post('entities/{id}/links', [\App\Http\Controllers\Api\EntitiesController::class, 'addLink']);
+    Route::post('entities/{id}/locations', [\App\Http\Controllers\Api\EntitiesController::class, 'addLocation']);
+    Route::post('entities/{id}/contacts', [\App\Http\Controllers\Api\EntitiesController::class, 'addContact']);
+    Route::put('entities/{id}/links/{linkId}', [\App\Http\Controllers\Api\EntitiesController::class, 'updateLink']);
+    Route::patch('entities/{id}/links/{linkId}', [\App\Http\Controllers\Api\EntitiesController::class, 'patchLink']);
+    Route::put('entities/{id}/locations/{locationId}', [\App\Http\Controllers\Api\EntitiesController::class, 'updateLocation']);
+    Route::patch('entities/{id}/locations/{locationId}', [\App\Http\Controllers\Api\EntitiesController::class, 'patchLocation']);
+    Route::put('entities/{id}/contacts/{contactId}', [\App\Http\Controllers\Api\EntitiesController::class, 'updateContact']);
+    Route::patch('entities/{id}/contacts/{contactId}', [\App\Http\Controllers\Api\EntitiesController::class, 'patchContact']);
+    Route::delete('entities/{id}/links/{linkId}', [\App\Http\Controllers\Api\EntitiesController::class, 'deleteLink']);
+    Route::delete('entities/{id}/locations/{locationId}', [\App\Http\Controllers\Api\EntitiesController::class, 'deleteLocation']);
+    Route::delete('entities/{id}/contacts/{contactId}', [\App\Http\Controllers\Api\EntitiesController::class, 'deleteContact']);
+    Route::post('entities/{entity}/follow', [\App\Http\Controllers\Api\EntitiesController::class, 'followJson'])->middleware('auth:sanctum');
+    Route::post('entities/{entity}/unfollow', [\App\Http\Controllers\Api\EntitiesController::class, 'unfollowJson'])->middleware('auth:sanctum');
+    Route::get('entities/popular', ['as' => 'entities.popular', 'uses' => '\App\Http\Controllers\Api\EntitiesController@popular']);
+    Route::get('entities/following', ['as' => 'entities.following', 'uses' => '\App\Http\Controllers\Api\EntitiesController@indexFollowingJson'])->middleware('auth:sanctum');
     // PUT replaces the resource; PATCH applies a partial update. Both are
     // wired explicitly so they map to distinct controller methods rather than
     // the single update() endpoint Route::resource would otherwise generate.
-    Route::put('entities/{entity}', 'Api\EntitiesController@update')->name('entities.update');
-    Route::patch('entities/{entity}', 'Api\EntitiesController@patch')->name('entities.patch');
+    Route::put('entities/{entity}', [\App\Http\Controllers\Api\EntitiesController::class, 'update'])->name('entities.update');
+    Route::patch('entities/{entity}', [\App\Http\Controllers\Api\EntitiesController::class, 'patch'])->name('entities.patch');
     Route::resource('entities', 'Api\EntitiesController')->except(['update']);
 
-    Route::match(['get', 'post'], 'entity-types/filter', ['as' => 'entityType.filter', 'uses' => 'Api\EntityTypesController@filter']);
-    Route::get('entity-types/reset', ['as' => 'entity-types.reset', 'uses' => 'Api\EntityTypesController@reset']);
-    Route::get('entity-types/rpp-reset', ['as' => 'entity-types.rppReset', 'uses' => 'Api\EntityTypesController@rppReset']);
-    Route::put('entity-types/{entity_type}', 'Api\EntityTypesController@update')->name('entity-types.update');
-    Route::patch('entity-types/{entity_type}', 'Api\EntityTypesController@patch')->name('entity-types.patch');
+    Route::match(['get', 'post'], 'entity-types/filter', ['as' => 'entityType.filter', 'uses' => '\App\Http\Controllers\Api\EntityTypesController@filter']);
+    Route::get('entity-types/reset', ['as' => 'entity-types.reset', 'uses' => '\App\Http\Controllers\Api\EntityTypesController@reset']);
+    Route::get('entity-types/rpp-reset', ['as' => 'entity-types.rppReset', 'uses' => '\App\Http\Controllers\Api\EntityTypesController@rppReset']);
+    Route::put('entity-types/{entity_type}', [\App\Http\Controllers\Api\EntityTypesController::class, 'update'])->name('entity-types.update');
+    Route::patch('entity-types/{entity_type}', [\App\Http\Controllers\Api\EntityTypesController::class, 'patch'])->name('entity-types.patch');
     Route::resource('entity-types', 'Api\EntityTypesController')->except(['update']);
 
-    Route::match(['get', 'post'], 'entity-statuses/filter', ['as' => 'entityStatus.filter', 'uses' => 'Api\EntityStatusesController@filter']);
-    Route::get('entity-statuses/reset', ['as' => 'entity-statuses.reset', 'uses' => 'Api\EntityStatusesController@reset']);
-    Route::get('entity-statuses/rpp-reset', ['as' => 'entity-statuses.rppReset', 'uses' => 'Api\EntityStatusesController@rppReset']);
-    Route::put('entity-statuses/{entity_status}', 'Api\EntityStatusesController@update')->name('entity-statuses.update');
-    Route::patch('entity-statuses/{entity_status}', 'Api\EntityStatusesController@patch')->name('entity-statuses.patch');
+    Route::match(['get', 'post'], 'entity-statuses/filter', ['as' => 'entityStatus.filter', 'uses' => '\App\Http\Controllers\Api\EntityStatusesController@filter']);
+    Route::get('entity-statuses/reset', ['as' => 'entity-statuses.reset', 'uses' => '\App\Http\Controllers\Api\EntityStatusesController@reset']);
+    Route::get('entity-statuses/rpp-reset', ['as' => 'entity-statuses.rppReset', 'uses' => '\App\Http\Controllers\Api\EntityStatusesController@rppReset']);
+    Route::put('entity-statuses/{entity_status}', [\App\Http\Controllers\Api\EntityStatusesController::class, 'update'])->name('entity-statuses.update');
+    Route::patch('entity-statuses/{entity_status}', [\App\Http\Controllers\Api\EntityStatusesController::class, 'patch'])->name('entity-statuses.patch');
     Route::resource('entity-statuses', 'Api\EntityStatusesController')->except(['update']);
 
-    Route::match(['get', 'post'], 'event-types/filter', ['as' => 'eventType.filter', 'uses' => 'Api\EventTypesController@filter']);
-    Route::get('event-types/reset', ['as' => 'event-types.reset', 'uses' => 'Api\EventTypesController@reset']);
-    Route::get('event-types/rpp-reset', ['as' => 'event-types.rppReset', 'uses' => 'Api\EventTypesController@rppReset']);
-    Route::put('event-types/{event_type}', 'Api\EventTypesController@update')->name('event-types.update');
-    Route::patch('event-types/{event_type}', 'Api\EventTypesController@patch')->name('event-types.patch');
+    Route::match(['get', 'post'], 'event-types/filter', ['as' => 'eventType.filter', 'uses' => '\App\Http\Controllers\Api\EventTypesController@filter']);
+    Route::get('event-types/reset', ['as' => 'event-types.reset', 'uses' => '\App\Http\Controllers\Api\EventTypesController@reset']);
+    Route::get('event-types/rpp-reset', ['as' => 'event-types.rppReset', 'uses' => '\App\Http\Controllers\Api\EventTypesController@rppReset']);
+    Route::put('event-types/{event_type}', [\App\Http\Controllers\Api\EventTypesController::class, 'update'])->name('event-types.update');
+    Route::patch('event-types/{event_type}', [\App\Http\Controllers\Api\EventTypesController::class, 'patch'])->name('event-types.patch');
     Route::resource('event-types', 'Api\EventTypesController')->except(['update']);
 
-    Route::match(['get', 'post'], 'event-statuses/filter', ['as' => 'eventStatus.filter', 'uses' => 'Api\EventStatusesController@filter']);
-    Route::get('event-statuses/reset', ['as' => 'event-statuses.reset', 'uses' => 'Api\EventStatusesController@reset']);
-    Route::get('event-statuses/rpp-reset', ['as' => 'event-statuses.rppReset', 'uses' => 'Api\EventStatusesController@rppReset']);
-    Route::put('event-statuses/{event_status}', 'Api\EventStatusesController@update')->name('event-statuses.update');
-    Route::patch('event-statuses/{event_status}', 'Api\EventStatusesController@patch')->name('event-statuses.patch');
+    Route::match(['get', 'post'], 'event-statuses/filter', ['as' => 'eventStatus.filter', 'uses' => '\App\Http\Controllers\Api\EventStatusesController@filter']);
+    Route::get('event-statuses/reset', ['as' => 'event-statuses.reset', 'uses' => '\App\Http\Controllers\Api\EventStatusesController@reset']);
+    Route::get('event-statuses/rpp-reset', ['as' => 'event-statuses.rppReset', 'uses' => '\App\Http\Controllers\Api\EventStatusesController@rppReset']);
+    Route::put('event-statuses/{event_status}', [\App\Http\Controllers\Api\EventStatusesController::class, 'update'])->name('event-statuses.update');
+    Route::patch('event-statuses/{event_status}', [\App\Http\Controllers\Api\EventStatusesController::class, 'patch'])->name('event-statuses.patch');
     Route::resource('event-statuses', 'Api\EventStatusesController')->except(['update']);
 
-    Route::match(['get', 'post'], 'forums/filter', ['as' => 'forums.filter', 'uses' => 'Api\ForumsController@filter']);
-    Route::get('forums/reset', ['as' => 'forums.reset', 'uses' => 'Api\ForumsController@reset']);
-    Route::get('forums/rpp-reset', ['as' => 'forums.rppReset', 'uses' => 'Api\ForumsController@rppReset']);
-    Route::put('forums/{forum}', 'Api\ForumsController@update')->name('forums.update');
-    Route::patch('forums/{forum}', 'Api\ForumsController@patch')->name('forums.patch');
+    Route::match(['get', 'post'], 'forums/filter', ['as' => 'forums.filter', 'uses' => '\App\Http\Controllers\Api\ForumsController@filter']);
+    Route::get('forums/reset', ['as' => 'forums.reset', 'uses' => '\App\Http\Controllers\Api\ForumsController@reset']);
+    Route::get('forums/rpp-reset', ['as' => 'forums.rppReset', 'uses' => '\App\Http\Controllers\Api\ForumsController@rppReset']);
+    Route::put('forums/{forum}', [\App\Http\Controllers\Api\ForumsController::class, 'update'])->name('forums.update');
+    Route::patch('forums/{forum}', [\App\Http\Controllers\Api\ForumsController::class, 'patch'])->name('forums.patch');
     Route::apiResource('forums', 'Api\ForumsController')->except(['update']);
 
-    Route::match(['get', 'post'], 'links/filter', ['as' => 'links.filter', 'uses' => 'Api\LinksController@filter']);
-    Route::get('links/reset', ['as' => 'links.reset', 'uses' => 'Api\LinksController@reset']);
-    Route::get('links/rpp-reset', ['as' => 'links.rppReset', 'uses' => 'Api\LinksController@rppReset']);
+    Route::match(['get', 'post'], 'links/filter', ['as' => 'links.filter', 'uses' => '\App\Http\Controllers\Api\LinksController@filter']);
+    Route::get('links/reset', ['as' => 'links.reset', 'uses' => '\App\Http\Controllers\Api\LinksController@reset']);
+    Route::get('links/rpp-reset', ['as' => 'links.rppReset', 'uses' => '\App\Http\Controllers\Api\LinksController@rppReset']);
     Route::apiResource('links', 'Api\LinksController');
-    Route::put('menus/{menu}', 'Api\MenusController@update')->name('menus.update');
-    Route::patch('menus/{menu}', 'Api\MenusController@patch')->name('menus.patch');
+    Route::put('menus/{menu}', [\App\Http\Controllers\Api\MenusController::class, 'update'])->name('menus.update');
+    Route::patch('menus/{menu}', [\App\Http\Controllers\Api\MenusController::class, 'patch'])->name('menus.patch');
     Route::resource('menus', 'Api\MenusController')->except(['update']);
 
-    Route::match(['get', 'post'], 'locations/filter', ['as' => 'locations.filter', 'uses' => 'Api\LocationsController@filter']);
-    Route::get('locations/reset', ['as' => 'locations.reset', 'uses' => 'Api\LocationsController@reset']);
-    Route::get('locations/rpp-reset', ['as' => 'locations.rppReset', 'uses' => 'Api\LocationsController@rppReset']);
-    Route::put('locations/{location}', 'Api\LocationsController@update')->name('locations.update');
-    Route::patch('locations/{location}', 'Api\LocationsController@patch')->name('locations.patch');
+    Route::match(['get', 'post'], 'locations/filter', ['as' => 'locations.filter', 'uses' => '\App\Http\Controllers\Api\LocationsController@filter']);
+    Route::get('locations/reset', ['as' => 'locations.reset', 'uses' => '\App\Http\Controllers\Api\LocationsController@reset']);
+    Route::get('locations/rpp-reset', ['as' => 'locations.rppReset', 'uses' => '\App\Http\Controllers\Api\LocationsController@rppReset']);
+    Route::put('locations/{location}', [\App\Http\Controllers\Api\LocationsController::class, 'update'])->name('locations.update');
+    Route::patch('locations/{location}', [\App\Http\Controllers\Api\LocationsController::class, 'patch'])->name('locations.patch');
     Route::resource('locations', 'Api\LocationsController')->except(['update']);
 
-    Route::get('series/reset', ['as' => 'series.reset', 'uses' => 'Api\SeriesController@reset']);
-    Route::get('series/rpp-reset', ['as' => 'series.rppReset', 'uses' => 'Api\SeriesController@rppReset']);
-    Route::get('series/{series}/photos', ['as' => 'series.photos', 'uses' => 'Api\SeriesController@photos']);
-    Route::get('series/{series}/all-photos', ['as' => 'series.allPhotos', 'uses' => 'Api\SeriesController@allPhotos']);
-    Route::post('series/{id}/photos', 'Api\SeriesController@addPhoto');
-    Route::post('series/{series}/follow', 'Api\SeriesController@followJson')->middleware('auth:sanctum');
-    Route::post('series/{series}/unfollow', 'Api\SeriesController@unfollowJson')->middleware('auth:sanctum');
-    Route::get('series/popular', ['as' => 'series.popular', 'uses' => 'Api\SeriesController@popular']);
-    Route::put('series/{series}', 'Api\SeriesController@update')->name('series.update');
-    Route::patch('series/{series}', 'Api\SeriesController@patch')->name('series.patch');
+    Route::get('series/reset', ['as' => 'series.reset', 'uses' => '\App\Http\Controllers\Api\SeriesController@reset']);
+    Route::get('series/rpp-reset', ['as' => 'series.rppReset', 'uses' => '\App\Http\Controllers\Api\SeriesController@rppReset']);
+    Route::get('series/{series}/photos', ['as' => 'series.photos', 'uses' => '\App\Http\Controllers\Api\SeriesController@photos']);
+    Route::get('series/{series}/all-photos', ['as' => 'series.allPhotos', 'uses' => '\App\Http\Controllers\Api\SeriesController@allPhotos']);
+    Route::post('series/{id}/photos', [\App\Http\Controllers\Api\SeriesController::class, 'addPhoto']);
+    Route::post('series/{series}/follow', [\App\Http\Controllers\Api\SeriesController::class, 'followJson'])->middleware('auth:sanctum');
+    Route::post('series/{series}/unfollow', [\App\Http\Controllers\Api\SeriesController::class, 'unfollowJson'])->middleware('auth:sanctum');
+    Route::get('series/popular', ['as' => 'series.popular', 'uses' => '\App\Http\Controllers\Api\SeriesController@popular']);
+    Route::put('series/{series}', [\App\Http\Controllers\Api\SeriesController::class, 'update'])->name('series.update');
+    Route::patch('series/{series}', [\App\Http\Controllers\Api\SeriesController::class, 'patch'])->name('series.patch');
     Route::apiResource('series', 'Api\SeriesController')->except(['update']);
 
-    Route::match(['get', 'post'], 'tags/filter', ['as' => 'tags.filter', 'uses' => 'Api\TagsController@filter']);
-    Route::get('tags/reset', ['as' => 'tags.reset', 'uses' => 'Api\TagsController@reset']);
-    Route::get('tags/rpp-reset', ['as' => 'tags.rppReset', 'uses' => 'Api\TagsController@rppReset']);
-    Route::post('tags/{tag}/follow', 'Api\TagsController@followJson')->middleware('auth:sanctum');
-    Route::post('tags/{tag}/unfollow', 'Api\TagsController@unfollowJson')->middleware('auth:sanctum');
-    Route::delete('tags/{tag}', 'Api\TagsController@destroy');
-    Route::get('tags/{tag}/related-tags', ['as' => 'tags.relatedTags', 'uses' => 'Api\TagsController@relatedTags']);
-    Route::get('tags/popular', ['as' => 'tags.popular', 'uses' => 'Api\TagsController@popular']);
+    Route::match(['get', 'post'], 'tags/filter', ['as' => 'tags.filter', 'uses' => '\App\Http\Controllers\Api\TagsController@filter']);
+    Route::get('tags/reset', ['as' => 'tags.reset', 'uses' => '\App\Http\Controllers\Api\TagsController@reset']);
+    Route::get('tags/rpp-reset', ['as' => 'tags.rppReset', 'uses' => '\App\Http\Controllers\Api\TagsController@rppReset']);
+    Route::post('tags/{tag}/follow', [\App\Http\Controllers\Api\TagsController::class, 'followJson'])->middleware('auth:sanctum');
+    Route::post('tags/{tag}/unfollow', [\App\Http\Controllers\Api\TagsController::class, 'unfollowJson'])->middleware('auth:sanctum');
+    Route::delete('tags/{tag}', [\App\Http\Controllers\Api\TagsController::class, 'destroy']);
+    Route::get('tags/{tag}/related-tags', ['as' => 'tags.relatedTags', 'uses' => '\App\Http\Controllers\Api\TagsController@relatedTags']);
+    Route::get('tags/popular', ['as' => 'tags.popular', 'uses' => '\App\Http\Controllers\Api\TagsController@popular']);
     Route::resource('tags', 'Api\TagsController')->except(['destroy']);
-    Route::match(['get', 'post'], 'tag-types/filter', ['as' => 'tag-types.filter', 'uses' => 'Api\TagTypesController@filter']);
+    Route::match(['get', 'post'], 'tag-types/filter', ['as' => 'tag-types.filter', 'uses' => '\App\Http\Controllers\Api\TagTypesController@filter']);
     Route::resource('tag-types', 'Api\TagTypesController')->only(['index', 'show']);
 
 
-    Route::match(['get', 'post'], 'roles/filter', ['as' => 'roles.filter', 'uses' => 'Api\RolesController@filter']);
-    Route::get('roles/reset', ['as' => 'roles.reset', 'uses' => 'Api\RolesController@reset']);
-    Route::get('roles/rpp-reset', ['as' => 'roles.rppReset', 'uses' => 'Api\RolesController@rppReset']);
-    Route::put('roles/{role}', 'Api\RolesController@update')->name('roles.update');
-    Route::patch('roles/{role}', 'Api\RolesController@patch')->name('roles.patch');
+    Route::match(['get', 'post'], 'roles/filter', ['as' => 'roles.filter', 'uses' => '\App\Http\Controllers\Api\RolesController@filter']);
+    Route::get('roles/reset', ['as' => 'roles.reset', 'uses' => '\App\Http\Controllers\Api\RolesController@reset']);
+    Route::get('roles/rpp-reset', ['as' => 'roles.rppReset', 'uses' => '\App\Http\Controllers\Api\RolesController@rppReset']);
+    Route::put('roles/{role}', [\App\Http\Controllers\Api\RolesController::class, 'update'])->name('roles.update');
+    Route::patch('roles/{role}', [\App\Http\Controllers\Api\RolesController::class, 'patch'])->name('roles.patch');
     Route::resource('roles', 'Api\RolesController')->except(['update']);
 
 
-    Route::match(['get', 'post'], 'posts/filter', ['as' => 'posts.filter', 'uses' => 'Api\PostsController@filter']);
-    Route::get('posts/reset', ['as' => 'posts.reset', 'uses' => 'Api\PostsController@reset']);
-    Route::get('posts/rpp-reset', ['as' => 'posts.rppReset', 'uses' => 'Api\PostsController@rppReset']);
-    Route::put('posts/{post}', 'Api\PostsController@update')->name('posts.update');
-    Route::patch('posts/{post}', 'Api\PostsController@patch')->name('posts.patch');
+    Route::match(['get', 'post'], 'posts/filter', ['as' => 'posts.filter', 'uses' => '\App\Http\Controllers\Api\PostsController@filter']);
+    Route::get('posts/reset', ['as' => 'posts.reset', 'uses' => '\App\Http\Controllers\Api\PostsController@reset']);
+    Route::get('posts/rpp-reset', ['as' => 'posts.rppReset', 'uses' => '\App\Http\Controllers\Api\PostsController@rppReset']);
+    Route::put('posts/{post}', [\App\Http\Controllers\Api\PostsController::class, 'update'])->name('posts.update');
+    Route::patch('posts/{post}', [\App\Http\Controllers\Api\PostsController::class, 'patch'])->name('posts.patch');
     Route::apiResource('posts', 'Api\PostsController')->except(['update']);
 
-    Route::match(['get', 'post'], 'threads/filter', ['as' => 'threads.filter', 'uses' => 'Api\ThreadsController@filter']);
-    Route::get('threads/reset', ['as' => 'threads.reset', 'uses' => 'Api\ThreadsController@reset']);
-    Route::get('threads/rpp-reset', ['as' => 'threads.rppReset', 'uses' => 'Api\ThreadsController@rppReset']);
-    Route::get('threads/{threadId}/posts', ['as' => 'threads.posts', 'uses' => 'Api\ThreadsController@posts']);
-    Route::put('threads/{thread}', 'Api\ThreadsController@update')->name('threads.update');
-    Route::patch('threads/{thread}', 'Api\ThreadsController@patch')->name('threads.patch');
+    Route::match(['get', 'post'], 'threads/filter', ['as' => 'threads.filter', 'uses' => '\App\Http\Controllers\Api\ThreadsController@filter']);
+    Route::get('threads/reset', ['as' => 'threads.reset', 'uses' => '\App\Http\Controllers\Api\ThreadsController@reset']);
+    Route::get('threads/rpp-reset', ['as' => 'threads.rppReset', 'uses' => '\App\Http\Controllers\Api\ThreadsController@rppReset']);
+    Route::get('threads/{threadId}/posts', ['as' => 'threads.posts', 'uses' => '\App\Http\Controllers\Api\ThreadsController@posts']);
+    Route::put('threads/{thread}', [\App\Http\Controllers\Api\ThreadsController::class, 'update'])->name('threads.update');
+    Route::patch('threads/{thread}', [\App\Http\Controllers\Api\ThreadsController::class, 'patch'])->name('threads.patch');
     Route::apiResource('threads', 'Api\ThreadsController')->except(['update']);
 
-    Route::match(['get', 'post'], 'users/filter', ['as' => 'users.filter', 'uses' => 'Api\UsersController@filter']);
-    Route::get('users/reset', ['as' => 'users.reset', 'uses' => 'Api\UsersController@reset']);
-    Route::get('users/rpp-reset', ['as' => 'users.rppReset', 'uses' => 'Api\UsersController@rppReset']);
-    Route::get('users/{user}/events-attending', ['as' => 'users.events-attending', 'uses' => 'Api\UsersController@eventsAttending']);
+    Route::match(['get', 'post'], 'users/filter', ['as' => 'users.filter', 'uses' => '\App\Http\Controllers\Api\UsersController@filter']);
+    Route::get('users/reset', ['as' => 'users.reset', 'uses' => '\App\Http\Controllers\Api\UsersController@reset']);
+    Route::get('users/rpp-reset', ['as' => 'users.rppReset', 'uses' => '\App\Http\Controllers\Api\UsersController@rppReset']);
+    Route::get('users/{user}/events-attending', ['as' => 'users.events-attending', 'uses' => '\App\Http\Controllers\Api\UsersController@eventsAttending']);
     Route::apiResource('users', 'Api\UsersController');
 
-    Route::match(['get', 'post'], 'visibilities/filter', ['as' => 'visibilities.filter', 'uses' => 'Api\VisibilitiesController@filter']);
+    Route::match(['get', 'post'], 'visibilities/filter', ['as' => 'visibilities.filter', 'uses' => '\App\Http\Controllers\Api\VisibilitiesController@filter']);
     Route::resource('visibilities', 'Api\VisibilitiesController')->only(['index', 'show']);
 
-    Route::match(['get', 'post'], 'occurrence-types/filter', ['as' => 'occurrence-types.filter', 'uses' => 'Api\OccurrenceTypesController@filter']);
+    Route::match(['get', 'post'], 'occurrence-types/filter', ['as' => 'occurrence-types.filter', 'uses' => '\App\Http\Controllers\Api\OccurrenceTypesController@filter']);
     Route::resource('occurrence-types', 'Api\OccurrenceTypesController')->only(['index', 'show']);
 
-    Route::match(['get', 'post'], 'occurrence-weeks/filter', ['as' => 'occurrence-weeks.filter', 'uses' => 'Api\OccurrenceWeeksController@filter']);
+    Route::match(['get', 'post'], 'occurrence-weeks/filter', ['as' => 'occurrence-weeks.filter', 'uses' => '\App\Http\Controllers\Api\OccurrenceWeeksController@filter']);
     Route::resource('occurrence-weeks', 'Api\OccurrenceWeeksController')->only(['index', 'show']);
 
-    Route::match(['get', 'post'], 'occurrence-days/filter', ['as' => 'occurrence-days.filter', 'uses' => 'Api\OccurrenceDaysController@filter']);
+    Route::match(['get', 'post'], 'occurrence-days/filter', ['as' => 'occurrence-days.filter', 'uses' => '\App\Http\Controllers\Api\OccurrenceDaysController@filter']);
     Route::resource('occurrence-days', 'Api\OccurrenceDaysController')->only(['index', 'show']);
 
     // photo management endpoints
-    Route::post('photos/{photo}/set-primary', 'Api\\PhotosController@setPrimary');
-    Route::post('photos/{photo}/unset-primary', 'Api\\PhotosController@unsetPrimary');
-    Route::delete('photos/{photo}', 'Api\\PhotosController@destroy');
+    Route::post('photos/{photo}/set-primary', [\App\Http\Controllers\Api\PhotosController::class, 'setPrimary']);
+    Route::post('photos/{photo}/unset-primary', [\App\Http\Controllers\Api\PhotosController::class, 'unsetPrimary']);
+    Route::delete('photos/{photo}', [\App\Http\Controllers\Api\PhotosController::class, 'destroy']);
 });
 
 // routes protected by the shield middleware
@@ -251,18 +251,18 @@ Route::middleware('shield')->name('shield.')->group(function () {
 });
 
 // calendar routes - these are used by the web app for dynamic loading
-Route::get('calendar-events', 'EventsController@calendarEventsApi')->name('calendarEvents.api');
-Route::get('tag-calendar-events', 'EventsController@tagCalendarEventsApi')->name('tagCalendarEvents.api');
+Route::get('calendar-events', [\App\Http\Controllers\EventsController::class, 'calendarEventsApi'])->name('calendarEvents.api');
+Route::get('tag-calendar-events', [\App\Http\Controllers\EventsController::class, 'tagCalendarEventsApi'])->name('tagCalendarEvents.api');
 
 // user registration endpoint
-Route::post('register', 'Api\\RegisterController@register');
+Route::post('register', [\App\Http\Controllers\Api\RegisterController::class, 'register']);
 
 // Email verification endpoint — signature enforced to prevent
 // account takeover via crafted URLs.
-Route::get('email/verify/{id}/{hash}', 'Api\\EmailVerificationController@verify')
+Route::get('email/verify/{id}/{hash}', [\App\Http\Controllers\Api\EmailVerificationController::class, 'verify'])
     ->middleware(['signed:relative', 'throttle:6,1'])
     ->name('api.verification.verify');
 
 // password reset endpoints
-Route::post('user/send-password-reset-email', 'Api\\PasswordResetController@sendPasswordResetEmail');
-Route::post('user/reset-password', 'Api\\PasswordResetController@resetPassword');
+Route::post('user/send-password-reset-email', [\App\Http\Controllers\Api\PasswordResetController::class, 'sendPasswordResetEmail']);
+Route::post('user/reset-password', [\App\Http\Controllers\Api\PasswordResetController::class, 'resetPassword']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,12 +42,12 @@ use Illuminate\Support\Facades\Route;
 Auth::routes();
 
 // Email verification routes — `verification.verify` MUST be signed.
-Route::get('email/verify', 'Auth\VerificationController@show')
+Route::get('email/verify', [\App\Http\Controllers\Auth\VerificationController::class, 'show'])
     ->name('verification.notice');
-Route::get('email/verify/{id}/{hash}', 'Auth\VerificationController@verify')
+Route::get('email/verify/{id}/{hash}', [\App\Http\Controllers\Auth\VerificationController::class, 'verify'])
     ->middleware(['signed:relative', 'throttle:6,1'])
     ->name('verification.verify');
-Route::post('email/resend', 'Auth\VerificationController@resend')
+Route::post('email/resend', [\App\Http\Controllers\Auth\VerificationController::class, 'resend'])
     ->name('verification.resend');
 
 Route::get('tokens/test', function () {
@@ -57,77 +57,62 @@ Route::get('tokens/test', function () {
 Route::view('/api/docs', 'docs.swagger');
 
 
-// Authentication Routes...
-$this->get('login', 'Auth\LoginController@showLoginForm')->name('login');
-$this->post('login', 'Auth\LoginController@login');
-$this->post('logout', 'Auth\LoginController@logout')->name('logout');
+Route::get('/', [\App\Http\Controllers\PagesController::class, 'home'])->name('home');
+Route::get('/home', [\App\Http\Controllers\PagesController::class, 'home'])->name('pages.home');
 
-// Registration Routes...
-$this->get('register', 'Auth\RegisterController@showRegistrationForm')->name('register');
-$this->post('register', 'Auth\RegisterController@register')->middleware(ProtectAgainstSpam::class);
-
-// Password Reset Routes...
-Route::get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm')->name('password.forgot');
-Route::post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail');
-Route::get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')->name('password.reset');
-Route::post('password/reset', 'Auth\ResetPasswordController@reset');
-
-Route::get('/', 'PagesController@home')->name('home');
-Route::get('/home', 'PagesController@home')->name('pages.home');
-
-Route::get('about', 'PagesController@about');
-Route::get('privacy', 'PagesController@privacy');
-Route::get('tos', 'PagesController@tos');
-Route::get('radar', 'PagesController@radar')->middleware('auth')->name('radar');
-Route::get('popular', 'PagesController@popular')->name('pages.popular');
+Route::get('about', [\App\Http\Controllers\PagesController::class, 'about']);
+Route::get('privacy', [\App\Http\Controllers\PagesController::class, 'privacy']);
+Route::get('tos', [\App\Http\Controllers\PagesController::class, 'tos']);
+Route::get('radar', [\App\Http\Controllers\PagesController::class, 'radar'])->middleware('auth')->name('radar');
+Route::get('popular', [\App\Http\Controllers\PagesController::class, 'popular'])->name('pages.popular');
 
 // Post-signup "Getting To Know You" onboarding (issue #901)
 Route::middleware('auth')->group(function () {
-    Route::get('onboarding/data', 'OnboardingController@data')->name('onboarding.data');
-    Route::post('onboarding/follow', 'OnboardingController@store')->name('onboarding.store');
-    Route::post('onboarding/dismiss', 'OnboardingController@dismiss')->name('onboarding.dismiss');
+    Route::get('onboarding/data', [\App\Http\Controllers\OnboardingController::class, 'data'])->name('onboarding.data');
+    Route::post('onboarding/follow', [\App\Http\Controllers\OnboardingController::class, 'store'])->name('onboarding.store');
+    Route::post('onboarding/dismiss', [\App\Http\Controllers\OnboardingController::class, 'dismiss'])->name('onboarding.dismiss');
 });
 
-Route::get('help', 'PagesController@help');
-Route::get('all-modules', 'PagesController@allModules')->name('pages.allModules');
+Route::get('help', [\App\Http\Controllers\PagesController::class, 'help']);
+Route::get('all-modules', [\App\Http\Controllers\PagesController::class, 'allModules'])->name('pages.allModules');
 
-Route::get('calendar', 'CalendarController@index')->name('calendar');
-Route::get('calendar/by-date/{year}/{month?}/{day?}', 'CalendarController@indexByDate')->name('calendar.byDate')
+Route::get('calendar', [\App\Http\Controllers\CalendarController::class, 'index'])->name('calendar');
+Route::get('calendar/by-date/{year}/{month?}/{day?}', [\App\Http\Controllers\CalendarController::class, 'indexByDate'])->name('calendar.byDate')
     ->where('year', '[1-9][0-9][0-9][0-9]')
     ->where('month', '(0?[1-9]|1[012])$')
     ->where('day', '[0-3][0-9]');
-Route::get('calendar/tag/{tag}', 'CalendarController@calendarTags')->name('calendar.tag');
-Route::get('tag-calendar', 'CalendarController@calendarTagOnly')->name('tag-calendar');
-Route::get('calendar/related-to/{slug}', 'CalendarController@calendarRelatedTo');
-Route::get('calendar/free', 'CalendarController@calendarFree')->name('calendar.free');
-Route::get('calendar/attending', 'CalendarController@calendarAttending')->name('calendar.attending');
-Route::get('calendar/type/{tag}', 'CalendarController@calendarEventTypes')->name('calendar.type');
-Route::get('calendar/min-age/{age}', 'CalendarController@calendarMinAge')->name('calendar.minAge');
+Route::get('calendar/tag/{tag}', [\App\Http\Controllers\CalendarController::class, 'calendarTags'])->name('calendar.tag');
+Route::get('tag-calendar', [\App\Http\Controllers\CalendarController::class, 'calendarTagOnly'])->name('tag-calendar');
+Route::get('calendar/related-to/{slug}', [\App\Http\Controllers\CalendarController::class, 'calendarRelatedTo']);
+Route::get('calendar/free', [\App\Http\Controllers\CalendarController::class, 'calendarFree'])->name('calendar.free');
+Route::get('calendar/attending', [\App\Http\Controllers\CalendarController::class, 'calendarAttending'])->name('calendar.attending');
+Route::get('calendar/type/{tag}', [\App\Http\Controllers\CalendarController::class, 'calendarEventTypes'])->name('calendar.type');
+Route::get('calendar/min-age/{age}', [\App\Http\Controllers\CalendarController::class, 'calendarMinAge'])->name('calendar.minAge');
 
-Route::get('search', 'PagesController@search')->name('pages.search');
+Route::get('search', [\App\Http\Controllers\PagesController::class, 'search'])->name('pages.search');
 
 Route::match(['get', 'post'], 'auto-relate-entity/{id}', [
     'as' => 'pages.relate',
-    'uses' => 'PagesController@autoRelateEntity',
+    'uses' => '\App\Http\Controllers\PagesController@autoRelateEntity',
 ]);
 
 Route::get('users/{id}/notify', [
     'as' => 'users.notify',
-    'uses' => 'UsersController@notifyUser',
+    'uses' => '\App\Http\Controllers\UsersController@notifyUser',
 ]);
-Route::match(['get', 'post'], 'activity/filter', ['as' => 'activities.filter', 'uses' => 'ActivityController@index']);
-Route::get('activity', 'ActivityController@index')->name('activities.index');
-Route::get('activity/graph', 'ActivityController@graph')->name('activities.graph')->middleware(['auth', 'can:admin']);
-Route::get('activity/graph/export', 'ActivityController@exportGraph')->name('activities.graph.export')->middleware(['auth', 'can:admin']);
-Route::get('activity/reset', ['as' => 'activities.reset', 'uses' => 'ActivityController@reset']);
-Route::get('activity/rpp-reset', ['as' => 'activities.rppReset', 'uses' => 'ActivityController@rppReset']);
+Route::match(['get', 'post'], 'activity/filter', ['as' => 'activities.filter', 'uses' => '\App\Http\Controllers\ActivityController@index']);
+Route::get('activity', [\App\Http\Controllers\ActivityController::class, 'index'])->name('activities.index');
+Route::get('activity/graph', [\App\Http\Controllers\ActivityController::class, 'graph'])->name('activities.graph')->middleware(['auth', 'can:admin']);
+Route::get('activity/graph/export', [\App\Http\Controllers\ActivityController::class, 'exportGraph'])->name('activities.graph.export')->middleware(['auth', 'can:admin']);
+Route::get('activity/reset', ['as' => 'activities.reset', 'uses' => '\App\Http\Controllers\ActivityController@reset']);
+Route::get('activity/rpp-reset', ['as' => 'activities.rppReset', 'uses' => '\App\Http\Controllers\ActivityController@rppReset']);
 
-Route::get('tools', 'PagesController@tools')->name('pages.tools');
-Route::post('invite', 'PagesController@invite')->name('pages.invite');
+Route::get('tools', [\App\Http\Controllers\PagesController::class, 'tools'])->name('pages.tools');
+Route::post('invite', [\App\Http\Controllers\PagesController::class, 'invite'])->name('pages.invite');
 
 Route::get('events/importPhotos', [
     'as' => 'events.importPhotos',
-    'uses' => 'EventsController@importPhotos',
+    'uses' => '\App\Http\Controllers\EventsController@importPhotos',
 ]);
 
 
@@ -141,92 +126,92 @@ Route::get('impersonate/{user}', function (User $user) {
     return redirect('/');
 })->middleware('can:admin')->name('user.impersonate');
 
-Route::post('users/{id}/photos', 'UsersController@addPhoto');
-Route::delete('users/{id}/photos/{photo_id}', 'UsersController@deletePhoto');
+Route::post('users/{id}/photos', [\App\Http\Controllers\UsersController::class, 'addPhoto']);
+Route::delete('users/{id}/photos/{photo_id}', [\App\Http\Controllers\UsersController::class, 'deletePhoto']);
 
 Route::get('users/{id}/activate', [
     'as' => 'users.activate',
-    'uses' => 'UsersController@activate',
+    'uses' => '\App\Http\Controllers\UsersController@activate',
 ]);
 
 Route::get('users/{id}/reminder', [
     'as' => 'users.reminder',
-    'uses' => 'UsersController@reminder',
+    'uses' => '\App\Http\Controllers\UsersController@reminder',
 ]);
 
 Route::get('users/{id}/weekly', [
     'as' => 'users.weekly',
-    'uses' => 'UsersController@weekly',
+    'uses' => '\App\Http\Controllers\UsersController@weekly',
 ]);
 
 Route::get('users/{id}/suspend', [
     'as' => 'users.suspend',
-    'uses' => 'UsersController@suspend',
+    'uses' => '\App\Http\Controllers\UsersController@suspend',
 ]);
 
 Route::get('users/{id}/ical', [
     'as' => 'users.ical',
-    'uses' => 'UsersController@ical',
+    'uses' => '\App\Http\Controllers\UsersController@ical',
 ]);
 
 Route::get('users/{id}/delete', [
     'as' => 'users.delete',
-    'uses' => 'UsersController@delete',
+    'uses' => '\App\Http\Controllers\UsersController@delete',
 ]);
 
 Route::get('users/{id}/reset-password', [
     'as' => 'users.showResetPassword',
-    'uses' => 'UsersController@showResetPassword',
+    'uses' => '\App\Http\Controllers\UsersController@showResetPassword',
 ])->middleware('can:grant_access');
 
 Route::post('users/{id}/reset-password', [
     'as' => 'users.resetPassword',
-    'uses' => 'UsersController@resetPassword',
+    'uses' => '\App\Http\Controllers\UsersController@resetPassword',
 ])->middleware('can:grant_access');
 
 Route::post('users/{id}/export-data', [
     'as' => 'users.exportData',
-    'uses' => 'UsersController@exportData',
+    'uses' => '\App\Http\Controllers\UsersController@exportData',
 ])->middleware('auth');
 
 Route::post('users/{id}/restart-onboarding', [
     'as' => 'users.restartOnboarding',
-    'uses' => 'UsersController@restartOnboarding',
+    'uses' => '\App\Http\Controllers\UsersController@restartOnboarding',
 ])->middleware('auth');
 
 Route::get('exports/download/{filename}', [
     'as' => 'exports.download',
-    'uses' => 'UsersController@downloadExport',
+    'uses' => '\App\Http\Controllers\UsersController@downloadExport',
 ])->middleware('signed');
 
-Route::post('purge', 'UsersController@purge')->name('users.purge');
+Route::post('purge', [\App\Http\Controllers\UsersController::class, 'purge'])->name('users.purge');
 
-Route::match(['get', 'post'], 'users/{id}/attending', 'EventsController@indexUserAttending')->name('users.attending');
-Route::match(['get', 'post'], 'users/{id}/attending-ical', 'EventsController@indexUserAttendingIcal')->name('users.attendingIcal');
-Route::match(['get', 'post'], 'users/{id}/interested-ical', 'EventsController@indexUserInterestedIcal')->name('users.interestedIcal');
-Route::match(['get', 'post'], 'users/{id}/reset-user-attending', ['as' => 'users.resetUserAttending', 'uses' => 'EventsController@resetUserAttending']);
-Route::get('users/{id}/rpp-reset-user-attending', ['as' => 'users.rppResetUserAttending', 'uses' => 'EventsController@rppResetUserAttending']);
+Route::match(['get', 'post'], 'users/{id}/attending', [\App\Http\Controllers\EventsController::class, 'indexUserAttending'])->name('users.attending');
+Route::match(['get', 'post'], 'users/{id}/attending-ical', [\App\Http\Controllers\EventsController::class, 'indexUserAttendingIcal'])->name('users.attendingIcal');
+Route::match(['get', 'post'], 'users/{id}/interested-ical', [\App\Http\Controllers\EventsController::class, 'indexUserInterestedIcal'])->name('users.interestedIcal');
+Route::match(['get', 'post'], 'users/{id}/reset-user-attending', ['as' => 'users.resetUserAttending', 'uses' => '\App\Http\Controllers\EventsController@resetUserAttending']);
+Route::get('users/{id}/rpp-reset-user-attending', ['as' => 'users.rppResetUserAttending', 'uses' => '\App\Http\Controllers\EventsController@rppResetUserAttending']);
 
-Route::match(['get', 'post'], 'users/filter', ['as' => 'users.filter', 'uses' => 'UsersController@filter']);
-Route::get('users/reset', ['as' => 'users.reset', 'uses' => 'UsersController@reset']);
-Route::get('users/rpp-reset', ['as' => 'users.rppReset', 'uses' => 'UsersController@rppReset']);
+Route::match(['get', 'post'], 'users/filter', ['as' => 'users.filter', 'uses' => '\App\Http\Controllers\UsersController@filter']);
+Route::get('users/reset', ['as' => 'users.reset', 'uses' => '\App\Http\Controllers\UsersController@reset']);
+Route::get('users/rpp-reset', ['as' => 'users.rppReset', 'uses' => '\App\Http\Controllers\UsersController@rppReset']);
 
 Route::resource('users', 'UsersController')->except(['show'])->middleware('auth');
-Route::get('users/{user}', 'UsersController@show')->name('users.show');
+Route::get('users/{user}', [\App\Http\Controllers\UsersController::class, 'show'])->name('users.show');
 
-Route::get('profile/{user}', 'UsersController@show')->name('users.profile-show');
-Route::get('profile', 'UsersController@profile')->name('users.profile');
+Route::get('profile/{user}', [\App\Http\Controllers\UsersController::class, 'show'])->name('users.profile-show');
+Route::get('profile', [\App\Http\Controllers\UsersController::class, 'profile'])->name('users.profile');
 // PHOTOS
-Route::get('photos/reset', ['as' => 'photos.reset', 'uses' => 'PhotosController@reset']);
-Route::get('photos/rpp-reset', ['as' => 'photos.rppReset', 'uses' => 'PhotosController@rppReset']);
-Route::delete('photos/{id}', 'PhotosController@destroy');
-Route::post('photos/{id}/set-primary', 'PhotosController@setPrimary');
-Route::post('photos/{id}/unset-primary', 'PhotosController@unsetPrimary');
-Route::post('photos/{id}/set-event', 'PhotosController@setEvent');
-Route::post('photos/{id}/unset-event', 'PhotosController@unsetEvent');
-Route::get('photos/tag/{tag}', 'PhotosController@indexTags')->name('photos.tag');
+Route::get('photos/reset', ['as' => 'photos.reset', 'uses' => '\App\Http\Controllers\PhotosController@reset']);
+Route::get('photos/rpp-reset', ['as' => 'photos.rppReset', 'uses' => '\App\Http\Controllers\PhotosController@rppReset']);
+Route::delete('photos/{id}', [\App\Http\Controllers\PhotosController::class, 'destroy']);
+Route::post('photos/{id}/set-primary', [\App\Http\Controllers\PhotosController::class, 'setPrimary']);
+Route::post('photos/{id}/unset-primary', [\App\Http\Controllers\PhotosController::class, 'unsetPrimary']);
+Route::post('photos/{id}/set-event', [\App\Http\Controllers\PhotosController::class, 'setEvent']);
+Route::post('photos/{id}/unset-event', [\App\Http\Controllers\PhotosController::class, 'unsetEvent']);
+Route::get('photos/tag/{tag}', [\App\Http\Controllers\PhotosController::class, 'indexTags'])->name('photos.tag');
 
-Route::match(['get', 'post'], 'photos/filter', ['as' => 'photos.filter', 'uses' => 'PhotosController@filter']);
+Route::match(['get', 'post'], 'photos/filter', ['as' => 'photos.filter', 'uses' => '\App\Http\Controllers\PhotosController@filter']);
 
 Route::bind('photos', function ($id) {
     return Photo::whereId($id)->firstOrFail();
@@ -237,16 +222,16 @@ Route::resource('photos', 'PhotosController');
 // EVENTS
 Route::get('events/create-series', [
     'as' => 'events.createSeries',
-    'uses' => 'EventsController@createSeries',
+    'uses' => '\App\Http\Controllers\EventsController@createSeries',
 ]);
 Route::get('events/create-thread', [
     'as' => 'events.createThread',
-    'uses' => 'EventsController@createThread',
+    'uses' => '\App\Http\Controllers\EventsController@createThread',
 ]);
 
 Route::get('events/{id}/duplicate', [
     'as' => 'events.duplicate',
-    'uses' => 'EventsController@duplicate',
+    'uses' => '\App\Http\Controllers\EventsController@duplicate',
 ]);
 
 Route::get('events/dispatch', function () {
@@ -258,117 +243,117 @@ Route::get('update', function () {
     EventUpdated::dispatch(new Event());
 });
 
-Route::get('events/today', 'EventsController@indexToday');
-Route::match(['get', 'post'], 'events/grid', 'EventsController@indexGrid')->name('events.grid');
-Route::get('events/grid/tag/{slug}', 'EventsController@indexGridTags')->name('events.grid.tag');
-Route::get('events/grid/by-date/{year}/{month?}/{day?}', 'EventsController@indexGridByDate')->name('events.grid.byDate')
+Route::get('events/today', [\App\Http\Controllers\EventsController::class, 'indexToday']);
+Route::match(['get', 'post'], 'events/grid', [\App\Http\Controllers\EventsController::class, 'indexGrid'])->name('events.grid');
+Route::get('events/grid/tag/{slug}', [\App\Http\Controllers\EventsController::class, 'indexGridTags'])->name('events.grid.tag');
+Route::get('events/grid/by-date/{year}/{month?}/{day?}', [\App\Http\Controllers\EventsController::class, 'indexGridByDate'])->name('events.grid.byDate')
     ->where('year', '[1-9][0-9][0-9][0-9]')
     ->where('month', '(0?[1-9]|1[012])')
     ->where('day', '(0?[1-9]|[12][0-9]|3[01])');
-Route::get('events/grid/related-to/{slug}', 'EventsController@indexGridRelatedTo')->name('events.grid.relatedto');
-Route::get('events/grid/type/{slug}', 'EventsController@indexGridTypes')->name('events.grid.type');
-Route::get('events/grid/series/{slug}', 'EventsController@indexGridSeries')->name('events.grid.series');
-Route::get('events/grid/apply-filter', ['as' => 'events.grid.applyFilterFromUrl', 'uses' => 'EventsController@applyGridFilterFromUrl']);
-Route::match(['get', 'post'], 'events/photos', 'EventsController@indexPhoto')->name('events.photo');
-Route::get('events/future', 'EventsController@indexFuture')->name('events.future');
-Route::get('events/upcoming/{date?}', 'EventsController@indexUpcoming')->name('events.upcoming');
-Route::get('events/add/{date?}', 'EventsController@indexAdd')->name('events.add')
+Route::get('events/grid/related-to/{slug}', [\App\Http\Controllers\EventsController::class, 'indexGridRelatedTo'])->name('events.grid.relatedto');
+Route::get('events/grid/type/{slug}', [\App\Http\Controllers\EventsController::class, 'indexGridTypes'])->name('events.grid.type');
+Route::get('events/grid/series/{slug}', [\App\Http\Controllers\EventsController::class, 'indexGridSeries'])->name('events.grid.series');
+Route::get('events/grid/apply-filter', ['as' => 'events.grid.applyFilterFromUrl', 'uses' => '\App\Http\Controllers\EventsController@applyGridFilterFromUrl']);
+Route::match(['get', 'post'], 'events/photos', [\App\Http\Controllers\EventsController::class, 'indexPhoto'])->name('events.photo');
+Route::get('events/future', [\App\Http\Controllers\EventsController::class, 'indexFuture'])->name('events.future');
+Route::get('events/upcoming/{date?}', [\App\Http\Controllers\EventsController::class, 'indexUpcoming'])->name('events.upcoming');
+Route::get('events/add/{date?}', [\App\Http\Controllers\EventsController::class, 'indexAdd'])->name('events.add')
     ->where('date', '[1-2][0-9][0-9][0-9][0-3][0-9][0-9][0-9]');    
-Route::get('events/past', 'EventsController@indexPast');
-Route::get('events/week', 'EventsController@indexWeek')->name('events.week');
-Route::get('events/starting/{date}', 'EventsController@indexStarting')
+Route::get('events/past', [\App\Http\Controllers\EventsController::class, 'indexPast']);
+Route::get('events/week', [\App\Http\Controllers\EventsController::class, 'indexWeek'])->name('events.week');
+Route::get('events/starting/{date}', [\App\Http\Controllers\EventsController::class, 'indexStarting'])
     ->where('date', '[0-9]{8}|[0-9]{4}-[0-9]{2}-[0-9]{2}');
-Route::get('events/{id}/load-embeds', 'EventsController@loadEmbeds');
-Route::get('events/{id}/load-minimal-embeds', 'EventsController@loadMinimalEmbeds');
-Route::get('events/{slug}/minimal-embeds', 'EventsController@loadMinimalEmbedsBySlug');
-Route::get('events/{slug}/embeds', 'EventsController@loadEmbedsBySlug');
-Route::get('events/by-date/{year}/{month?}/{day?}', 'EventsController@indexByDate')
+Route::get('events/{id}/load-embeds', [\App\Http\Controllers\EventsController::class, 'loadEmbeds']);
+Route::get('events/{id}/load-minimal-embeds', [\App\Http\Controllers\EventsController::class, 'loadMinimalEmbeds']);
+Route::get('events/{slug}/minimal-embeds', [\App\Http\Controllers\EventsController::class, 'loadMinimalEmbedsBySlug']);
+Route::get('events/{slug}/embeds', [\App\Http\Controllers\EventsController::class, 'loadEmbedsBySlug']);
+Route::get('events/by-date/{year}/{month?}/{day?}', [\App\Http\Controllers\EventsController::class, 'indexByDate'])
     ->where('year', '[1-9][0-9][0-9][0-9]')
     ->where('month', '(0?[1-9]|1[012])$')
     ->where('day', '(0?[1-9]|[12][0-9]|3[01])');
-Route::get('events/daily', 'EventsController@daily');
-Route::get('events/day/{day}', 'EventsController@day')->name('events.day')
+Route::get('events/daily', [\App\Http\Controllers\EventsController::class, 'daily']);
+Route::get('events/day/{day}', [\App\Http\Controllers\EventsController::class, 'day'])->name('events.day')
     ->where('day', '[12][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])');
-Route::match(['get', 'post'], 'events/attending', 'EventsController@indexAttending')->name('events.attending');
-Route::match(['get', 'post'], 'events/filter', ['as' => 'events.filter', 'uses' => 'EventsController@filter']);
-Route::get('events/apply-filter', ['as' => 'events.applyFilterFromUrl', 'uses' => 'EventsController@applyFilterFromUrl']);
-Route::get('events/reset', ['as' => 'events.reset', 'uses' => 'EventsController@reset']);
-Route::get('events/rpp-reset', ['as' => 'events.rppReset', 'uses' => 'EventsController@rppReset']);
+Route::match(['get', 'post'], 'events/attending', [\App\Http\Controllers\EventsController::class, 'indexAttending'])->name('events.attending');
+Route::match(['get', 'post'], 'events/filter', ['as' => 'events.filter', 'uses' => '\App\Http\Controllers\EventsController@filter']);
+Route::get('events/apply-filter', ['as' => 'events.applyFilterFromUrl', 'uses' => '\App\Http\Controllers\EventsController@applyFilterFromUrl']);
+Route::get('events/reset', ['as' => 'events.reset', 'uses' => '\App\Http\Controllers\EventsController@reset']);
+Route::get('events/rpp-reset', ['as' => 'events.rppReset', 'uses' => '\App\Http\Controllers\EventsController@rppReset']);
 
 // FB access token
-Route::get('fb-access', 'EventsController@fbAuthToken');
+Route::get('fb-access', [\App\Http\Controllers\EventsController::class, 'fbAuthToken']);
 
 // POST to Instagram
-Route::get('events/{id}/instagram-post', 'Api\\EventInstagramController@postCarouselToInstagram')->name('events.instagramPost');
-Route::get('events/{id}/instagram-story-post', 'Api\\EventInstagramController@postStoryToInstagram')->name('events.instagramStoryPost');
-Route::get('events/{id}/instagram-post-single', 'Api\\EventInstagramController@postToInstagram')->name('events.instagramPostSingle');
-Route::get('events/instagram-post-week', 'Api\\EventInstagramController@postWeekToInstagram')->name('events.instagramPostWeek');
-Route::get('events/instagram-weekend-preview', 'Api\\EventInstagramController@postWeekendPreviewToInstagram')->name('events.instagramWeekendPreview');
+Route::get('events/{id}/instagram-post', [\App\Http\Controllers\Api\EventInstagramController::class, 'postCarouselToInstagram'])->name('events.instagramPost');
+Route::get('events/{id}/instagram-story-post', [\App\Http\Controllers\Api\EventInstagramController::class, 'postStoryToInstagram'])->name('events.instagramStoryPost');
+Route::get('events/{id}/instagram-post-single', [\App\Http\Controllers\Api\EventInstagramController::class, 'postToInstagram'])->name('events.instagramPostSingle');
+Route::get('events/instagram-post-week', [\App\Http\Controllers\Api\EventInstagramController::class, 'postWeekToInstagram'])->name('events.instagramPostWeek');
+Route::get('events/instagram-weekend-preview', [\App\Http\Controllers\Api\EventInstagramController::class, 'postWeekendPreviewToInstagram'])->name('events.instagramWeekendPreview');
 
 // Background job status + notifications
-Route::get('job-status', 'JobStatusController@index')->name('job-status.index');
-Route::get('job-status/{id}', 'JobStatusController@show')->name('job-status.show')->where('id', '[0-9]+');
-Route::post('job-status/notifications/read', 'JobStatusController@markNotificationsRead')->name('job-status.notifications.read');
+Route::get('job-status', [\App\Http\Controllers\JobStatusController::class, 'index'])->name('job-status.index');
+Route::get('job-status/{id}', [\App\Http\Controllers\JobStatusController::class, 'show'])->name('job-status.show')->where('id', '[0-9]+');
+Route::post('job-status/notifications/read', [\App\Http\Controllers\JobStatusController::class, 'markNotificationsRead'])->name('job-status.notifications.read');
 
-Route::get('events/tag/{tag}', 'EventsController@indexTags')->name('events.tag');
-Route::get('events/venue/{slug}', 'EventsController@indexVenues')->name('events.venue');
-Route::get('events/related-to/{slug}', 'EventsController@indexRelatedTo')->name('events.relatedto');
-Route::get('events/type/{slug}', 'EventsController@indexTypes');
-Route::get('events/series/{slug}', 'EventsController@indexSeries');
-Route::get('events/feed', 'EventsController@feed');
-Route::get('events/ical', 'EventsController@indexIcal')->name('events.indexIcal');
-Route::get('events/feed/tag/{tag}', 'EventsController@feedTags');
-Route::get('events/brief-text', 'EventsController@briefText');
+Route::get('events/tag/{tag}', [\App\Http\Controllers\EventsController::class, 'indexTags'])->name('events.tag');
+Route::get('events/venue/{slug}', [\App\Http\Controllers\EventsController::class, 'indexVenues'])->name('events.venue');
+Route::get('events/related-to/{slug}', [\App\Http\Controllers\EventsController::class, 'indexRelatedTo'])->name('events.relatedto');
+Route::get('events/type/{slug}', [\App\Http\Controllers\EventsController::class, 'indexTypes']);
+Route::get('events/series/{slug}', [\App\Http\Controllers\EventsController::class, 'indexSeries']);
+Route::get('events/feed', [\App\Http\Controllers\EventsController::class, 'feed']);
+Route::get('events/ical', [\App\Http\Controllers\EventsController::class, 'indexIcal'])->name('events.indexIcal');
+Route::get('events/feed/tag/{tag}', [\App\Http\Controllers\EventsController::class, 'feedTags']);
+Route::get('events/brief-text', [\App\Http\Controllers\EventsController::class, 'briefText']);
 Route::get(
     'events/export',
     [
         'as' => 'events.export',
-        'uses' => 'EventsController@export',
+        'uses' => '\App\Http\Controllers\EventsController@export',
     ]
 );
 Route::get(
     'events/export-attending',
     [
         'as' => 'events.export.attending',
-        'uses' => 'EventsController@exportAttending',
+        'uses' => '\App\Http\Controllers\EventsController@exportAttending',
     ]
 );
 
 Route::get('events/{id}/generate-image', [
     'as' => 'events.generateImage',
-    'uses' => 'EventsController@generateImage',
+    'uses' => '\App\Http\Controllers\EventsController@generateImage',
 ]);
 
 Route::get('events/{id}/import-photo', [
     'as' => 'events.importPhoto',
-    'uses' => 'EventsController@importPhoto',
+    'uses' => '\App\Http\Controllers\EventsController@importPhoto',
 ]);
 
 Route::get('events/{id}/remind', [
     'as' => 'events.remind',
-    'uses' => 'EventsController@remind',
+    'uses' => '\App\Http\Controllers\EventsController@remind',
 ]);
 
 Route::get('events/{id}/tweet', [
     'as' => 'events.tweet',
-    'uses' => 'EventsController@tweet',
+    'uses' => '\App\Http\Controllers\EventsController@tweet',
 ]);
 
 Route::get('events/{id}/attend', [
     'as' => 'events.attend',
-    'uses' => 'EventsController@attend',
+    'uses' => '\App\Http\Controllers\EventsController@attend',
 ]);
 
 Route::get('events/{id}/unattend', [
     'as' => 'events.unattend',
-    'uses' => 'EventsController@unattend',
+    'uses' => '\App\Http\Controllers\EventsController@unattend',
 ]);
 
-Route::post('events/{id}/photos', 'EventsController@addPhoto');
-Route::delete('events/{id}/photos/{photo_id}', 'EventsController@deletePhoto');
+Route::post('events/{id}/photos', [\App\Http\Controllers\EventsController::class, 'addPhoto']);
+Route::delete('events/{id}/photos/{photo_id}', [\App\Http\Controllers\EventsController::class, 'deletePhoto']);
 
 // Flyer analysis – returns extracted event data as JSON
-Route::post('events/analyze-flyer', 'FlyerAnalysisController@analyze')->name('events.analyzeFlyer');
+Route::post('events/analyze-flyer', [\App\Http\Controllers\FlyerAnalysisController::class, 'analyze'])->name('events.analyzeFlyer');
 
 //Default resource for events
 Route::resource('events', 'EventsController');
@@ -378,60 +363,60 @@ Route::bind('forums', function ($id) {
     return Forum::whereId($id)->firstOrFail();
 });
 
-Route::get('forums/all', 'ForumsController@indexAll');
-Route::match(['get', 'post'], 'forums/filter', ['as' => 'forums.filter', 'uses' => 'ForumsController@filter']);
-Route::get('forums/reset', ['as' => 'forums.reset', 'uses' => 'ForumsController@reset']);
-Route::get('forums/rpp-reset', ['as' => 'forums.rppReset', 'uses' => 'ForumsController@rppReset']);
+Route::get('forums/all', [\App\Http\Controllers\ForumsController::class, 'indexAll']);
+Route::match(['get', 'post'], 'forums/filter', ['as' => 'forums.filter', 'uses' => '\App\Http\Controllers\ForumsController@filter']);
+Route::get('forums/reset', ['as' => 'forums.reset', 'uses' => '\App\Http\Controllers\ForumsController@reset']);
+Route::get('forums/rpp-reset', ['as' => 'forums.rppReset', 'uses' => '\App\Http\Controllers\ForumsController@rppReset']);
 Route::resource('forums', 'ForumsController');
 
 // THREADS
-Route::match(['get', 'post'], 'threads/following', 'ThreadsController@indexFollowing')->name('threads.following')->middleware('auth');
+Route::match(['get', 'post'], 'threads/following', [\App\Http\Controllers\ThreadsController::class, 'indexFollowing'])->name('threads.following')->middleware('auth');
 
 Route::bind('threads', function ($id) {
     return Thread::whereId($id)->firstOrFail();
 });
 
-Route::get('threads/all', 'ThreadsController@indexAll');
-Route::get('threads/category/{slug}', 'ThreadsController@indexCategories');
-Route::get('threads/tag/{tag}', 'ThreadsController@indexTags')->name('threads.tag');
-Route::get('threads/series/{tag}', 'ThreadsController@indexSeries')->name('threads.series');
-Route::get('threads/related-to/{slug}', 'ThreadsController@indexRelatedTo');
-Route::post('threads/{thread}/posts', 'PostsController@store');
-Route::get('threads/{id}/lock', 'ThreadsController@lock')->name('threads.lock');
-Route::get('threads/{id}/unlock', 'ThreadsController@unlock')->name('threads.unlock');
+Route::get('threads/all', [\App\Http\Controllers\ThreadsController::class, 'indexAll']);
+Route::get('threads/category/{slug}', [\App\Http\Controllers\ThreadsController::class, 'indexCategories']);
+Route::get('threads/tag/{tag}', [\App\Http\Controllers\ThreadsController::class, 'indexTags'])->name('threads.tag');
+Route::get('threads/series/{tag}', [\App\Http\Controllers\ThreadsController::class, 'indexSeries'])->name('threads.series');
+Route::get('threads/related-to/{slug}', [\App\Http\Controllers\ThreadsController::class, 'indexRelatedTo']);
+Route::post('threads/{thread}/posts', [\App\Http\Controllers\PostsController::class, 'store']);
+Route::get('threads/{id}/lock', [\App\Http\Controllers\ThreadsController::class, 'lock'])->name('threads.lock');
+Route::get('threads/{id}/unlock', [\App\Http\Controllers\ThreadsController::class, 'unlock'])->name('threads.unlock');
 
-Route::match(['get', 'post'], 'threads/filter', ['as' => 'threads.filter', 'uses' => 'ThreadsController@filter']);
-Route::get('threads/reset', ['as' => 'threads.reset', 'uses' => 'ThreadsController@reset']);
-Route::get('threads/rpp-reset', ['as' => 'threads.rppReset', 'uses' => 'ThreadsController@rppReset']);
+Route::match(['get', 'post'], 'threads/filter', ['as' => 'threads.filter', 'uses' => '\App\Http\Controllers\ThreadsController@filter']);
+Route::get('threads/reset', ['as' => 'threads.reset', 'uses' => '\App\Http\Controllers\ThreadsController@reset']);
+Route::get('threads/rpp-reset', ['as' => 'threads.rppReset', 'uses' => '\App\Http\Controllers\ThreadsController@rppReset']);
 
 Route::get('threads/{id}/like', [
     'as' => 'threads.like',
-    'uses' => 'ThreadsController@like',
+    'uses' => '\App\Http\Controllers\ThreadsController@like',
 ]);
 
 Route::get('threads/{id}/unlike', [
     'as' => 'threads.unlike',
-    'uses' => 'ThreadsController@unlike',
+    'uses' => '\App\Http\Controllers\ThreadsController@unlike',
 ]);
 
 Route::get('threads/{id}/follow', [
     'as' => 'threads.follow',
-    'uses' => 'ThreadsController@follow',
+    'uses' => '\App\Http\Controllers\ThreadsController@follow',
 ]);
 
 Route::get('threads/{id}/unfollow', [
     'as' => 'threads.unfollow',
-    'uses' => 'ThreadsController@unfollow',
+    'uses' => '\App\Http\Controllers\ThreadsController@unfollow',
 ]);
 
 Route::resource('threads', 'ThreadsController');
 
 // POSTS
-Route::match(['get', 'post'], 'posts/filter', ['as' => 'posts.filter', 'uses' => 'PostsController@filter']);
-Route::get('posts/reset', ['as' => 'posts.reset', 'uses' => 'PostsController@reset']);
-Route::get('posts/rpp-reset', ['as' => 'posts.rppReset', 'uses' => 'PostsController@rppReset']);
-Route::get('posts/tag/{tag}', 'PostsController@indexTags')->name('posts.tag');
-Route::get('posts/all', 'PostsController@indexAll');
+Route::match(['get', 'post'], 'posts/filter', ['as' => 'posts.filter', 'uses' => '\App\Http\Controllers\PostsController@filter']);
+Route::get('posts/reset', ['as' => 'posts.reset', 'uses' => '\App\Http\Controllers\PostsController@reset']);
+Route::get('posts/rpp-reset', ['as' => 'posts.rppReset', 'uses' => '\App\Http\Controllers\PostsController@rppReset']);
+Route::get('posts/tag/{tag}', [\App\Http\Controllers\PostsController::class, 'indexTags'])->name('posts.tag');
+Route::get('posts/all', [\App\Http\Controllers\PostsController::class, 'indexAll']);
 
 Route::bind('posts', function ($id) {
     return Post::whereId($id)->firstOrFail();
@@ -439,21 +424,21 @@ Route::bind('posts', function ($id) {
 
 Route::get('posts/{id}/like', [
     'as' => 'posts.like',
-    'uses' => 'PostsController@like',
+    'uses' => '\App\Http\Controllers\PostsController@like',
 ]);
 
 Route::get('posts/{id}/unlike', [
     'as' => 'posts.unlike',
-    'uses' => 'PostsController@unlike',
+    'uses' => '\App\Http\Controllers\PostsController@unlike',
 ]);
 
 Route::resource('posts', 'PostsController');
 
 // THREAD CATEGORIES
-Route::get('categories/all', 'CategoriesController@indexAll');
-Route::match(['get', 'post'], 'categories/filter', ['as' => 'categories.filter', 'uses' => 'CategoriesController@filter']);
-Route::get('categories/reset', ['as' => 'categories.reset', 'uses' => 'CategoriesController@reset']);
-Route::get('categories/rpp-reset', ['as' => 'categories.rppReset', 'uses' => 'CategoriesController@rppReset']);
+Route::get('categories/all', [\App\Http\Controllers\CategoriesController::class, 'indexAll']);
+Route::match(['get', 'post'], 'categories/filter', ['as' => 'categories.filter', 'uses' => '\App\Http\Controllers\CategoriesController@filter']);
+Route::get('categories/reset', ['as' => 'categories.reset', 'uses' => '\App\Http\Controllers\CategoriesController@reset']);
+Route::get('categories/rpp-reset', ['as' => 'categories.rppReset', 'uses' => '\App\Http\Controllers\CategoriesController@rppReset']);
 
 Route::bind('categories', function ($id) {
     return ThreadCategory::whereId($id)->firstOrFail();
@@ -462,11 +447,11 @@ Route::bind('categories', function ($id) {
 Route::resource('categories', 'CategoriesController');
 
 // BLOGS
-Route::get('blogs/all', 'BlogsController@indexAll');
-Route::match(['get', 'post'], 'blogs/filter', ['as' => 'blogs.filter', 'uses' => 'BlogsController@filter']);
-Route::get('blogs/reset', ['as' => 'blogs.reset', 'uses' => 'BlogsController@reset']);
-Route::get('blogs/rpp-reset', ['as' => 'blogs.rppReset', 'uses' => 'BlogsController@rppReset']);
-Route::post('blogs/{id}/photos', 'BlogsController@addPhoto');
+Route::get('blogs/all', [\App\Http\Controllers\BlogsController::class, 'indexAll']);
+Route::match(['get', 'post'], 'blogs/filter', ['as' => 'blogs.filter', 'uses' => '\App\Http\Controllers\BlogsController@filter']);
+Route::get('blogs/reset', ['as' => 'blogs.reset', 'uses' => '\App\Http\Controllers\BlogsController@reset']);
+Route::get('blogs/rpp-reset', ['as' => 'blogs.rppReset', 'uses' => '\App\Http\Controllers\BlogsController@rppReset']);
+Route::post('blogs/{id}/photos', [\App\Http\Controllers\BlogsController::class, 'addPhoto']);
 
 Route::bind('blogs', function ($id) {
     return Blog::whereId($id)->firstOrFail();
@@ -475,21 +460,21 @@ Route::bind('blogs', function ($id) {
 Route::resource('blogs', 'BlogsController');
 
 // MENUS
-Route::get('menus/all', 'MenusController@indexAll');
-Route::match(['get', 'post'], 'menus/filter', ['as' => 'menus.filter', 'uses' => 'MenusController@filter']);
-Route::get('menus/reset', ['as' => 'menus.reset', 'uses' => 'MenusController@reset']);
-Route::get('menus/rpp-reset', ['as' => 'menus.rppReset', 'uses' => 'MenusController@rppReset']);
+Route::get('menus/all', [\App\Http\Controllers\MenusController::class, 'indexAll']);
+Route::match(['get', 'post'], 'menus/filter', ['as' => 'menus.filter', 'uses' => '\App\Http\Controllers\MenusController@filter']);
+Route::get('menus/reset', ['as' => 'menus.reset', 'uses' => '\App\Http\Controllers\MenusController@reset']);
+Route::get('menus/rpp-reset', ['as' => 'menus.rppReset', 'uses' => '\App\Http\Controllers\MenusController@rppReset']);
 Route::bind('menus', function ($id) {
     return Menu::whereId($id)->firstOrFail();
 });
 Route::resource('menus', 'MenusController');
-Route::get('menus/{id}/content', 'MenusController@content');
+Route::get('menus/{id}/content', [\App\Http\Controllers\MenusController::class, 'content']);
 
 // PERMISSIONS
-Route::get('permissions/all', 'PermissionsController@indexAll');
-Route::match(['get', 'post'], 'permissions/filter', ['as' => 'permissions.filter', 'uses' => 'PermissionsController@filter']);
-Route::get('permissions/reset', ['as' => 'permissions.reset', 'uses' => 'PermissionsController@reset']);
-Route::get('permissions/rpp-reset', ['as' => 'permissions.rppReset', 'uses' => 'PermissionsController@rppReset']);
+Route::get('permissions/all', [\App\Http\Controllers\PermissionsController::class, 'indexAll']);
+Route::match(['get', 'post'], 'permissions/filter', ['as' => 'permissions.filter', 'uses' => '\App\Http\Controllers\PermissionsController@filter']);
+Route::get('permissions/reset', ['as' => 'permissions.reset', 'uses' => '\App\Http\Controllers\PermissionsController@reset']);
+Route::get('permissions/rpp-reset', ['as' => 'permissions.rppReset', 'uses' => '\App\Http\Controllers\PermissionsController@rppReset']);
 
 Route::bind('permissions', function ($id) {
     return Permission::whereId($id)->firstOrFail();
@@ -498,37 +483,37 @@ Route::bind('permissions', function ($id) {
 Route::resource('permissions', 'PermissionsController');
 
 // EntityTypes
-Route::get('entity-types/all', 'EntityTypesController@indexAll');
+Route::get('entity-types/all', [\App\Http\Controllers\EntityTypesController::class, 'indexAll']);
 
-Route::match(['get', 'post'], 'entity-types/filter', ['as' => 'entity-types.filter', 'uses' => 'EntityTypesController@filter']);
-Route::get('entity-types/reset', ['as' => 'entityTypes.reset', 'uses' => 'EntityTypesController@reset']);
-Route::get('entity-types/rpp-reset', ['as' => 'entityTypes.rppReset', 'uses' => 'EntityTypesController@rppReset']);
+Route::match(['get', 'post'], 'entity-types/filter', ['as' => 'entity-types.filter', 'uses' => '\App\Http\Controllers\EntityTypesController@filter']);
+Route::get('entity-types/reset', ['as' => 'entityTypes.reset', 'uses' => '\App\Http\Controllers\EntityTypesController@reset']);
+Route::get('entity-types/rpp-reset', ['as' => 'entityTypes.rppReset', 'uses' => '\App\Http\Controllers\EntityTypesController@rppReset']);
 
 Route::bind('entity-types', function ($id) {
     return EntityType::whereId($id)->firstOrFail();
 });
 
 Route::resource('entity-types', 'EntityTypesController');
-Route::delete('entity-types/{id}', 'EntityTypesController@destroy');
+Route::delete('entity-types/{id}', [\App\Http\Controllers\EntityTypesController::class, 'destroy']);
 
 // Roles
-Route::match(['get', 'post'], 'roles/filter', ['as' => 'roles.filter', 'uses' => 'RolesController@filter']);
-Route::get('roles/reset', ['as' => 'roles.reset', 'uses' => 'RolesController@reset']);
-Route::get('roles/rpp-reset', ['as' => 'roles.rppReset', 'uses' => 'RolesController@rppReset']);
+Route::match(['get', 'post'], 'roles/filter', ['as' => 'roles.filter', 'uses' => '\App\Http\Controllers\RolesController@filter']);
+Route::get('roles/reset', ['as' => 'roles.reset', 'uses' => '\App\Http\Controllers\RolesController@reset']);
+Route::get('roles/rpp-reset', ['as' => 'roles.rppReset', 'uses' => '\App\Http\Controllers\RolesController@rppReset']);
 
 Route::bind('roles', function ($id) {
     return Role::whereId($id)->firstOrFail();
 });
 
 Route::resource('roles', 'RolesController');
-Route::delete('roles/{id}', 'RolesController@destroy');
+Route::delete('roles/{id}', [\App\Http\Controllers\RolesController::class, 'destroy']);
 
 // GROUPS
-Route::match(['get', 'post'], 'groups/filter', ['as' => 'groups.filter', 'uses' => 'GroupsController@filter']);
-Route::get('groups/all', 'GroupsController@indexAll');
+Route::match(['get', 'post'], 'groups/filter', ['as' => 'groups.filter', 'uses' => '\App\Http\Controllers\GroupsController@filter']);
+Route::get('groups/all', [\App\Http\Controllers\GroupsController::class, 'indexAll']);
 
-Route::get('groups/reset', ['as' => 'groups.reset', 'uses' => 'GroupsController@reset']);
-Route::get('groups/rpp-reset', ['as' => 'groups.rppReset', 'uses' => 'GroupsController@rppReset']);
+Route::get('groups/reset', ['as' => 'groups.reset', 'uses' => '\App\Http\Controllers\GroupsController@reset']);
+Route::get('groups/rpp-reset', ['as' => 'groups.rppReset', 'uses' => '\App\Http\Controllers\GroupsController@rppReset']);
 
 Route::bind('groups', function ($id) {
     return Group::whereId($id)->firstOrFail();
@@ -537,46 +522,46 @@ Route::bind('groups', function ($id) {
 Route::resource('groups', 'GroupsController');
 
 // ENTITIES
-Route::match(['get', 'post'], 'entities/following', 'EntitiesController@indexFollowing')->name('entities.following')->middleware('auth');
+Route::match(['get', 'post'], 'entities/following', [\App\Http\Controllers\EntitiesController::class, 'indexFollowing'])->name('entities.following')->middleware('auth');
 
-Route::get('entities/{id}/load-embeds', 'EntitiesController@loadEmbeds');
-Route::get('entities/{id}/load-minimal-embeds', 'EntitiesController@loadMinimalEmbeds');
-Route::get('entities/{slug}/minimal-embeds', 'EntitiesController@loadMinimalEmbedsBySlug');
-Route::get('entities/{slug}/embeds', 'EntitiesController@loadEmbedsBySlug');
-Route::post('entities/{id}/photos', 'EntitiesController@addPhoto');
+Route::get('entities/{id}/load-embeds', [\App\Http\Controllers\EntitiesController::class, 'loadEmbeds']);
+Route::get('entities/{id}/load-minimal-embeds', [\App\Http\Controllers\EntitiesController::class, 'loadMinimalEmbeds']);
+Route::get('entities/{slug}/minimal-embeds', [\App\Http\Controllers\EntitiesController::class, 'loadMinimalEmbedsBySlug']);
+Route::get('entities/{slug}/embeds', [\App\Http\Controllers\EntitiesController::class, 'loadEmbedsBySlug']);
+Route::post('entities/{id}/photos', [\App\Http\Controllers\EntitiesController::class, 'addPhoto']);
 
-Route::get('entities/type/{type}', 'EntitiesController@indexTypes');
+Route::get('entities/type/{type}', [\App\Http\Controllers\EntitiesController::class, 'indexTypes']);
 
-Route::get('entities/role/{role}', 'EntitiesController@indexRoles')->name('entities.role');
+Route::get('entities/role/{role}', [\App\Http\Controllers\EntitiesController::class, 'indexRoles'])->name('entities.role');
 
-Route::match(['get', 'post'], 'entities/filter', ['as' => 'entities.filter', 'uses' => 'EntitiesController@filter']);
-Route::get('entities/apply-filter', ['as' => 'entities.applyFilterFromUrl', 'uses' => 'EntitiesController@applyFilterFromUrl']);
-Route::get('entities/reset', ['as' => 'entities.reset', 'uses' => 'EntitiesController@reset']);
-Route::get('entities/rpp-reset', ['as' => 'entities.rppReset', 'uses' => 'EntitiesController@rppReset']);
+Route::match(['get', 'post'], 'entities/filter', ['as' => 'entities.filter', 'uses' => '\App\Http\Controllers\EntitiesController@filter']);
+Route::get('entities/apply-filter', ['as' => 'entities.applyFilterFromUrl', 'uses' => '\App\Http\Controllers\EntitiesController@applyFilterFromUrl']);
+Route::get('entities/reset', ['as' => 'entities.reset', 'uses' => '\App\Http\Controllers\EntitiesController@reset']);
+Route::get('entities/rpp-reset', ['as' => 'entities.rppReset', 'uses' => '\App\Http\Controllers\EntitiesController@rppReset']);
 
-Route::post('entities/quick-store', 'EntitiesController@quickStore')->name('entities.quickStore')->middleware('auth');
+Route::post('entities/quick-store', [\App\Http\Controllers\EntitiesController::class, 'quickStore'])->name('entities.quickStore')->middleware('auth');
 
-Route::get('entities/tag/{tag}', 'EntitiesController@indexTags')->name('entities.tag');
-Route::get('entities/alias/{alias}', 'EntitiesController@indexAliases')->name('entities.alias');
-Route::get('entities/slug/{slug}', 'EntitiesController@indexSlug')->name('entities.slug');
+Route::get('entities/tag/{tag}', [\App\Http\Controllers\EntitiesController::class, 'indexTags'])->name('entities.tag');
+Route::get('entities/alias/{alias}', [\App\Http\Controllers\EntitiesController::class, 'indexAliases'])->name('entities.alias');
+Route::get('entities/slug/{slug}', [\App\Http\Controllers\EntitiesController::class, 'indexSlug'])->name('entities.slug');
 
 Route::get('entities/{id}/tweet', [
     'as' => 'entities.tweet',
-    'uses' => 'EntitiesController@tweet',
+    'uses' => '\App\Http\Controllers\EntitiesController@tweet',
 ]);
 
-Route::get('entities/{id}/instagram-post', 'EntitiesController@postToInstagram')->name('entities.instagramPost');
-Route::get('entities/{id}/instagram-story-post', 'EntitiesController@postStoryToInstagram')->name('entities.instagramStoryPost');
-Route::get('entities/{id}/send-update-summary', 'EntitiesController@sendUpdateSummary')->name('entities.sendUpdateSummary')->middleware('auth');
+Route::get('entities/{id}/instagram-post', [\App\Http\Controllers\EntitiesController::class, 'postToInstagram'])->name('entities.instagramPost');
+Route::get('entities/{id}/instagram-story-post', [\App\Http\Controllers\EntitiesController::class, 'postStoryToInstagram'])->name('entities.instagramStoryPost');
+Route::get('entities/{id}/send-update-summary', [\App\Http\Controllers\EntitiesController::class, 'sendUpdateSummary'])->name('entities.sendUpdateSummary')->middleware('auth');
 
 Route::match(['get', 'post'], 'entities/{id}/follow', [
     'as' => 'entities.follow',
-    'uses' => 'EntitiesController@follow',
+    'uses' => '\App\Http\Controllers\EntitiesController@follow',
 ]);
 
 Route::get('entities/{id}/unfollow', [
     'as' => 'entities.unfollow',
-    'uses' => 'EntitiesController@unfollow',
+    'uses' => '\App\Http\Controllers\EntitiesController@unfollow',
 ]);
 
 Route::bind('entities', function ($id) {
@@ -595,9 +580,9 @@ Route::bind('contacts', function ($id) {
     return Contact::whereId($id)->firstOrFail();
 });
 
-Route::get('/entities/{entity:slug}/contacts/{contact:id}/create', 'ContactsController@create');
-Route::get('/entities/{entity:slug}/contacts/{contact:id}/edit', 'ContactsController@edit');
-Route::post('/entities/{entity:slug}/contacts/{contact:id}/update', 'ContactsController@update');
+Route::get('/entities/{entity:slug}/contacts/{contact:id}/create', [\App\Http\Controllers\ContactsController::class, 'create']);
+Route::get('/entities/{entity:slug}/contacts/{contact:id}/edit', [\App\Http\Controllers\ContactsController::class, 'edit']);
+Route::post('/entities/{entity:slug}/contacts/{contact:id}/update', [\App\Http\Controllers\ContactsController::class, 'update']);
 Route::resource('entities.contacts', 'ContactsController');
 
 Route::bind('links', function ($id) {
@@ -610,115 +595,113 @@ Route::bind('comments', function ($id) {
     return Comment::whereId($id)->firstOrFail();
 });
 
-Route::get('/entities/{entity:slug}/comments/{comment:id}/edit', 'CommentsController@edit');
-Route::delete('/entities/{entity:slug}/comments/{comment:id}/edit', 'CommentsController@destroy');
+Route::get('/entities/{entity:slug}/comments/{comment:id}/edit', [\App\Http\Controllers\CommentsController::class, 'edit']);
+Route::delete('/entities/{entity:slug}/comments/{comment:id}/edit', [\App\Http\Controllers\CommentsController::class, 'destroy']);
 
 Route::resource('entities.comments', 'CommentsController');
 Route::resource('events.comments', 'CommentsController');
 Route::resource('events.reviews', 'EventReviewsController');
 
 // REVIEWS
-Route::match(['get', 'post'], 'reviews/filter', ['as' => 'reviews.filter', 'uses' => 'ReviewsController@filter']);
-Route::get('reviews/filter', ['as' => 'reviews.filter', 'uses' => 'ReviewsController@filter']);
-Route::get('reviews/reset', ['as' => 'reviews.reset', 'uses' => 'ReviewsController@reset']);
-Route::get('reviews/rpp-reset', ['as' => 'reviews.rppReset', 'uses' => 'ReviewsController@rppReset']);
+Route::match(['get', 'post'], 'reviews/filter', ['as' => 'reviews.filter', 'uses' => '\App\Http\Controllers\ReviewsController@filter']);
+Route::get('reviews/filter', ['as' => 'reviews.filter', 'uses' => '\App\Http\Controllers\ReviewsController@filter']);
+Route::get('reviews/reset', ['as' => 'reviews.reset', 'uses' => '\App\Http\Controllers\ReviewsController@reset']);
+Route::get('reviews/rpp-reset', ['as' => 'reviews.rppReset', 'uses' => '\App\Http\Controllers\ReviewsController@rppReset']);
 Route::resource('reviews', 'ReviewsController');
 
 // SERIES
-Route::get('series/{id}/load-embeds', 'SeriesController@loadEmbeds');
-Route::get('series/{id}/load-minimal-embeds', 'SeriesController@loadMinimalEmbeds');
-Route::get('series/{slug}/minimal-embeds', 'SeriesController@loadMinimalEmbedsBySlug');
-Route::get('series/{slug}/embeds', 'SeriesController@loadEmbedsBySlug');
-Route::match(['get', 'post'], 'series/following', 'SeriesController@indexFollowing')->name('series.following')->middleware('auth');
+Route::get('series/{id}/load-embeds', [\App\Http\Controllers\SeriesController::class, 'loadEmbeds']);
+Route::get('series/{id}/load-minimal-embeds', [\App\Http\Controllers\SeriesController::class, 'loadMinimalEmbeds']);
+Route::get('series/{slug}/minimal-embeds', [\App\Http\Controllers\SeriesController::class, 'loadMinimalEmbedsBySlug']);
+Route::get('series/{slug}/embeds', [\App\Http\Controllers\SeriesController::class, 'loadEmbedsBySlug']);
+Route::match(['get', 'post'], 'series/following', [\App\Http\Controllers\SeriesController::class, 'indexFollowing'])->name('series.following')->middleware('auth');
 
 Route::get('series/createOccurrence', [
     'as' => 'series.createOccurrence',
-    'uses' => 'SeriesController@createOccurrence',
+    'uses' => '\App\Http\Controllers\SeriesController@createOccurrence',
 ]);
 
-Route::get('series/type/{type}', 'SeriesController@indexTypes');
-Route::get('series/tag/{tag}', 'SeriesController@indexTags')->name('series.tag');
-Route::get('series/related-to/{slug}', 'SeriesController@indexRelatedTo');
-Route::get('series/week', 'SeriesController@indexWeek');
-Route::get('series/cancelled', 'SeriesController@indexCancelled')->name('series.cancelled');
-Route::post('series/{id}/photos', 'SeriesController@addPhoto');
-Route::delete('series/{id}/photos/{photo_id}', 'SeriesController@deletePhoto');
+Route::get('series/type/{type}', [\App\Http\Controllers\SeriesController::class, 'indexTypes']);
+Route::get('series/tag/{tag}', [\App\Http\Controllers\SeriesController::class, 'indexTags'])->name('series.tag');
+Route::get('series/related-to/{slug}', [\App\Http\Controllers\SeriesController::class, 'indexRelatedTo']);
+Route::get('series/week', [\App\Http\Controllers\SeriesController::class, 'indexWeek']);
+Route::get('series/cancelled', [\App\Http\Controllers\SeriesController::class, 'indexCancelled'])->name('series.cancelled');
+Route::post('series/{id}/photos', [\App\Http\Controllers\SeriesController::class, 'addPhoto']);
+Route::delete('series/{id}/photos/{photo_id}', [\App\Http\Controllers\SeriesController::class, 'deletePhoto']);
 Route::get(
     'series/export',
     [
         'as' => 'series.export',
-        'uses' => 'SeriesController@export',
+        'uses' => '\App\Http\Controllers\SeriesController@export',
     ]
 );
-Route::match(['get', 'post'], 'series/filter', ['as' => 'series.filter', 'uses' => 'SeriesController@filter']);
-Route::get('series/apply-filter', ['as' => 'series.applyFilterFromUrl', 'uses' => 'SeriesController@applyFilterFromUrl']);
-Route::get('series/reset', ['as' => 'series.reset', 'uses' => 'SeriesController@reset']);
-Route::get('series/rpp-reset', ['as' => 'series.rppReset', 'uses' => 'SeriesController@rppReset']);
+Route::match(['get', 'post'], 'series/filter', ['as' => 'series.filter', 'uses' => '\App\Http\Controllers\SeriesController@filter']);
+Route::get('series/apply-filter', ['as' => 'series.applyFilterFromUrl', 'uses' => '\App\Http\Controllers\SeriesController@applyFilterFromUrl']);
+Route::get('series/reset', ['as' => 'series.reset', 'uses' => '\App\Http\Controllers\SeriesController@reset']);
+Route::get('series/rpp-reset', ['as' => 'series.rppReset', 'uses' => '\App\Http\Controllers\SeriesController@rppReset']);
 
 Route::get('series/{id}/follow', [
     'as' => 'series.follow',
-    'uses' => 'SeriesController@follow',
+    'uses' => '\App\Http\Controllers\SeriesController@follow',
 ]);
 
 Route::get('series/{id}/unfollow', [
     'as' => 'series.unfollow',
-    'uses' => 'SeriesController@unfollow',
+    'uses' => '\App\Http\Controllers\SeriesController@unfollow',
 ]);
 
 
 Route::resource('series', 'SeriesController');
 
-Route::get('series/{series:slug}', 'SeriesController@show')->name('series.show');
+Route::get('series/{series:slug}', [\App\Http\Controllers\SeriesController::class, 'show'])->name('series.show');
 
 
-Route::get('tags/create', 'TagsController@create')->name('tags.create');
-Route::get('tags/{tag}', 'TagsController@show')->name('tags.show');
-Route::get('tags/{tag}/edit', 'TagsController@edit')->name('tags.edit');
+Route::get('tags/create', [\App\Http\Controllers\TagsController::class, 'create'])->name('tags.create');
+Route::get('tags/{tag}', [\App\Http\Controllers\TagsController::class, 'show'])->name('tags.show');
+Route::get('tags/{tag}/edit', [\App\Http\Controllers\TagsController::class, 'edit'])->name('tags.edit');
 
 Route::get('tags/{id}/follow', [
     'as' => 'tags.follow',
-    'uses' => 'TagsController@follow',
+    'uses' => '\App\Http\Controllers\TagsController@follow',
 ]);
 
 Route::get('tags/{id}/unfollow', [
     'as' => 'tags.unfollow',
-    'uses' => 'TagsController@unfollow',
+    'uses' => '\App\Http\Controllers\TagsController@unfollow',
 ]);
 
 Route::resource('tags', 'TagsController');
 
 // Add the route for rss
-Route::get('rss', 'EventsController@rss');
-Route::get('rss/tag/{tag}', 'EventsController@rssTags');
+Route::get('rss', [\App\Http\Controllers\EventsController::class, 'rss']);
+Route::get('rss/tag/{tag}', [\App\Http\Controllers\EventsController::class, 'rssTags']);
 
 // Semantic alternate routes for entities by role
 // These routes provide cleaner URLs for common entity types
 // Index routes: /venue, /artist, /dj, etc. - lists entities by role
-Route::get('venue', 'EntitiesController@indexRoles')->defaults('role', 'venue')->name('venue.index');
-Route::get('artist', 'EntitiesController@indexRoles')->defaults('role', 'artist')->name('artist.index');
-Route::get('dj', 'EntitiesController@indexRoles')->defaults('role', 'dj')->name('dj.index');
-Route::get('producer', 'EntitiesController@indexRoles')->defaults('role', 'producer')->name('producer.index');
-Route::get('promoter', 'EntitiesController@indexRoles')->defaults('role', 'promoter')->name('promoter.index');
-Route::get('shop', 'EntitiesController@indexRoles')->defaults('role', 'shop')->name('shop.index');
-Route::get('band', 'EntitiesController@indexRoles')->defaults('role', 'band')->name('band.index');
-Route::get('visualist', 'EntitiesController@indexRoles')->defaults('role', 'visualist')->name('visualist.index');
+Route::get('venue', [\App\Http\Controllers\EntitiesController::class, 'indexRoles'])->defaults('role', 'venue')->name('venue.index');
+Route::get('artist', [\App\Http\Controllers\EntitiesController::class, 'indexRoles'])->defaults('role', 'artist')->name('artist.index');
+Route::get('dj', [\App\Http\Controllers\EntitiesController::class, 'indexRoles'])->defaults('role', 'dj')->name('dj.index');
+Route::get('producer', [\App\Http\Controllers\EntitiesController::class, 'indexRoles'])->defaults('role', 'producer')->name('producer.index');
+Route::get('promoter', [\App\Http\Controllers\EntitiesController::class, 'indexRoles'])->defaults('role', 'promoter')->name('promoter.index');
+Route::get('shop', [\App\Http\Controllers\EntitiesController::class, 'indexRoles'])->defaults('role', 'shop')->name('shop.index');
+Route::get('band', [\App\Http\Controllers\EntitiesController::class, 'indexRoles'])->defaults('role', 'band')->name('band.index');
+Route::get('visualist', [\App\Http\Controllers\EntitiesController::class, 'indexRoles'])->defaults('role', 'visualist')->name('visualist.index');
 
 // Detail routes: /venue/{slug}, /artist/{slug}, etc. - shows specific entity
-Route::get('venue/{slug}', 'EntitiesController@showByRoleAndSlug')->defaults('role', 'venue')->name('venue.show');
-Route::get('artist/{slug}', 'EntitiesController@showByRoleAndSlug')->defaults('role', 'artist')->name('artist.show');
-Route::get('dj/{slug}', 'EntitiesController@showByRoleAndSlug')->defaults('role', 'dj')->name('dj.show');
-Route::get('producer/{slug}', 'EntitiesController@showByRoleAndSlug')->defaults('role', 'producer')->name('producer.show');
-Route::get('promoter/{slug}', 'EntitiesController@showByRoleAndSlug')->defaults('role', 'promoter')->name('promoter.show');
-Route::get('shop/{slug}', 'EntitiesController@showByRoleAndSlug')->defaults('role', 'shop')->name('shop.show');
-Route::get('band/{slug}', 'EntitiesController@showByRoleAndSlug')->defaults('role', 'band')->name('band.show');
-Route::get('visualist/{slug}', 'EntitiesController@showByRoleAndSlug')->defaults('role', 'visualist')->name('visualist.show');
+Route::get('venue/{slug}', [\App\Http\Controllers\EntitiesController::class, 'showByRoleAndSlug'])->defaults('role', 'venue')->name('venue.show');
+Route::get('artist/{slug}', [\App\Http\Controllers\EntitiesController::class, 'showByRoleAndSlug'])->defaults('role', 'artist')->name('artist.show');
+Route::get('dj/{slug}', [\App\Http\Controllers\EntitiesController::class, 'showByRoleAndSlug'])->defaults('role', 'dj')->name('dj.show');
+Route::get('producer/{slug}', [\App\Http\Controllers\EntitiesController::class, 'showByRoleAndSlug'])->defaults('role', 'producer')->name('producer.show');
+Route::get('promoter/{slug}', [\App\Http\Controllers\EntitiesController::class, 'showByRoleAndSlug'])->defaults('role', 'promoter')->name('promoter.show');
+Route::get('shop/{slug}', [\App\Http\Controllers\EntitiesController::class, 'showByRoleAndSlug'])->defaults('role', 'shop')->name('shop.show');
+Route::get('band/{slug}', [\App\Http\Controllers\EntitiesController::class, 'showByRoleAndSlug'])->defaults('role', 'band')->name('band.show');
+Route::get('visualist/{slug}', [\App\Http\Controllers\EntitiesController::class, 'showByRoleAndSlug'])->defaults('role', 'visualist')->name('visualist.show');
 
 // Click tracking for event and series ticket links
-Route::get('go/evt-{id}', 'ClickTrackController@redirectEvent')->name('clicktrack.event')->where('id', '[0-9]+');
-Route::get('go/ser-{id}', 'ClickTrackController@redirectSeries')->name('clicktrack.series')->where('id', '[0-9]+');
+Route::get('go/evt-{id}', [\App\Http\Controllers\ClickTrackController::class, 'redirectEvent'])->name('clicktrack.event')->where('id', '[0-9]+');
+Route::get('go/ser-{id}', [\App\Http\Controllers\ClickTrackController::class, 'redirectSeries'])->name('clicktrack.series')->where('id', '[0-9]+');
 
 // Short URLs – create a short URL and resolve it
-Route::post('short-url', 'ShortUrlController@shorten')->name('short-url.shorten');
-Route::get('s/{code}', 'ShortUrlController@redirect')->name('short-url.redirect')->where('code', '[a-zA-Z0-9]+');
-
-Auth::routes();
+Route::post('short-url', [\App\Http\Controllers\ShortUrlController::class, 'shorten'])->name('short-url.shorten');
+Route::get('s/{code}', [\App\Http\Controllers\ShortUrlController::class, 'redirect'])->name('short-url.redirect')->where('code', '[a-zA-Z0-9]+');

--- a/tests/Feature/AuthRouteWiringTest.php
+++ b/tests/Feature/AuthRouteWiringTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+/**
+ * Locks in the auth route wiring after consolidating the duplicate
+ * Auth::routes() calls and the shadowed manual auth route block in
+ * routes/web.php. If a refactor (or a laravel/ui change) drops one of
+ * these names or the signed-verification hardening, this fails loudly.
+ */
+class AuthRouteWiringTest extends TestCase
+{
+    public function test_auth_route_names_are_registered(): void
+    {
+        foreach ([
+            'login',
+            'logout',
+            'register',
+            'password.request',
+            'password.email',
+            'password.reset',
+            'password.update',
+            'verification.notice',
+            'verification.verify',
+            'verification.resend',
+        ] as $name) {
+            $this->assertTrue(Route::has($name), "Route [$name] is not registered");
+        }
+    }
+
+    public function test_verification_verify_route_is_signed_and_throttled(): void
+    {
+        $route = Route::getRoutes()->getByName('verification.verify');
+
+        $this->assertNotNull($route);
+        $this->assertContains('signed:relative', $route->middleware());
+        $this->assertContains('throttle:6,1', $route->middleware());
+    }
+}


### PR DESCRIPTION
Part of the Laravel 12 upgrade track (see #2016 / #2017).

String controller actions (`'Api\EventsController@indexJson'`) depend on the deprecated `RouteServiceProvider::$namespace` auto-prefixing, removed from the Laravel 11+ skeleton. Converting now, while both syntaxes work, makes the framework bump PR much smaller.

**Changes**
- 403 string actions across `routes/web.php` / `routes/api.php` converted to `[Controller::class, 'method']`; the `['uses' => ...]` array-form routes use absolute `'\App\Http\Controllers\X@m'` strings (`uses` doesn't accept callable arrays — verified via route:list that the array form silently degrades to a Closure action).
- Removed the duplicate `Auth::routes()` at the bottom of `web.php` plus the manual auth-route block it fully shadowed. The live routes come from `Auth::routes()` today (names `password.request`/`password.email`/`password.update`, which the views reference); the manual block's variants (`password.forgot`, unnamed POSTs) were dead. The shadowed block also referenced the nonexistent `ProtectAgainstSpam` middleware — had it ever won registration order, every `POST /register` would have 500'd. Restoring real registration spam protection stays a separate issue.
- New `AuthRouteWiringTest` asserts all auth route names exist and `verification.verify` keeps `signed:relative` + `throttle:6,1` (behavioral signed-URL tests already exist in `EmailVerificationTest`).

**Verification**
- `php artisan route:list --json` diffed before/after: all 699 routes byte-identical (method, uri, name, action, middleware).
- PHPStan: no errors.
- 302 tests green locally (Unit suite + auth/register/verification feature tests); full suite in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)