### PR TITLE
Add colored status dot to user cards on users index

### DIFF
--- a/docs/superpowers/plans/2026-07-29-user-status-dot.md
+++ b/docs/superpowers/plans/2026-07-29-user-status-dot.md
@@ -1,0 +1,215 @@
+# User Status Dot Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a small colored status dot on each user card's avatar on the users index, visible to all viewers.
+
+**Architecture:** A new Blade partial `users/status-dot.blade.php` maps `user_status_id` to a literal Tailwind color class and renders an absolutely-positioned dot; `users/card-tw.blade.php` includes it inside the avatar wrapper (made `relative`) and drops its dead status-badge block. No controller changes — `UsersController@index` already eager-loads `status`.
+
+**Tech Stack:** Laravel 12 Blade, Tailwind 4 (classes must appear literally in Blade files — Tailwind only scans `resources/views` and JS), PHPUnit feature tests against MySQL.
+
+## Global Constraints
+
+- Color map (from spec): Active(2)=`bg-green-500`, Pending(1)=`bg-yellow-400`, Suspended(3)=`bg-orange-500`, Banned(4)=`bg-red-500`, Deleted(5)=`bg-gray-400`, null/unknown = no dot.
+- Use full-form `@php ... @endphp` — the `@php(...)` paren form fails to compile in this app.
+- Status constants come from `App\Models\UserStatus` (PENDING=1, ACTIVE=2, SUSPENDED=3, BANNED=4, DELETED=5).
+- Feature tests: `use RefreshDatabase;` + `protected $seed = true;` + `$this->withExceptionHandling();` (suite convention).
+- `User::factory()` assigns a RANDOM `user_status_id` — always pass an explicit `user_status_id` when the test depends on status.
+- New Tailwind classes require `npm run build` before they're visible on a deployed/dev site.
+
+---
+
+### Task 1: Status dot partial + card integration (TDD)
+
+**Files:**
+- Create: `resources/views/users/status-dot.blade.php`
+- Modify: `resources/views/users/card-tw.blade.php:4-19` (avatar wrapper)
+- Test: `tests/Feature/UserStatusDotTest.php` (new)
+
+**Interfaces:**
+- Consumes: `$user` (an `App\Models\User` with `user_status_id` and eager-loaded `status`), `UserStatus` constants.
+- Produces: partial `users/status-dot` — expects `$user` in scope; renders `<span data-status-dot ...>` or nothing. `data-status-dot` is the stable hook tests and future JS may rely on.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Feature/UserStatusDotTest.php`:
+
+```php
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\UserStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserStatusDotTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    /** @test */
+    public function users_index_shows_colored_status_dot_for_user_with_status(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        $response = $this->get('/users?limit=1000');
+        $response->assertStatus(200);
+
+        $card = $this->extractCard($response->getContent(), $user->id);
+        $this->assertStringContainsString('data-status-dot', $card);
+        $this->assertStringContainsString('bg-green-500', $card);
+        $this->assertStringContainsString('title="Active"', $card);
+    }
+
+    /** @test */
+    public function users_index_shows_no_dot_for_user_without_status(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = User::factory()->create(['user_status_id' => null]);
+
+        $response = $this->get('/users?limit=1000');
+        $response->assertStatus(200);
+
+        $card = $this->extractCard($response->getContent(), $user->id);
+        $this->assertStringNotContainsString('data-status-dot', $card);
+    }
+
+    private function extractCard(string $html, int $userId): string
+    {
+        $matched = preg_match(
+            '/<article[^>]*id="user-card-'.$userId.'".*?<\/article>/s',
+            $html,
+            $m
+        );
+        $this->assertSame(1, $matched, "Card for user {$userId} not found on index");
+
+        return $m[0];
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./vendor/bin/phpunit tests/Feature/UserStatusDotTest.php`
+Expected: FAIL — `data-status-dot` not found (feature not implemented). If the card itself isn't found, fix the test before proceeding, not the view.
+
+- [ ] **Step 3: Create the partial**
+
+Create `resources/views/users/status-dot.blade.php`:
+
+```blade
+{{-- Colored status indicator dot; expects $user in scope. Renders nothing without a mapped status. --}}
+@php
+$statusDotClass = match ($user->user_status_id) {
+    \App\Models\UserStatus::ACTIVE => 'bg-green-500',
+    \App\Models\UserStatus::PENDING => 'bg-yellow-400',
+    \App\Models\UserStatus::SUSPENDED => 'bg-orange-500',
+    \App\Models\UserStatus::BANNED => 'bg-red-500',
+    \App\Models\UserStatus::DELETED => 'bg-gray-400',
+    default => null,
+};
+@endphp
+@if ($statusDotClass)
+<span data-status-dot
+    class="absolute bottom-1 right-1 w-4 h-4 rounded-full border-2 border-card {{ $statusDotClass }}"
+    title="{{ optional($user->status)->name }}"></span>
+@endif
+```
+
+- [ ] **Step 4: Wire it into the card**
+
+In `resources/views/users/card-tw.blade.php`, change the avatar wrapper (line 5) from `<div class="mb-4">` to `<div class="mb-4 relative">` and add the include just before that div closes:
+
+```blade
+        <!-- User Avatar -->
+        <div class="mb-4 relative">
+            @if ($photo = $user->getPrimaryPhoto())
+            ...existing avatar markup unchanged...
+            @endif
+            @include('users.status-dot')
+        </div>
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `./vendor/bin/phpunit tests/Feature/UserStatusDotTest.php`
+Expected: PASS (2 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/Feature/UserStatusDotTest.php resources/views/users/status-dot.blade.php resources/views/users/card-tw.blade.php
+git commit -m "Add colored status dot to user cards on users index"
+```
+
+---
+
+### Task 2: Remove dead status badge block from card
+
+**Files:**
+- Modify: `resources/views/users/card-tw.blade.php:26-33`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: nothing — pure dead-code removal. The block checks `$user->user_status`, a property that does not exist (the relation is `status`), so it has never rendered.
+
+- [ ] **Step 1: Remove the block**
+
+Delete these lines from `card-tw.blade.php`:
+
+```blade
+        <!-- User Status Badge -->
+        @if (isset($user->user_status))
+        <div class="mb-3">
+            <span class="badge-tw {{ $user->user_status->name == 'Active' ? 'badge-primary-tw' : 'badge-secondary-tw' }} text-xs">
+                {{ $user->user_status->name }}
+            </span>
+        </div>
+        @endif
+```
+
+- [ ] **Step 2: Verify nothing else references the pattern and tests still pass**
+
+Run: `grep -rn "user_status\b" resources/views/users/` — expect no hits in `card-tw.blade.php` (the `user_status_id` field in `form-tw.blade.php` is unrelated and stays).
+Run: `./vendor/bin/phpunit tests/Feature/UserStatusDotTest.php`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add resources/views/users/card-tw.blade.php
+git commit -m "Remove dead user_status badge block from user card"
+```
+
+---
+
+### Task 3: Build assets + full verification
+
+**Files:**
+- Modify: none (build output only)
+
+**Interfaces:**
+- Consumes: the literal classes from Task 1 (`bg-green-500`, `bg-yellow-400`, `bg-orange-500`, `bg-red-500`, `bg-gray-400`).
+- Produces: compiled CSS containing those classes, so the dot is actually colored in the browser.
+
+- [ ] **Step 1: Build and confirm classes survived the Tailwind scan**
+
+Run: `npm run build && grep -c "bg-yellow-400" public/build/assets/*.css`
+Expected: build succeeds; grep count ≥ 1.
+
+- [ ] **Step 2: Run static analysis and the users feature tests**
+
+Run: `composer phpstan`
+Expected: no NEW errors (baseline errors are pre-existing).
+Run: `./vendor/bin/phpunit tests/Feature/UserStatusDotTest.php tests/Feature/UsersTest.php`
+Expected: PASS
+
+- [ ] **Step 3: Commit (only if build artifacts are tracked; otherwise nothing to commit)**
+
+Run: `git status --short public/build` — if this repo tracks build output, commit it; if ignored, skip.

--- a/docs/superpowers/specs/2026-07-29-user-status-dot-design.md
+++ b/docs/superpowers/specs/2026-07-29-user-status-dot-design.md
@@ -7,7 +7,11 @@
 
 On the users index page, each user card's avatar gets a small colored dot on its
 bottom-right edge (presence-indicator style) reflecting the user's `UserStatus`.
-Visible **only to super_admins**. Hover shows the status name via `title`.
+Visible **to all viewers** (the index is a public directory). Hover shows the
+status name via `title`.
+
+> Revised 2026-07-29: originally admin-only; Geoff requested status be visible
+> to any user on the list page.
 
 ## Color mapping
 
@@ -31,8 +35,7 @@ Visible **only to super_admins**. Hover shows the status name via `title`.
     circle with `title="{{ $user->status->name }}"`.
 - `resources/views/users/card-tw.blade.php`:
   - Avatar wrapper gets `relative`.
-  - Include the partial gated by `$signedIn && Auth::user()->hasGroup('super_admin')`
-    (same check as the card's edit button).
+  - Include the partial unconditionally (all viewers see it).
   - **Remove the dead status badge block** — it checks `$user->user_status`, a
     property that doesn't exist (the relation is `status`), so it has never rendered.
 - No controller changes: `UsersController@index` already eager-loads `status` and
@@ -48,5 +51,6 @@ Visible **only to super_admins**. Hover shows the status name via `title`.
 Feature test on the users index (suite conventions: `$seed = true`,
 `withExceptionHandling()`):
 
-- As super_admin: response contains the dot markup for a user with a known status.
-- As regular user and as anonymous visitor: response does not contain the dot markup.
+- As anonymous visitor: response contains the dot markup (correct color class and
+  `title`) for a user with a known status.
+- A user with no status renders no dot.

--- a/docs/superpowers/specs/2026-07-29-user-status-dot-design.md
+++ b/docs/superpowers/specs/2026-07-29-user-status-dot-design.md
@@ -1,0 +1,52 @@
+# User status dot on users index — design
+
+**Date:** 2026-07-29
+**Status:** Approved (brainstormed with Geoff Maddock)
+
+## Summary
+
+On the users index page, each user card's avatar gets a small colored dot on its
+bottom-right edge (presence-indicator style) reflecting the user's `UserStatus`.
+Visible **only to super_admins**. Hover shows the status name via `title`.
+
+## Color mapping
+
+| Status (`user_status_id`) | Color class |
+|---|---|
+| Active (2) | `bg-green-500` |
+| Pending (1) | `bg-yellow-400` |
+| Suspended (3) | `bg-orange-500` |
+| Banned (4) | `bg-red-500` |
+| Deleted (5) | `bg-gray-400` |
+| null / unknown | no dot rendered |
+
+## Implementation
+
+- New partial `resources/views/users/status-dot.blade.php`:
+  - Full-form `@php ... @endphp` block (the `@php(...)` paren form breaks in this
+    app) with a `match` on `$user->user_status_id` returning **literal** Tailwind
+    class strings — literal because Tailwind only scans `resources/views` and JS,
+    so classes composed in `app/` PHP would be purged.
+  - Renders an absolutely-positioned `w-4 h-4 rounded-full border-2 border-card`
+    circle with `title="{{ $user->status->name }}"`.
+- `resources/views/users/card-tw.blade.php`:
+  - Avatar wrapper gets `relative`.
+  - Include the partial gated by `$signedIn && Auth::user()->hasGroup('super_admin')`
+    (same check as the card's edit button).
+  - **Remove the dead status badge block** — it checks `$user->user_status`, a
+    property that doesn't exist (the relation is `status`), so it has never rendered.
+- No controller changes: `UsersController@index` already eager-loads `status` and
+  `user_status_id` is on the row.
+
+## Rejected alternatives
+
+- Color map on the `UserStatus` model: requires a Tailwind safelist; two places to maintain.
+- Inline in `card-tw.blade.php`: card is already busy; partial is reusable on the show page later.
+
+## Testing
+
+Feature test on the users index (suite conventions: `$seed = true`,
+`withExceptionHandling()`):
+
+- As super_admin: response contains the dot markup for a user with a known status.
+- As regular user and as anonymous visitor: response does not contain the dot markup.

--- a/docs/superpowers/specs/2026-07-29-user-status-dot-design.md
+++ b/docs/superpowers/specs/2026-07-29-user-status-dot-design.md
@@ -7,8 +7,9 @@
 
 On the users index page, each user card's avatar gets a small colored dot on its
 bottom-right edge (presence-indicator style) reflecting the user's `UserStatus`.
-Visible **to all viewers** (the index is a public directory). Hover shows the
-status name via `title`.
+Visible **to all viewers of the page** — note the users resource route carries
+`->middleware('auth')` (routes/web.php:199), so in practice that means any
+signed-in user. Hover shows the status name via `title`.
 
 > Revised 2026-07-29: originally admin-only; Geoff requested status be visible
 > to any user on the list page.

--- a/resources/views/users/card-tw.blade.php
+++ b/resources/views/users/card-tw.blade.php
@@ -24,15 +24,6 @@
             <a href="{{ route('users.show', [$user]) }}">{{ $user->name }}</a>
         </h3>
 
-        <!-- User Status Badge -->
-        @if (isset($user->user_status))
-        <div class="mb-3">
-            <span class="badge-tw {{ $user->user_status->name == 'Active' ? 'badge-primary-tw' : 'badge-secondary-tw' }} text-xs">
-                {{ $user->user_status->name }}
-            </span>
-        </div>
-        @endif
-
         <!-- User Bio/Description -->
         @if ($user->profile && $user->profile->bio)
         <p class="text-sm text-muted-foreground mb-3 line-clamp-3">{{ $user->profile->bio }}</p>

--- a/resources/views/users/card-tw.blade.php
+++ b/resources/views/users/card-tw.blade.php
@@ -2,7 +2,7 @@
 <article class="card-tw hover:border-primary/30 transition-all" id="user-card-{{ $user->id }}">
     <div class="p-4 flex flex-col items-center text-center">
         <!-- User Avatar -->
-        <div class="mb-4">
+        <div class="mb-4 relative">
             @if ($photo = $user->getPrimaryPhoto())
             <a href="{{ route('users.show', [$user]) }}">
                 <img src="{{ Storage::disk('external')->url($photo->getStorageThumbnail()) }}"
@@ -16,6 +16,7 @@
                 </div>
             </a>
             @endif
+            @include('users.status-dot')
         </div>
 
         <!-- User Name -->

--- a/resources/views/users/status-dot.blade.php
+++ b/resources/views/users/status-dot.blade.php
@@ -1,0 +1,16 @@
+{{-- Colored status indicator dot; expects $user in scope. Renders nothing without a mapped status. --}}
+@php
+$statusDotClass = match ($user->user_status_id) {
+    \App\Models\UserStatus::ACTIVE => 'bg-green-500',
+    \App\Models\UserStatus::PENDING => 'bg-yellow-400',
+    \App\Models\UserStatus::SUSPENDED => 'bg-orange-500',
+    \App\Models\UserStatus::BANNED => 'bg-red-500',
+    \App\Models\UserStatus::DELETED => 'bg-gray-400',
+    default => null,
+};
+@endphp
+@if ($statusDotClass)
+<span data-status-dot
+    class="absolute bottom-1 right-1 w-4 h-4 rounded-full border-2 border-card {{ $statusDotClass }}"
+    title="{{ optional($user->status)->name }}"></span>
+@endif

--- a/tests/Feature/UserStatusDotTest.php
+++ b/tests/Feature/UserStatusDotTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\UserStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserStatusDotTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    /** @test */
+    public function users_index_shows_colored_status_dot_for_user_with_status(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        $response = $this->actingAs($user)->get('/users?limit=1000');
+        $response->assertStatus(200);
+
+        $card = $this->extractCard($response->getContent(), $user->id);
+        $this->assertStringContainsString('data-status-dot', $card);
+        $this->assertStringContainsString('bg-green-500', $card);
+        $this->assertStringContainsString('title="Active"', $card);
+    }
+
+    /** @test */
+    public function status_dot_color_matches_user_status(): void
+    {
+        $this->withExceptionHandling();
+
+        $pending = User::factory()->create(['user_status_id' => UserStatus::PENDING]);
+        $banned = User::factory()->create(['user_status_id' => UserStatus::BANNED]);
+
+        $response = $this->actingAs($pending)->get('/users?limit=1000');
+        $response->assertStatus(200);
+        $html = $response->getContent();
+
+        $this->assertStringContainsString('bg-yellow-400', $this->extractCard($html, $pending->id));
+        $this->assertStringContainsString('bg-red-500', $this->extractCard($html, $banned->id));
+    }
+
+    /** @test */
+    public function users_index_shows_no_dot_for_unmapped_status(): void
+    {
+        $this->withExceptionHandling();
+
+        // user_status_id has no FK constraint; an unmapped id exercises the
+        // defensive default branch of the partial.
+        $user = User::factory()->create(['user_status_id' => 999]);
+
+        $response = $this->actingAs($user)->get('/users?limit=1000');
+        $response->assertStatus(200);
+
+        $card = $this->extractCard($response->getContent(), $user->id);
+        $this->assertStringNotContainsString('data-status-dot', $card);
+    }
+
+    private function extractCard(string $html, int $userId): string
+    {
+        $matched = preg_match(
+            '/<article[^>]*id="user-card-'.$userId.'".*?<\/article>/s',
+            $html,
+            $m
+        );
+        $this->assertSame(1, $matched, "Card for user {$userId} not found on index");
+
+        return $m[0];
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a small colored status indicator dot to each user card's avatar on the users index (presence-indicator style, bottom-right of the avatar), with the status name shown on hover.
- Color mapping: Active = green, Pending = yellow, Suspended = orange, Banned = red, Deleted = gray; unmapped/unknown status renders no dot.
- New partial `resources/views/users/status-dot.blade.php` keeps the literal Tailwind classes in a Blade file so they survive the content scan; no controller changes (index already eager-loads `status`).
- Removes the dead status badge block from `card-tw.blade.php` — it checked `$user->user_status`, a property that doesn't exist (the relation is `status`), so it never rendered.
- Includes design spec + implementation plan docs under `docs/superpowers/`.

Visible to any signed-in user (the users resource route is auth-gated).

## Testing

- New `tests/Feature/UserStatusDotTest.php`: dot renders with correct color and title for a known status; per-status color mapping; no dot for unmapped status id.
- Full PHPUnit suite green locally: 1063 tests, 0 failures.
- `composer phpstan` clean; `npm run build` confirms the color classes survive Tailwind's scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)