### PR TITLE
Show future attending-event thumbnails on user cards for public profiles

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -133,7 +133,7 @@ class UsersController extends Controller
         $query = $listResultSet->getList();
 
         // get the users
-        $users = $query->with('status')->paginate($listResultSet->getLimit());
+        $users = $query->with($this->cardEagerLoads($request->user()))->paginate($listResultSet->getLimit());
 
         // saves the updated session
         $listParamSessionStore->save();
@@ -198,6 +198,7 @@ class UsersController extends Controller
 
         // get the users
         $users = $query
+            ->with($this->cardEagerLoads($request->user()))
             ->paginate($listResultSet->getLimit());
 
         // saves the updated session
@@ -954,6 +955,22 @@ class UsersController extends Controller
     {
         return [
             'userStatusOptions' => ['' => ''] + UserStatus::orderBy('name', 'ASC')->pluck('name', 'name')->all(),
+        ];
+    }
+
+    /**
+     * Eager loads needed to render users/card-tw without N+1 queries.
+     */
+    protected function cardEagerLoads(?User $viewer): array
+    {
+        return [
+            'status',
+            'profile',
+            'photos',
+            'groups',
+            'attendingEvents' => function ($q) use ($viewer) {
+                $q->future()->visible($viewer)->with('photos');
+            },
         ];
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -277,6 +277,15 @@ class User extends Authenticatable implements AuthorizableContract, CanResetPass
     }
 
     /**
+     * Events the user has responded to as attending.
+     */
+    public function attendingEvents(): BelongsToMany
+    {
+        return $this->belongsToMany(Event::class, 'event_responses')
+            ->wherePivot('response_type_id', 1);
+    }
+
+    /**
      * Return the count of logins the user has made.
      */
     public function getLoginCountAttribute(): int

--- a/resources/views/users/attending-events-tw.blade.php
+++ b/resources/views/users/attending-events-tw.blade.php
@@ -1,0 +1,38 @@
+{{-- Future events this user is attending: one non-wrapping row of small square
+     thumbnails. Renders nothing unless the profile is public and the
+     constrained relation was eager-loaded by the controller. --}}
+@php
+    $showAttending = $user->relationLoaded('attendingEvents')
+        && $user->profile
+        && $user->profile->setting_public_profile == 1
+        && $user->attendingEvents->isNotEmpty();
+@endphp
+@if ($showAttending)
+@php
+    $attendingTotal = $user->attendingEvents->count();
+    $attendingShown = $user->attendingEvents->take(4);
+@endphp
+<div class="flex flex-nowrap items-center justify-center gap-1.5 mb-3" data-attending-events>
+    @foreach ($attendingShown as $attendingEvent)
+    <a href="{{ route('events.show', ['event' => $attendingEvent->slug]) }}"
+        title="{{ $attendingEvent->name }}"
+        class="block w-12 h-12 shrink-0 rounded-md overflow-hidden border border-border hover:border-primary transition-colors">
+        @if ($attendingPhoto = $attendingEvent->getPrimaryPhoto())
+        <img src="{{ Storage::disk('external')->url($attendingPhoto->getStorageThumbnail()) }}"
+            alt="{{ $attendingEvent->name }}"
+            class="w-full h-full object-cover">
+        @else
+        <img src="/images/event-placeholder.png"
+            alt="{{ $attendingEvent->name }}"
+            class="w-full h-full object-cover opacity-50">
+        @endif
+    </a>
+    @endforeach
+    @if ($attendingTotal > 4)
+    <span class="w-12 h-12 shrink-0 rounded-md bg-card border border-border flex items-center justify-center text-xs text-muted-foreground"
+        title="{{ $attendingTotal - 4 }} more upcoming events">
+        +{{ $attendingTotal - 4 }}
+    </span>
+    @endif
+</div>
+@endif

--- a/resources/views/users/card-tw.blade.php
+++ b/resources/views/users/card-tw.blade.php
@@ -54,6 +54,9 @@
             @endif
         </div>
 
+        <!-- Attending Future Events -->
+        @include('users.attending-events-tw', ['user' => $user])
+
         <!-- User Groups/Roles -->
         @unless ($user->groups->isEmpty())
         <div class="flex flex-wrap gap-1 justify-center">

