### PR TITLE
Add name/email to user edit form; enforce authorization on user edit/update/destroy

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -384,9 +384,20 @@ class UsersController extends Controller
         flash('Success', 'Your user has been created!');
     }
 
+    /**
+     * Only the user themselves or an admin may edit/update/delete a user.
+     */
+    protected function authorizeUserChange(User $user): void
+    {
+        abort_unless(
+            $this->user && ($this->user->id === $user->id || $this->user->can('grant_access')),
+            403
+        );
+    }
+
     public function edit(User $user): View
     {
-        $this->middleware('auth');
+        $this->authorizeUserChange($user);
 
         return view('users.edit-tw', compact('user'))
             ->with($this->getFormOptions());
@@ -394,7 +405,15 @@ class UsersController extends Controller
 
     public function update(User $user, ProfileRequest $request): RedirectResponse
     {
+        $this->authorizeUserChange($user);
+
         $input = $request->all();
+
+        // status and group membership are admin-only fields; strip them for
+        // everyone else so a self-edit POST cannot escalate privileges
+        if (!$this->user->can('grant_access')) {
+            unset($input['user_status_id'], $input['group_list']);
+        }
 
         $input['setting_weekly_update'] = isset($input['setting_weekly_update']) ? 1 : 0;
         $input['setting_daily_update'] = isset($input['setting_daily_update']) ? 1 : 0;
@@ -407,8 +426,8 @@ class UsersController extends Controller
         // Some legacy users have no profile row yet (EVENTREPO-VW); create one on demand.
         $user->profile()->firstOrCreate([])->fill($input)->save();
 
-        if ($request->has('group_list')) {
-            $user->groups()->sync($request->input('group_list', []));
+        if (isset($input['group_list'])) {
+            $user->groups()->sync($input['group_list']);
         }
 
         // add to activity log
@@ -424,6 +443,8 @@ class UsersController extends Controller
      */
     public function destroy(User $user): RedirectResponse
     {
+        $this->authorizeUserChange($user);
+
         // add to activity log
         Activity::log($user, $this->user, 3);
 

--- a/app/Http/Requests/ProfileRequest.php
+++ b/app/Http/Requests/ProfileRequest.php
@@ -13,7 +13,7 @@ class ProfileRequest extends Request
      */
     public function authorize()
     {
-        return true;  // we have no users yet
+        return true;  // authorization is enforced in UsersController
     }
 
     /**
@@ -23,8 +23,11 @@ class ProfileRequest extends Request
      */
     public function rules()
     {
+        $userId = optional($this->route('user'))->id;
+
         return [
-            //'name' => 'required|min:3',
+            'name' => 'required|string|min:3|max:255',
+            'email' => 'required|string|email|max:255|unique:users,email,'.($userId ?? 'NULL').',id',
         ];
     }
 }

--- a/resources/views/users/form-tw.blade.php
+++ b/resources/views/users/form-tw.blade.php
@@ -1,3 +1,32 @@
+{{-- Name --}}
+<x-ui.form-group
+    name="name"
+    label="Name"
+    :error="$errors->first('name')"
+    helpText="The user's display name">
+    <x-ui.input
+        type="text"
+        name="name"
+        id="name"
+        :value="old('name', $user->name ?? '')"
+        placeholder="Enter name"
+        :hasError="$errors->has('name')" />
+</x-ui.form-group>
+
+{{-- Email --}}
+<x-ui.form-group
+    name="email"
+    label="Email"
+    :error="$errors->first('email')">
+    <x-ui.input
+        type="email"
+        name="email"
+        id="email"
+        :value="old('email', $user->email ?? '')"
+        placeholder="Enter email address"
+        :hasError="$errors->has('email')" />
+</x-ui.form-group>
+
 {{-- First Name --}}
 <x-ui.form-group
     name="first_name"

--- a/tests/Feature/UserEditUpdateTest.php
+++ b/tests/Feature/UserEditUpdateTest.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Group;
+use App\Models\User;
+use App\Models\UserStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserEditUpdateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private function makeAdmin(): User
+    {
+        $admin = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $admin->assignGroup('admin');
+
+        return $admin->fresh();
+    }
+
+    /** @test */
+    public function edit_form_shows_populated_name_and_email_fields(): void
+    {
+        $this->withExceptionHandling();
+
+        $admin = $this->makeAdmin();
+        $target = User::factory()->create([
+            'name' => 'Target Person',
+            'email' => 'target@example.com',
+            'user_status_id' => UserStatus::ACTIVE,
+        ]);
+
+        $response = $this->actingAs($admin)->get(route('users.edit', $target->id));
+        $response->assertStatus(200);
+
+        $html = $response->getContent();
+        $this->assertMatchesRegularExpression(
+            '/<input[^>]*name="name"[^>]*value="Target Person"/',
+            $html
+        );
+        $this->assertMatchesRegularExpression(
+            '/<input[^>]*name="email"[^>]*value="target@example\.com"/',
+            $html
+        );
+    }
+
+    /** @test */
+    public function admin_can_update_another_users_name_and_email(): void
+    {
+        $this->withExceptionHandling();
+
+        $admin = $this->makeAdmin();
+        $target = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        $response = $this->actingAs($admin)->patch(route('users.update', $target->id), [
+            'name' => 'Renamed Person',
+            'email' => 'renamed@example.com',
+        ]);
+
+        $response->assertSessionHasNoErrors();
+        $target->refresh();
+        $this->assertSame('Renamed Person', $target->name);
+        $this->assertSame('renamed@example.com', $target->email);
+    }
+
+    /** @test */
+    public function update_rejects_missing_name_and_invalid_email(): void
+    {
+        $this->withExceptionHandling();
+
+        $admin = $this->makeAdmin();
+        $target = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $originalEmail = $target->email;
+
+        $response = $this->actingAs($admin)->patch(route('users.update', $target->id), [
+            'name' => '',
+            'email' => 'not-an-email',
+        ]);
+
+        $response->assertSessionHasErrors(['name', 'email']);
+        $this->assertSame($originalEmail, $target->fresh()->email);
+    }
+
+    /** @test */
+    public function update_rejects_email_already_used_by_another_user(): void
+    {
+        $this->withExceptionHandling();
+
+        $admin = $this->makeAdmin();
+        $other = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $target = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        $response = $this->actingAs($admin)->patch(route('users.update', $target->id), [
+            'name' => $target->name,
+            'email' => $other->email,
+        ]);
+
+        $response->assertSessionHasErrors(['email']);
+    }
+
+    /** @test */
+    public function user_can_update_own_profile_keeping_own_email(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        $response = $this->actingAs($user)->patch(route('users.update', $user->id), [
+            'name' => 'My New Name',
+            'email' => $user->email,
+        ]);
+
+        $response->assertSessionHasNoErrors();
+        $this->assertSame('My New Name', $user->fresh()->name);
+    }
+
+    /** @test */
+    public function regular_user_cannot_view_edit_form_for_another_user(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $target = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        $this->actingAs($user)
+            ->get(route('users.edit', $target->id))
+            ->assertStatus(403);
+    }
+
+    /** @test */
+    public function regular_user_cannot_update_another_user(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $target = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $originalName = $target->name;
+
+        $this->actingAs($user)
+            ->patch(route('users.update', $target->id), [
+                'name' => 'Hacked Name',
+                'email' => 'hacked@example.com',
+            ])
+            ->assertStatus(403);
+
+        $this->assertSame($originalName, $target->fresh()->name);
+    }
+
+    /** @test */
+    public function regular_user_cannot_delete_another_user(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $target = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        $this->actingAs($user)
+            ->delete(route('users.destroy', $target->id))
+            ->assertStatus(403);
+
+        $this->assertNotNull(User::find($target->id));
+    }
+
+    /** @test */
+    public function regular_user_cannot_grant_themselves_groups_or_change_status(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $adminGroup = Group::where('name', 'admin')->firstOrFail();
+
+        $response = $this->actingAs($user)->patch(route('users.update', $user->id), [
+            'name' => $user->name,
+            'email' => $user->email,
+            'user_status_id' => UserStatus::SUSPENDED,
+            'group_list' => [$adminGroup->id],
+        ]);
+
+        $response->assertSessionHasNoErrors();
+        $user->refresh();
+        $this->assertSame(UserStatus::ACTIVE, $user->user_status_id);
+        $this->assertFalse($user->hasGroup('admin'));
+    }
+
+    /** @test */
+    public function admin_can_still_change_status_and_groups(): void
+    {
+        $this->withExceptionHandling();
+
+        $admin = $this->makeAdmin();
+        $target = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $adminGroup = Group::where('name', 'admin')->firstOrFail();
+
+        $response = $this->actingAs($admin)->patch(route('users.update', $target->id), [
+            'name' => $target->name,
+            'email' => $target->email,
+            'user_status_id' => UserStatus::SUSPENDED,
+            'group_list' => [$adminGroup->id],
+        ]);
+
+        $response->assertSessionHasNoErrors();
+        $target->refresh();
+        $this->assertSame(UserStatus::SUSPENDED, $target->user_status_id);
+        $this->assertTrue($target->hasGroup('admin'));
+    }
+}


### PR DESCRIPTION
## Summary

**Edit form fix** (reported: "form is not being populated with the user's properties")

- The edit form carried only profile-table fields, so `users.name` / `users.email` never appeared, and legacy users with no `profiles` row rendered a fully blank form. Name and Email inputs are now at the top of the form, populated from the user row.
- `ProfileRequest` previously had **no validation rules at all**; it now validates name (required, 3–255) and email (required, valid, unique except the target user).

**Authorization fix** (found while making email editable)

- `edit()`, `update()`, and `destroy()` had no ownership check — any signed-in user could edit, update, or delete any account by URL.
- `update()` applied `user_status_id` and `group_list` unconditionally, so a regular user could POST themselves into the admin group (verified by a failing-first test).
- All three actions now require self-or-`grant_access`; status/group fields are stripped from non-admin submissions.

Pre-existing quirk left alone: the create form shares this partial and prefills from the globally-shared `$user` (the viewer); `store()` validates via `UserRequest` (unique email), so no harm — flagged for separate cleanup.

## Testing

- New `tests/Feature/UserEditUpdateTest.php` (10 tests, written TDD red-first): populated fields, validated updates (invalid/duplicate email, missing name), self-edit still works, 403s for non-owners on edit/update/destroy, privilege-escalation blocked, admin status/group management still works.
- Full PHPUnit suite green locally: 1073 tests, 0 failures. `composer phpstan` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)