### PR TITLE
Improve inline quick-add venue/promoter forms (descriptions, image, duplicate warning)

### DIFF
--- a/app/Http/Controllers/EntitiesController.php
+++ b/app/Http/Controllers/EntitiesController.php
@@ -798,11 +798,14 @@ class EntitiesController extends Controller
      * Quickly create a minimal entity (venue or promoter) from the event form and return JSON.
      * Lets users add a missing venue/promoter inline without leaving the event form.
      */
-    public function quickStore(Request $request): JsonResponse
+    public function quickStore(Request $request, ImageHandler $imageHandler): JsonResponse
     {
         $validated = $request->validate([
             'name' => 'required|string|min:3|max:255',
             'role' => 'nullable|string',
+            'short' => 'nullable|string|max:255',
+            'description' => 'nullable|string',
+            'image' => 'nullable|file|mimes:jpg,jpeg,png,gif,webp|max:10240',
         ]);
 
         $roleName = in_array($request->input('role'), ['Venue', 'Promoter'], true)
@@ -820,8 +823,8 @@ class EntitiesController extends Controller
         $entity = Entity::create([
             'name' => $validated['name'],
             'slug' => $slug,
-            'short' => $validated['name'],
-            'description' => $validated['name'],
+            'short' => $validated['short'] ?? $validated['name'],
+            'description' => $validated['description'] ?? $validated['name'],
             'entity_type_id' => $roleName === 'Venue' ? EntityType::SPACE : EntityType::GROUP,
             'entity_status_id' => EntityStatus::ACTIVE,
             'created_by' => $this->user->id,
@@ -833,6 +836,13 @@ class EntitiesController extends Controller
 
         if ($role = Role::where('name', $roleName)->first()) {
             $entity->roles()->attach($role->id);
+        }
+
+        if ($request->hasFile('image')) {
+            $photo = $imageHandler->makePhoto($request->file('image'));
+            $photo->is_primary = 1;
+            $photo->save();
+            $entity->addPhoto($photo);
         }
 
         Activity::log($entity, $this->user, Action::CREATE);
@@ -848,6 +858,59 @@ class EntitiesController extends Controller
             'name' => $entity->name,
             'slug' => $entity->slug,
         ], 201);
+    }
+
+    /**
+     * Check for existing entities with a name similar to the one being quick-added,
+     * so the event form can warn the user about likely duplicates.
+     */
+    public function quickCheck(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|min:3|max:255',
+        ]);
+
+        $name = $validated['name'];
+
+        $candidates = Entity::where(function (Builder $query) use ($name) {
+            $query->where('name', 'like', '%'.$name.'%')
+                ->orWhereRaw('SOUNDEX(name) = SOUNDEX(?)', [$name])
+                ->orWhereHas('aliases', function ($q) use ($name) {
+                    $q->where('name', $name);
+                });
+        })
+            ->with(['entityType', 'aliases'])
+            ->limit(25)
+            ->get();
+
+        $matches = $candidates
+            ->map(function (Entity $entity) use ($name) {
+                $aliasMatch = $entity->aliases->contains(
+                    fn ($alias) => 0 === strcasecmp($alias->name, $name)
+                );
+                similar_text(mb_strtolower($name), mb_strtolower($entity->name), $percent);
+
+                return [
+                    'entity' => $entity,
+                    'score' => $aliasMatch ? 100.0 : $percent,
+                    'keep' => $aliasMatch
+                        || $percent >= 60
+                        || false !== mb_stripos($entity->name, $name)
+                        || false !== mb_stripos($name, $entity->name),
+                ];
+            })
+            ->filter(fn (array $match) => $match['keep'])
+            ->sortByDesc('score')
+            ->take(5)
+            ->values()
+            ->map(fn (array $match) => [
+                'id' => $match['entity']->id,
+                'name' => $match['entity']->name,
+                'slug' => $match['entity']->slug,
+                'entity_type' => $match['entity']->entityType?->name,
+            ]);
+
+        return response()->json(['data' => $matches]);
     }
 
     /**

--- a/resources/views/events/form.blade.php
+++ b/resources/views/events/form.blade.php
@@ -491,8 +491,38 @@
     <x-ui.form-group name="quick_add_name" label="Name">
         <x-ui.input type="text" id="quick-add-name" placeholder="e.g. The Smiling Moose" />
     </x-ui.form-group>
+
+    {{-- Possible duplicate warning --}}
+    <div id="quick-add-duplicates"
+         class="hidden mt-3 rounded-md border border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-700 p-3 text-sm"
+         role="alert">
+        <div class="flex items-start gap-2">
+            <i class="bi bi-exclamation-triangle-fill text-amber-600 dark:text-amber-400 mt-0.5 flex-shrink-0"></i>
+            <div class="min-w-0">
+                <p class="font-medium text-amber-800 dark:text-amber-300 mb-1">
+                    Similar entities already exist — click one to select it instead:
+                </p>
+                <ul id="quick-add-duplicates-list" class="space-y-1"></ul>
+                <p class="mt-1 text-amber-600 dark:text-amber-500 text-xs">
+                    Or ignore this and create a new entry anyway.
+                </p>
+            </div>
+        </div>
+    </div>
+
+    <x-ui.form-group name="quick_add_short" label="Short description (optional)" class="mt-3">
+        <x-ui.input type="text" id="quick-add-short" maxlength="255" placeholder="One-line summary" />
+    </x-ui.form-group>
+    <x-ui.form-group name="quick_add_description" label="Description (optional)" class="mt-3">
+        <x-ui.textarea id="quick-add-description" rows="3" placeholder="A fuller description"></x-ui.textarea>
+    </x-ui.form-group>
+    <x-ui.form-group name="quick_add_image" label="Default image (optional)" class="mt-3">
+        <input type="file" id="quick-add-image" accept="image/jpeg,image/png,image/gif,image/webp"
+               class="block w-full text-sm text-muted-foreground file:mr-3 file:rounded-md file:border-0 file:bg-primary file:px-3 file:py-1.5 file:text-sm file:font-medium file:text-primary-foreground hover:file:opacity-90" />
+    </x-ui.form-group>
+
     <p id="quick-add-error" class="hidden mt-2 text-sm text-red-600 dark:text-red-400"></p>
-    <p class="mt-3 text-xs text-muted-foreground">This creates a basic entry so you can keep building your event. You can add a photo, links and details later from the entity's page.</p>
+    <p class="mt-3 text-xs text-muted-foreground">This creates a basic entry so you can keep building your event. You can add links and more details later from the entity's page.</p>
 
     <x-slot:footer>
         <x-ui.button type="button" variant="outline" onclick="document.getElementById('quick-add-entity-modal').classList.add('hidden')">
@@ -533,6 +563,11 @@
         const quickAddName = document.getElementById('quick-add-name');
         const quickAddRole = document.getElementById('quick-add-role');
         const quickAddTarget = document.getElementById('quick-add-target');
+        const quickAddShort = document.getElementById('quick-add-short');
+        const quickAddDescription = document.getElementById('quick-add-description');
+        const quickAddImage = document.getElementById('quick-add-image');
+        const quickAddDuplicates = document.getElementById('quick-add-duplicates');
+        const quickAddDuplicatesList = document.getElementById('quick-add-duplicates-list');
         const quickAddError = document.getElementById('quick-add-error');
         const quickAddSubmit = document.getElementById('quick-add-submit');
 
@@ -541,12 +576,78 @@
             quickAddError.classList.remove('hidden');
         }
 
+        function hideQuickAddDuplicates() {
+            quickAddDuplicates.classList.add('hidden');
+            quickAddDuplicatesList.textContent = '';
+        }
+
+        function selectEntityAndClose(id, name) {
+            const select = $('#' + quickAddTarget.value);
+            let option = select.find('option[value="' + id + '"]');
+            if (option.length) {
+                select.val(id);
+            } else {
+                select.append(new Option(name, id, true, true));
+            }
+            select.trigger('change');
+            quickAddModal.classList.add('hidden');
+        }
+
+        function renderQuickAddDuplicates(matches) {
+            hideQuickAddDuplicates();
+            if (!matches.length) {
+                return;
+            }
+            matches.forEach(function (match) {
+                const li = document.createElement('li');
+                const btn = document.createElement('button');
+                btn.type = 'button';
+                btn.className = 'text-amber-800 dark:text-amber-300 underline hover:no-underline text-left';
+                btn.textContent = match.name + (match.entity_type ? ' (' + match.entity_type + ')' : '');
+                btn.addEventListener('click', function () {
+                    selectEntityAndClose(match.id, match.name);
+                });
+                li.appendChild(btn);
+                quickAddDuplicatesList.appendChild(li);
+            });
+            quickAddDuplicates.classList.remove('hidden');
+        }
+
+        let quickCheckTimer = null;
+        let quickCheckSeq = 0;
+        quickAddName.addEventListener('input', function () {
+            clearTimeout(quickCheckTimer);
+            const name = quickAddName.value.trim();
+            if (name.length < 3) {
+                hideQuickAddDuplicates();
+                return;
+            }
+            quickCheckTimer = setTimeout(function () {
+                const seq = ++quickCheckSeq;
+                fetch('{{ route('entities.quickCheck') }}?name=' + encodeURIComponent(name), {
+                    headers: { 'Accept': 'application/json' }
+                })
+                .then(function (response) { return response.ok ? response.json() : { data: [] }; })
+                .then(function (result) {
+                    // Ignore out-of-order responses from earlier keystrokes
+                    if (seq === quickCheckSeq) {
+                        renderQuickAddDuplicates(result.data || []);
+                    }
+                })
+                .catch(function () { /* duplicate check is advisory; ignore failures */ });
+            }, 400);
+        });
+
         document.querySelectorAll('[data-quick-add]').forEach(function (btn) {
             btn.addEventListener('click', function () {
                 const role = btn.getAttribute('data-quick-add');
                 quickAddRole.value = role;
                 quickAddTarget.value = btn.getAttribute('data-target');
                 quickAddName.value = '';
+                quickAddShort.value = '';
+                quickAddDescription.value = '';
+                quickAddImage.value = '';
+                hideQuickAddDuplicates();
                 quickAddError.classList.add('hidden');
                 document.getElementById('quick-add-entity-modal-title').textContent = 'Add ' + role;
                 quickAddModal.classList.remove('hidden');
@@ -565,14 +666,26 @@
 
             quickAddSubmit.disabled = true;
 
+            const formData = new FormData();
+            formData.append('name', name);
+            formData.append('role', quickAddRole.value);
+            if (quickAddShort.value.trim()) {
+                formData.append('short', quickAddShort.value.trim());
+            }
+            if (quickAddDescription.value.trim()) {
+                formData.append('description', quickAddDescription.value.trim());
+            }
+            if (quickAddImage.files.length) {
+                formData.append('image', quickAddImage.files[0]);
+            }
+
             fetch('{{ route('entities.quickStore') }}', {
                 method: 'POST',
                 headers: {
-                    'Content-Type': 'application/json',
                     'Accept': 'application/json',
                     'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
                 },
-                body: JSON.stringify({ name: name, role: quickAddRole.value })
+                body: formData
             })
             .then(function (response) {
                 return response.json().then(function (data) {
@@ -581,17 +694,16 @@
             })
             .then(function (result) {
                 if (!result.ok) {
-                    const msg = result.data && result.data.errors && result.data.errors.name
-                        ? result.data.errors.name[0]
+                    const errors = result.data && result.data.errors;
+                    const firstError = errors && (errors.name || errors.short || errors.description || errors.image);
+                    const msg = firstError
+                        ? firstError[0]
                         : (result.data.message || 'Could not create the entity. Please try again.');
                     showQuickAddError(msg);
                     return;
                 }
 
-                const select = $('#' + quickAddTarget.value);
-                const option = new Option(result.data.name, result.data.id, true, true);
-                select.append(option).trigger('change');
-                quickAddModal.classList.add('hidden');
+                selectEntityAndClose(result.data.id, result.data.name);
             })
             .catch(function () {
                 showQuickAddError('Something went wrong. Please try again.');

--- a/routes/web.php
+++ b/routes/web.php
@@ -540,6 +540,7 @@ Route::get('entities/reset', ['as' => 'entities.reset', 'uses' => '\App\Http\Con
 Route::get('entities/rpp-reset', ['as' => 'entities.rppReset', 'uses' => '\App\Http\Controllers\EntitiesController@rppReset']);
 
 Route::post('entities/quick-store', [\App\Http\Controllers\EntitiesController::class, 'quickStore'])->name('entities.quickStore')->middleware('auth');
+Route::get('entities/quick-check', [\App\Http\Controllers\EntitiesController::class, 'quickCheck'])->name('entities.quickCheck')->middleware('auth');
 
 Route::get('entities/tag/{tag}', [\App\Http\Controllers\EntitiesController::class, 'indexTags'])->name('entities.tag');
 Route::get('entities/alias/{alias}', [\App\Http\Controllers\EntitiesController::class, 'indexAliases'])->name('entities.alias');

--- a/tests/Feature/EntityQuickCheckTest.php
+++ b/tests/Feature/EntityQuickCheckTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Alias;
+use App\Models\Entity;
+use App\Models\EntityStatus;
+use App\Models\EntityType;
+use App\Models\User;
+use App\Models\UserStatus;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EntityQuickCheckTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    private function activeUser(): User
+    {
+        /** @var User $user */
+        $user = User::factory()->create([
+            'email_verified_at' => Carbon::now(),
+            'user_status_id' => UserStatus::ACTIVE,
+        ]);
+
+        return $user;
+    }
+
+    private function makeEntity(string $name, int $typeId = EntityType::SPACE): Entity
+    {
+        return Entity::factory()->create([
+            'name' => $name,
+            'slug' => \Illuminate\Support\Str::slug($name),
+            'entity_type_id' => $typeId,
+            'entity_status_id' => EntityStatus::ACTIVE,
+        ]);
+    }
+
+    /** @test */
+    public function a_guest_cannot_use_quick_check()
+    {
+        $this->getJson('/entities/quick-check?name=Spirit')
+            ->assertStatus(401);
+    }
+
+    /** @test */
+    public function quick_check_requires_a_name_of_at_least_three_characters()
+    {
+        $this->actingAs($this->activeUser())
+            ->getJson('/entities/quick-check?name=ab')
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('name');
+    }
+
+    /** @test */
+    public function quick_check_finds_an_exact_name_match()
+    {
+        $entity = $this->makeEntity('Spirit Lodge');
+
+        $this->actingAs($this->activeUser())
+            ->getJson('/entities/quick-check?name=Spirit Lodge')
+            ->assertStatus(200)
+            ->assertJsonFragment(['id' => $entity->id, 'name' => 'Spirit Lodge']);
+    }
+
+    /** @test */
+    public function quick_check_finds_a_substring_match()
+    {
+        $entity = $this->makeEntity('The Spirit Lodge Hall');
+
+        $this->actingAs($this->activeUser())
+            ->getJson('/entities/quick-check?name=spirit lodge')
+            ->assertStatus(200)
+            ->assertJsonFragment(['id' => $entity->id]);
+    }
+
+    /** @test */
+    public function quick_check_finds_a_close_misspelling()
+    {
+        $entity = $this->makeEntity('Spirit Lodge');
+
+        $this->actingAs($this->activeUser())
+            ->getJson('/entities/quick-check?name=Sprit Lodge')
+            ->assertStatus(200)
+            ->assertJsonFragment(['id' => $entity->id]);
+    }
+
+    /** @test */
+    public function quick_check_matches_entities_of_any_type_and_returns_the_type_label()
+    {
+        $this->makeEntity('Spirit Collective', EntityType::GROUP);
+
+        $response = $this->actingAs($this->activeUser())
+            ->getJson('/entities/quick-check?name=Spirit Collective')
+            ->assertStatus(200);
+
+        $match = collect($response->json('data'))->firstWhere('name', 'Spirit Collective');
+        $this->assertNotNull($match);
+        $this->assertSame('Group', $match['entity_type']);
+    }
+
+    /** @test */
+    public function quick_check_matches_an_entity_alias()
+    {
+        $entity = $this->makeEntity('Spirit Lodge');
+        $alias = Alias::create(['name' => 'The Lodge PGH']);
+        $entity->aliases()->attach($alias->id);
+
+        $this->actingAs($this->activeUser())
+            ->getJson('/entities/quick-check?name=The Lodge PGH')
+            ->assertStatus(200)
+            ->assertJsonFragment(['id' => $entity->id]);
+    }
+
+    /** @test */
+    public function quick_check_returns_nothing_for_an_unrelated_name()
+    {
+        $this->makeEntity('Spirit Lodge');
+
+        $this->actingAs($this->activeUser())
+            ->getJson('/entities/quick-check?name=Completely Different Venue Xyz')
+            ->assertStatus(200)
+            ->assertJsonMissing(['name' => 'Spirit Lodge']);
+    }
+
+    /** @test */
+    public function quick_check_returns_at_most_five_matches()
+    {
+        foreach (range(1, 8) as $i) {
+            $this->makeEntity('Spirit Venue '.$i);
+        }
+
+        $response = $this->actingAs($this->activeUser())
+            ->getJson('/entities/quick-check?name=Spirit Venue')
+            ->assertStatus(200);
+
+        $this->assertLessThanOrEqual(5, count($response->json('data')));
+    }
+}

--- a/tests/Feature/EntityQuickStoreTest.php
+++ b/tests/Feature/EntityQuickStoreTest.php
@@ -9,6 +9,8 @@ use App\Models\User;
 use App\Models\UserStatus;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
 
 class EntityQuickStoreTest extends TestCase
@@ -104,5 +106,81 @@ class EntityQuickStoreTest extends TestCase
             ->postJson('/entities/quick-store', ['name' => 'ab', 'role' => 'Venue'])
             ->assertStatus(422)
             ->assertJsonValidationErrors('name');
+    }
+
+    /** @test */
+    public function quick_create_stores_optional_short_and_full_description()
+    {
+        $user = $this->activeUser();
+
+        $this->actingAs($user)
+            ->postJson('/entities/quick-store', [
+                'name' => 'Mr Smalls Theatre',
+                'role' => 'Venue',
+                'short' => 'Converted church concert venue',
+                'description' => 'A concert venue in Millvale housed in a converted 19th-century church.',
+            ])
+            ->assertStatus(201);
+
+        $entity = Entity::where('name', 'Mr Smalls Theatre')->first();
+
+        $this->assertNotNull($entity);
+        $this->assertSame('Converted church concert venue', $entity->short);
+        $this->assertSame('A concert venue in Millvale housed in a converted 19th-century church.', $entity->description);
+    }
+
+    /** @test */
+    public function quick_create_uses_the_name_as_placeholder_when_descriptions_are_omitted()
+    {
+        $user = $this->activeUser();
+
+        $this->actingAs($user)
+            ->postJson('/entities/quick-store', ['name' => 'Placeholder Hall', 'role' => 'Venue'])
+            ->assertStatus(201);
+
+        $entity = Entity::where('name', 'Placeholder Hall')->first();
+
+        $this->assertSame('Placeholder Hall', $entity->short);
+        $this->assertSame('Placeholder Hall', $entity->description);
+    }
+
+    /** @test */
+    public function quick_create_attaches_an_optional_image_as_primary_photo()
+    {
+        Storage::fake('external');
+        $user = $this->activeUser();
+
+        $this->actingAs($user)
+            ->post('/entities/quick-store', [
+                'name' => 'Spirit Lodge',
+                'role' => 'Venue',
+                'image' => UploadedFile::fake()->image('lodge.jpg'),
+            ], ['Accept' => 'application/json'])
+            ->assertStatus(201);
+
+        $entity = Entity::where('name', 'Spirit Lodge')->first();
+        $photo = $entity->photos()->first();
+
+        $this->assertNotNull($photo);
+        $this->assertSame(1, (int) $photo->is_primary);
+        $this->assertSame($user->id, $photo->created_by);
+    }
+
+    /** @test */
+    public function quick_create_rejects_a_non_image_file()
+    {
+        Storage::fake('external');
+        $user = $this->activeUser();
+
+        $this->actingAs($user)
+            ->post('/entities/quick-store', [
+                'name' => 'Bad Upload Hall',
+                'role' => 'Venue',
+                'image' => UploadedFile::fake()->create('document.pdf', 100, 'application/pdf'),
+            ], ['Accept' => 'application/json'])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('image');
+
+        $this->assertNull(Entity::where('name', 'Bad Upload Hall')->first());
     }
 }


### PR DESCRIPTION
## Summary

Improves the inline "Add Promoter" / "Add Venue" modal on the event create/edit form, per #2025:

- **Optional short + full description inputs** — passed through to the new entity instead of the name-placeholder stubs (which remain the fallback when left blank)
- **Optional default image upload** — sent as multipart with the quick-add request, processed through the existing `ImageHandler::makePhoto()` path and attached as the entity's primary photo; non-image files are rejected before the entity is created
- **Fuzzy duplicate warning while typing** — a new auth-only `GET entities/quick-check` endpoint gathers candidates via `LIKE %name%`, MySQL `SOUNDEX`, and exact alias match, ranks them with `similar_text()`, and returns the top 5 across **all** entity types. The modal shows matches in an amber warning panel (debounced 400ms, stale-response guarded); **clicking a match selects the existing entity** into the dropdown instead of creating a duplicate — or the user can ignore it and create anyway

The modal submit switched from JSON to `FormData` to carry the file; all modal inputs still have no `name` attributes so nothing leaks into the parent event form post.

## Test plan

- [x] New `EntityQuickCheckTest` (9 tests): auth, validation, exact/substring/misspelling ("Sprit Lodge" → "Spirit Lodge") matches, alias match, cross-type matching with type label, unrelated-name exclusion, 5-result cap
- [x] Extended `EntityQuickStoreTest` (+4 tests): descriptions stored, placeholder fallback preserved, image attached as primary photo with correct `created_by`, non-image rejected with 422
- [x] Regression: `EventsTest` (renders `/events/create` authed, exercising new modal markup) + `EntitiesTest` — 37 tests, 93 assertions green
- [x] `composer phpstan` clean; all Blade views compile
- [ ] Manual browser pass of the modal (duplicate warning, click-to-select, create with image)

Closes #2025

🤖 Generated with [Claude Code](https://claude.com/claude-code)