--- a/tests/Feature/UserAttendingEventsCardTest.php
+++ b/tests/Feature/UserAttendingEventsCardTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\EventResponse;
+use App\Models\Profile;
+use App\Models\User;
+use App\Models\UserStatus;
+use App\Models\Visibility;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserAttendingEventsCardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private function makeUser(array $profileAttributes = []): User
+    {
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        Profile::factory()->create(array_merge(['user_id' => $user->id], $profileAttributes));
+
+        return $user;
+    }
+
+    private function attendFutureEvent(User $user, int $daysAhead = 1, array $overrides = []): Event
+    {
+        $event = Event::factory()->create(array_merge([
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => Carbon::now()->addDays($daysAhead),
+            'end_at' => Carbon::now()->addDays($daysAhead)->addHour(),
+        ], $overrides));
+
+        EventResponse::create([
+            'event_id' => $event->id,
+            'user_id' => $user->id,
+            'response_type_id' => 1,
+        ]);
+
+        return $event;
+    }
+
+    private function extractCard(string $html, int $userId): string
+    {
+        $matched = preg_match(
+            '/<article[^>]*id="user-card-'.$userId.'".*?<\/article>/s',
+            $html,
+            $m
+        );
+        $this->assertSame(1, $matched, "Card for user {$userId} not found on index");
+
+        return $m[0];
+    }
+
+    /** @test */
+    public function public_profile_shows_attending_event_thumbnails(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = $this->makeUser();
+        $event = $this->attendFutureEvent($user);
+
+        $response = $this->actingAs($user)->get('/users?limit=1000');
+        $response->assertStatus(200);
+
+        $card = $this->extractCard($response->getContent(), $user->id);
+        $this->assertStringContainsString('data-attending-events', $card);
+        $this->assertStringContainsString(route('events.show', ['event' => $event->slug]), $card);
+        $this->assertStringContainsString('title="'.e($event->name).'"', $card);
+    }
+
+    /** @test */
+    public function row_caps_at_four_soonest_events_with_overflow_chip(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = $this->makeUser();
+        $events = [];
+        foreach (range(1, 6) as $daysAhead) {
+            $events[$daysAhead] = $this->attendFutureEvent($user, $daysAhead);
+        }
+
+        $response = $this->actingAs($user)->get('/users?limit=1000');
+        $response->assertStatus(200);
+
+        $card = $this->extractCard($response->getContent(), $user->id);
+        foreach (range(1, 4) as $daysAhead) {
+            $this->assertStringContainsString($events[$daysAhead]->slug, $card);
+        }
+        foreach (range(5, 6) as $daysAhead) {
+            $this->assertStringNotContainsString($events[$daysAhead]->slug, $card);
+        }
+        $this->assertStringContainsString('+2', $card);
+    }
+
+    /** @test */
+    public function no_future_events_renders_no_row(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = $this->makeUser();
+        $this->attendFutureEvent($user, 1, [
+            'start_at' => Carbon::now()->subDays(3),
+            'end_at' => Carbon::now()->subDays(3)->addHour(),
+        ]);
+
+        $response = $this->actingAs($user)->get('/users?limit=1000');
+        $response->assertStatus(200);
+
+        $card = $this->extractCard($response->getContent(), $user->id);
+        $this->assertStringNotContainsString('data-attending-events', $card);
+    }
+
+    /** @test */
+    public function private_profile_hides_row(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = $this->makeUser(['setting_public_profile' => 0]);
+        $this->attendFutureEvent($user);
+
+        $viewer = $this->makeUser();
+        $response = $this->actingAs($viewer)->get('/users?limit=1000');
+        $response->assertStatus(200);
+
+        $card = $this->extractCard($response->getContent(), $user->id);
+        $this->assertStringNotContainsString('data-attending-events', $card);
+    }
+
+    /** @test */
+    public function user_without_profile_row_shows_no_row(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $this->attendFutureEvent($user);
+
+        $viewer = $this->makeUser();
+        $response = $this->actingAs($viewer)->get('/users?limit=1000');
+        $response->assertStatus(200);
+
+        $card = $this->extractCard($response->getContent(), $user->id);
+        $this->assertStringNotContainsString('data-attending-events', $card);
+    }
+
+    /** @test */
+    public function private_events_of_others_are_not_shown(): void
+    {
+        $this->withExceptionHandling();
+
+        $creator = $this->makeUser();
+        $user = $this->makeUser();
+        $this->attendFutureEvent($user, 1, [
+            'visibility_id' => Visibility::VISIBILITY_PRIVATE,
+            'created_by' => $creator->id,
+        ]);
+
+        $viewer = $this->makeUser();
+        $response = $this->actingAs($viewer)->get('/users?limit=1000');
+        $response->assertStatus(200);
+
+        $card = $this->extractCard($response->getContent(), $user->id);
+        $this->assertStringNotContainsString('data-attending-events', $card);
+    }
+
+    /** @test */
+    public function filtered_index_keeps_the_row(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = $this->makeUser();
+        $user->update(['name' => 'Filterable Person']);
+        $event = $this->attendFutureEvent($user);
+
+        $response = $this->actingAs($user)->post(route('users.filter'), [
+            'filters' => ['name' => 'Filterable'],
+        ]);
+        $response->assertStatus(200);
+
+        $card = $this->extractCard($response->getContent(), $user->id);
+        $this->assertStringContainsString('data-attending-events', $card);
+        $this->assertStringContainsString($event->slug, $card);
+    }
+}


### PR DESCRIPTION
Adds User::attendingEvents() BelongsToMany (event_responses pivot, response_type_id 1), eager-loaded with future()+visible(viewer)+photos in both index() and filter(). New attending-events-tw partial renders the 4 soonest events as linked 48px thumbnails with a +N overflow chip, gated strictly on profiles.setting_public_profile and fail-closed when the relation isn't eager-loaded. Also eager-loads profile/photos/groups, fixing three pre-existing card N+1s.