### PR TITLE
Add micro-interactions inspired by Amicro (#2014)

### DIFF
--- a/public/js/custom.js
+++ b/public/js/custom.js
@@ -214,8 +214,11 @@ var App = (function () {
             $.ajax({
                 url: $link.attr('href'),
             }).done(function (data) {
+                let $replacement = $(data.Success).addClass('anim-zoom-in');
+                // pop the favorite/follow icon in its new state
+                $replacement.find('a.ajax-action').first().children('i, svg').addClass('anim-star-pop');
+                $(target).replaceWith($replacement);
                 // fire a flash message
-                $(target).replaceWith($(data.Success).addClass('anim-zoom-in'));
                 Swal.fire({
                     title: "Success",
                     text: data.Message,

--- a/public/js/custom.js
+++ b/public/js/custom.js
@@ -205,12 +205,17 @@ var App = (function () {
     var setupAjaxAction = function (init) {
         $(init).on('click', 'a.ajax-action', function (e) {
             e.preventDefault();
-            let target = $(this).data("target");
+            let $link = $(this);
+            if ($link.hasClass('is-pending')) {
+                return;
+            }
+            $link.addClass('is-pending');
+            let target = $link.data("target");
             $.ajax({
-                url: $(this).attr('href'),
+                url: $link.attr('href'),
             }).done(function (data) {
                 // fire a flash message
-                $(target).replaceWith(data.Success);
+                $(target).replaceWith($(data.Success).addClass('anim-zoom-in'));
                 Swal.fire({
                     title: "Success",
                     text: data.Message,
@@ -219,6 +224,7 @@ var App = (function () {
                 });
                 console.log('Updated target ' + target);
             }).fail(function () {
+                $link.removeClass('is-pending');
                 console.log('No events could be loaded')
             });
         });
@@ -391,18 +397,22 @@ var Home = (function () {
 
     // load a whole block of events
     var getEvents = function getEvents(url) {
+        $('#loading').addClass('is-active');
         $.ajax({
             url: url
         }).done(function (data) {
             $('#4days').html(data);
         }).fail(function () {
             console.log('No events could be loaded.');
+        }).always(function () {
+            $('#loading').removeClass('is-active');
         });
     };
 
     // load a whole block of events and append
     var addEvents = function addEvents(url, target) {
         if (url !== undefined) {
+            $('#loading').addClass('is-active');
             $.ajax({
                 url: url
             }).done(function (data) {
@@ -411,6 +421,8 @@ var Home = (function () {
                 App.loadEmbeds();
             }).fail(function () {
                 console.log('No events could be loaded.');
+            }).always(function () {
+                $('#loading').removeClass('is-active');
             });
         }
     };

--- a/resources/css/tailwind.css
+++ b/resources/css/tailwind.css
@@ -59,6 +59,11 @@
     @apply border-border;
   }
 
+  /* Hide Alpine-controlled elements until Alpine initializes */
+  [x-cloak] {
+    display: none !important;
+  }
+
   body {
     @apply bg-background text-foreground;
   }
@@ -88,6 +93,11 @@
 
 @keyframes tw-spin {
   to { transform: rotate(360deg); }
+}
+
+@keyframes tw-theme-swap {
+  from { opacity: 0; transform: rotate(-90deg) scale(0.6); }
+  to { opacity: 1; transform: rotate(0deg) scale(1); }
 }
 
 /* Legacy custom component classes - will be migrated to Blade components */
@@ -146,6 +156,11 @@
   .is-pending {
     @apply opacity-60 pointer-events-none;
     animation: tw-fade-in 0.6s ease-in-out infinite alternate;
+  }
+
+  /* Icon swap for the theme toggle: replays whenever x-show flips display */
+  .anim-theme-swap {
+    animation: tw-theme-swap 0.3s ease-out backwards;
   }
 
   /* Underline sweep on hover */

--- a/resources/css/tailwind.css
+++ b/resources/css/tailwind.css
@@ -100,6 +100,13 @@
   to { opacity: 1; transform: rotate(0deg) scale(1); }
 }
 
+@keyframes tw-star-pop {
+  0% { transform: scale(0); }
+  60% { transform: scale(1.4) rotate(8deg); }
+  80% { transform: scale(0.95) rotate(-4deg); }
+  100% { transform: scale(1) rotate(0deg); }
+}
+
 /* Legacy custom component classes - will be migrated to Blade components */
 @layer components {
 
@@ -161,6 +168,13 @@
   /* Icon swap for the theme toggle: replays whenever x-show flips display */
   .anim-theme-swap {
     animation: tw-theme-swap 0.3s ease-out backwards;
+  }
+
+  /* Favorite/follow icon pop (added from public/js/custom.js after an
+     ajax-action swap; inline-block so transforms apply to <i> icons) */
+  .anim-star-pop {
+    display: inline-block;
+    animation: tw-star-pop 0.45s ease-out backwards;
   }
 
   /* Underline sweep on hover */

--- a/resources/css/tailwind.css
+++ b/resources/css/tailwind.css
@@ -70,8 +70,88 @@
   }
 }
 
+/* Micro-interaction keyframes (issue #2014) */
+@keyframes tw-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes tw-fade-up {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes tw-zoom-in {
+  from { opacity: 0; transform: scale(0.97); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@keyframes tw-spin {
+  to { transform: rotate(360deg); }
+}
+
 /* Legacy custom component classes - will be migrated to Blade components */
 @layer components {
+
+  /* Entrance animations ("backwards" fill hides the element during any delay
+     without locking the end-keyframe transform, so hover transforms still work) */
+  .anim-fade-in {
+    animation: tw-fade-in 0.25s ease-out backwards;
+  }
+
+  .anim-fade-up {
+    animation: tw-fade-up 0.35s ease-out backwards;
+  }
+
+  .anim-zoom-in {
+    animation: tw-zoom-in 0.2s ease-out backwards;
+  }
+
+  /* Staggered grid entrance: set --stagger-i inline from Blade $loop->index */
+  .stagger-item {
+    animation: tw-fade-up 0.35s ease-out backwards;
+    animation-delay: calc(min(var(--stagger-i, 0), 12) * 40ms);
+  }
+
+  /* Spinners and loading states */
+  .spinner {
+    @apply h-10 w-10 rounded-full border-4 border-muted border-t-primary;
+    animation: tw-spin 0.8s linear infinite;
+  }
+
+  .loading {
+    @apply fixed inset-0 z-[100] hidden items-center justify-center bg-background/60 backdrop-blur-sm;
+  }
+
+  .loading.is-active {
+    @apply flex;
+  }
+
+  .load-spinner {
+    @apply flex justify-center py-6;
+  }
+
+  .load-spinner::after {
+    content: '';
+    @apply h-8 w-8 rounded-full border-4 border-muted border-t-primary;
+    animation: tw-spin 0.8s linear infinite;
+  }
+
+  .btn-spinner {
+    @apply inline-block h-4 w-4 rounded-full border-2 border-current border-t-transparent;
+    animation: tw-spin 0.8s linear infinite;
+  }
+
+  /* Pending state for ajax-action links (toggled from public/js/custom.js) */
+  .is-pending {
+    @apply opacity-60 pointer-events-none;
+    animation: tw-fade-in 0.6s ease-in-out infinite alternate;
+  }
+
+  /* Underline sweep on hover */
+  .link-reveal {
+    @apply bg-gradient-to-r from-primary to-primary bg-no-repeat bg-[length:0%_1px] bg-left-bottom transition-[background-size] duration-300 hover:bg-[length:100%_1px];
+  }
 
   /* Button styles */
   .btn-primary-tw {
@@ -92,7 +172,7 @@
   }
 
   .card-hover-tw {
-    @apply hover:shadow-xl transition-all duration-200;
+    @apply hover:shadow-xl hover:-translate-y-0.5 transition-[transform,box-shadow] duration-200 motion-reduce:transform-none;
   }
 
   /* Form inputs */
@@ -168,12 +248,12 @@
 
   /* Event card specific styles */
   .event-card-tw {
-    @apply bg-card rounded-lg overflow-hidden shadow-lg border border-border hover:shadow-xl transition-all duration-200 flex flex-col;
+    @apply bg-card rounded-lg overflow-hidden shadow-lg border border-border hover:shadow-xl hover:-translate-y-0.5 transition-[transform,box-shadow] duration-200 motion-reduce:transform-none flex flex-col;
   }
 
   /* Entity card specific styles */
   .entity-card-tw {
-    @apply bg-card rounded-lg overflow-hidden shadow-lg border border-border hover:shadow-xl transition-all duration-200 flex flex-col;
+    @apply bg-card rounded-lg overflow-hidden shadow-lg border border-border hover:shadow-xl hover:-translate-y-0.5 transition-[transform,box-shadow] duration-200 motion-reduce:transform-none flex flex-col;
   }
 
   .event-card-image-tw {
@@ -382,4 +462,25 @@
 .swal2-html-container,
 .swal2-content {
   @apply text-muted-foreground;
+}
+
+/* Collapse all motion for users who prefer reduced motion.
+   Spinners are exempt — indeterminate progress must stay visible. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .spinner,
+  .btn-spinner,
+  .load-spinner::after,
+  .animate-spin {
+    animation-duration: 0.8s !important;
+    animation-iteration-count: infinite !important;
+  }
 }

--- a/resources/views/components/theme-toggle.blade.php
+++ b/resources/views/components/theme-toggle.blade.php
@@ -15,8 +15,9 @@
 }">
     <button
         @click="toggle()"
-        class="inline-flex items-center justify-center rounded-md p-2 text-muted-foreground hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        class="inline-flex items-center justify-center rounded-md p-2 text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-[color,background-color,transform] active:scale-95 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
         :aria-label="isDark ? 'Switch to light mode' : 'Switch to dark mode'">
-        <i class="bi text-lg" :class="isDark ? 'bi-sun-fill' : 'bi-moon-fill'"></i>
+        <i x-show="isDark" x-cloak class="bi bi-sun-fill text-lg anim-theme-swap"></i>
+        <i x-show="!isDark" x-cloak class="bi bi-moon-fill text-lg anim-theme-swap"></i>
     </button>
 </div>

--- a/resources/views/components/ui/button.blade.php
+++ b/resources/views/components/ui/button.blade.php
@@ -2,10 +2,11 @@
     'variant' => 'default',
     'size' => 'default',
     'href' => null,
+    'loading' => false,
 ])
 
 @php
-$base = 'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50';
+$base = 'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,background-color,border-color,transform,opacity] active:scale-[0.98] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50';
 
 $variants = [
     'default' => 'bg-primary text-primary-foreground shadow hover:bg-primary/90',
@@ -27,14 +28,20 @@ $sizes = [
 $classes = $base
     . ' ' . ($variants[$variant] ?? $variants['default'])
     . ' ' . ($sizes[$size] ?? $sizes['default']);
+
+if ($loading) {
+    $classes .= $href ? ' opacity-60 pointer-events-none' : '';
+}
 @endphp
 
 @if($href)
-    <a href="{{ $href }}" {{ $attributes->merge(['class' => $classes]) }}>
+    <a href="{{ $href }}" {{ $attributes->merge(['class' => $classes]) }} @if($loading) aria-busy="true" @endif>
+        @if($loading)<span class="btn-spinner" aria-hidden="true"></span>@endif
         {{ $slot }}
     </a>
 @else
-    <button {{ $attributes->merge(['class' => $classes]) }}>
+    <button {{ $attributes->merge(['class' => $classes]) }} @if($loading) disabled aria-busy="true" @endif>
+        @if($loading)<span class="btn-spinner" aria-hidden="true"></span>@endif
         {{ $slot }}
     </button>
 @endif

--- a/resources/views/components/ui/modal.blade.php
+++ b/resources/views/components/ui/modal.blade.php
@@ -19,13 +19,13 @@ $sizeClass = $sizeClasses[$size] ?? $sizeClasses['md'];
 
 <!-- Modal Backdrop -->
 <div id="{{ $id }}"
-     class="hidden fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
+     class="hidden anim-fade-in fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
      role="dialog"
      aria-modal="true"
      aria-labelledby="{{ $id }}-title">
 
     <!-- Modal Container -->
-    <div class="bg-card rounded-lg shadow-xl {{ $sizeClass }} w-full max-h-[90vh] flex flex-col border border-border"
+    <div class="anim-zoom-in bg-card rounded-lg shadow-xl {{ $sizeClass }} w-full max-h-[90vh] flex flex-col border border-border"
          @click.stop>
 
         <!-- Modal Header -->

--- a/resources/views/entities/card-tw.blade.php
+++ b/resources/views/entities/card-tw.blade.php
@@ -1,5 +1,7 @@
 <!-- Entity Card Component -->
-<article class="entity-card-tw group {{ $entity->entityStatus->name === 'Inactive' ? 'opacity-50' : '' }}" id="entity-card-{{ $entity->id }}">
+<article class="entity-card-tw group {{ $entity->entityStatus->name === 'Inactive' ? 'opacity-50' : '' }} {{ isset($loop) ? 'stagger-item' : '' }}"
+	@isset($loop) style="--stagger-i: {{ $loop->index % 24 }}" @endisset
+	id="entity-card-{{ $entity->id }}">
 	<!-- Entity Image -->
 	<div class="relative overflow-hidden">
 		@if ($primary = $entity->getPrimaryPhoto())

--- a/resources/views/events/card-tw.blade.php
+++ b/resources/views/events/card-tw.blade.php
@@ -1,5 +1,7 @@
 <!-- Event Card Component -->
-<article class="event-card-tw group {{ $event->visibility->name === 'Cancelled' ? 'opacity-50' : '' }}" id="event-card-{{ $event->id }}">
+<article class="event-card-tw group {{ $event->visibility->name === 'Cancelled' ? 'opacity-50' : '' }} {{ isset($loop) ? 'stagger-item' : '' }}"
+    @isset($loop) style="--stagger-i: {{ $loop->index % 24 }}" @endisset
+    id="event-card-{{ $event->id }}">
     <!-- Event Image -->
     <div class="relative overflow-hidden">
         @if ($primary = $event->getPrimaryPhoto())
@@ -69,7 +71,7 @@
     <div class="event-card-content-tw">
         <!-- Event Title -->
         <h3 class="event-card-title-tw mb-2 line-clamp-2">
-            <a href="{{ route('events.show', [$event->slug]) }}">{{ $event->name }}</a>
+            <a href="{{ route('events.show', [$event->slug]) }}" class="link-reveal">{{ $event->name }}</a>
         </h3>
 
         <!-- Short Description -->

--- a/resources/views/events/cell-compact-tw.blade.php
+++ b/resources/views/events/cell-compact-tw.blade.php
@@ -1,4 +1,4 @@
-<div class="flex flex-col group">
+<div class="flex flex-col group {{ isset($loop) ? 'stagger-item' : '' }}" @isset($loop) style="--stagger-i: {{ $loop->index % 24 }}" @endisset>
     <!-- Date bar or placeholder to maintain alignment -->
     @if ($showDateBar)
         <div class="text-xs font-medium px-2 py-1 text-center mb-1 rounded-sm {{ $isWeekend ? 'badge-tw badge-warning-tw' : 'bg-accent text-foreground' }}">

--- a/resources/views/partials/sidebar-tw.blade.php
+++ b/resources/views/partials/sidebar-tw.blade.php
@@ -157,7 +157,7 @@
 
 
 <!-- Mobile Sidebar Overlay -->
-<div id="mobile-sidebar-overlay" class="hidden lg:hidden fixed inset-0 bg-black/50 z-40" onclick="closeMobileSidebar()"></div>
+<div id="mobile-sidebar-overlay" class="hidden anim-fade-in lg:hidden fixed inset-0 bg-black/50 z-40" onclick="closeMobileSidebar()"></div>
 
 <!-- Mobile Sidebar -->
 <aside id="mobile-sidebar" class="sidebar fixed inset-y-0 left-0 z-50 w-64 transform -translate-x-full transition-transform duration-200 ease-in-out lg:hidden bg-card border-r border-border flex flex-col">

--- a/resources/views/series/card-tw.blade.php
+++ b/resources/views/series/card-tw.blade.php
@@ -72,7 +72,7 @@
 
         <!-- Series Title -->
         <h3 class="event-card-title-tw mb-2 line-clamp-2">
-            <a href="{{ route('series.show', [$series->slug]) }}">{{ $series->name }}</a>
+            <a href="{{ route('series.show', [$series->slug]) }}" class="link-reveal">{{ $series->name }}</a>
         </h3>
 
         <!-- Short Description -->


### PR DESCRIPTION
## Summary

Issue #2014 asked to look into adding the animations from [Amicro](https://amicro.vercel.app/). Amicro is a **React + Motion** component library, so it can't be installed directly into this Blade/Alpine/Tailwind 4 app — instead this PR adapts its signature effects (entrance transitions, card hovers, button feedback, loaders) natively with CSS keyframes and class toggles. Zero new dependencies.

### What's included

**Foundation** (`resources/css/tailwind.css`)
- `tw-fade-in` / `tw-fade-up` / `tw-zoom-in` / `tw-spin` keyframes with `anim-*` classes (`backwards` fill so hover transforms aren't locked after entry)
- Global `prefers-reduced-motion` guard — all motion collapses to instant, spinners exempt (indeterminate progress must stay visible)

**High-impact targets**
- Card grids stagger in: `stagger-item` + inline `--stagger-i` from `$loop->index` on the card partial roots (events/entities/cell-compact), delay capped at 480ms via `min()`. CSS-only, so AJAX-appended pagination pages animate for free
- Card hover lift on `.event-card-tw` / `.entity-card-tw` / `.card-hover-tw` (transform + shadow only, `motion-reduce:transform-none`)
- `x-ui.button`: press feedback (`active:scale-[0.98]`) and a new `loading` prop → disabled + `aria-busy` + border spinner that inherits the variant's text color
- Resurrected the orphaned `#loading` overlay, `.spinner` and `.load-spinner` styles (markup existed but CSS only lived in dead legacy Bootstrap bundles) — pagination/infinite scroll now show the overlay
- `a.ajax-action` (attend/follow/like): `is-pending` dim + double-click guard while in flight, replacement target zooms in

**Polish**
- Modal and mobile-sidebar overlay fade/zoom on open (zero JS — display toggling restarts CSS animations)
- `link-reveal` underline sweep on event/series card titles
- Skipped Amicro's tilt-card and magnetic-button deliberately — they need per-element mousemove JS and read as gimmicky on dense grids

### Design constraint worth knowing

`tailwind.config.js` content globs don't include `public/js/`, so any class toggled only from `custom.js` would be purged if defined as a Tailwind utility. All JS-toggled classes are therefore plain CSS in `@layer components`. Verified post-build that `tw-fade-up`, `is-pending`, `.loading.is-active`, etc. survive in the compiled bundle.

## Testing

- `npm run build` passes; grepped compiled CSS for all new classes/keyframes
- `phpunit tests/Feature/EventsTest.php tests/Feature/EntitiesTest.php` — 19/19 pass
- Verified on dev.arcane.city that `/events/grid` renders `stagger-item` + `--stagger-i` markup
- Manual checks recommended before merge: dark mode, DevTools reduced-motion emulation, an ajax-action click, mobile drawer

Closes #2014

🤖 Generated with [Claude Code](https://claude.com/claude-code)