### PR TITLE
Gate tag edit/delete: creator-or-admin edit, admin-only delete

### DIFF
--- a/app/Http/Controllers/TagsController.php
+++ b/app/Http/Controllers/TagsController.php
@@ -84,6 +84,8 @@ class TagsController extends Controller
      */
     public function destroy(Tag $tag): RedirectResponse
     {
+        $this->authorize('delete', $tag);
+
         $tag->delete();
 
         return redirect('tags');
@@ -310,7 +312,7 @@ class TagsController extends Controller
      */
     public function edit(Tag $tag): View
     {
-        $this->middleware('auth');
+        $this->authorize('update', $tag);
 
         $tagTypes = TagType::orderBy('name', 'ASC')->pluck('name', 'id')->all();
 
@@ -639,6 +641,8 @@ class TagsController extends Controller
      */
     public function update(Tag $tag, TagRequest $request): RedirectResponse
     {
+        $this->authorize('update', $tag);
+
         $msg = '';
 
         $input = $request->all();

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use App\Filters\TagFilters;
 
@@ -33,6 +34,16 @@ class Tag extends Eloquent
     protected $fillable = [
         'name', 'tag_type_id', 'slug', 'description',
     ];
+
+    protected static function booted(): void
+    {
+        // stamp the creator; deliberately not in $fillable so it can't be mass-assigned
+        static::creating(function (Tag $tag) {
+            if (null === $tag->created_by && Auth::check()) {
+                $tag->created_by = Auth::id();
+            }
+        });
+    }
 
     public function getRouteKeyName()
     {

--- a/app/Policies/TagPolicy.php
+++ b/app/Policies/TagPolicy.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Tag;
+use App\Models\User;
+
+class TagPolicy
+{
+    // the `admin` group is granted everything by Gate::before in AuthServiceProvider
+
+    public function update(User $user, Tag $tag): bool
+    {
+        return $user->hasGroup('super_admin')
+            || ($tag->created_by && $user->id === $tag->created_by);
+    }
+
+    public function delete(User $user, Tag $tag): bool
+    {
+        return $user->hasGroup('super_admin');
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -4,8 +4,10 @@ namespace App\Providers;
 
 use App\Models\Permission;
 use App\Models\Post;
+use App\Models\Tag;
 use App\Models\Thread;
 use App\Policies\PostPolicy;
+use App\Policies\TagPolicy;
 use App\Policies\ThreadPolicy;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
@@ -29,6 +31,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected $policies = [
         Post::class => PostPolicy::class,
+        Tag::class => TagPolicy::class,
         Thread::class => ThreadPolicy::class,
     ];
 

--- a/database/migrations/2026_07_30_000000_add_created_by_to_tags_table.php
+++ b/database/migrations/2026_07_30_000000_add_created_by_to_tags_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tags', function (Blueprint $table) {
+            $table->unsignedInteger('created_by')->nullable()->after('tag_type_id')->index();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tags', function (Blueprint $table) {
+            $table->dropIndex(['created_by']);
+            $table->dropColumn('created_by');
+        });
+    }
+};

--- a/docs/superpowers/specs/2026-07-30-tag-admin-actions-design.md
+++ b/docs/superpowers/specs/2026-07-30-tag-admin-actions-design.md
@@ -1,90 +1,94 @@
 # Tag show page: admin action menu + guarded edit/delete
 
 **Date:** 2026-07-30
-**Status:** Approved
+**Status:** Implemented (revised during implementation — see Revisions)
 
 ## Problem
 
 On the tag show page (`resources/views/tags/show-tw.blade.php`), the Edit/Delete
-action menu is only rendered when the signed-in user is the tag's creator
-(`$user->id === $tagObject->created_by`). Admins cannot see or use the menu on
-tags they didn't create.
+action menu was gated on `$user->id === $tagObject->created_by`. During
+implementation we discovered the `tags` table has **no `created_by` column** —
+the check was always false, so the menu never rendered for anyone.
 
-Worse, the server side does not enforce anything:
+The server side enforced nothing:
 
-- `TagsController::destroy` has no auth or ownership check — any request to
-  `DELETE /tags/{tag}` deletes the tag, even from a guest.
-- `edit` / `update` only require a verified login (`verified` middleware); any
-  verified user can edit any tag.
+- `TagsController::destroy` had no auth or ownership check — any request to
+  `DELETE /tags/{tag}` deleted the tag, even from a guest.
+- `edit` / `update` only required a verified login; any verified user could
+  edit any tag.
+
+The menu's edit/delete URLs were also built from `$tagObject->id`, but tag
+routes bind by slug (`getRouteKeyName`), so they would have 404'd had the menu
+ever rendered.
 
 ## Goal
 
+- Track tag ownership going forward (`created_by`).
 - Show the tag action menu to the creator **and** to admins (`admin` or
   `super_admin` group).
-- Allow admins to delete (and edit) tags they didn't create.
-- Enforce the same rule server-side: `destroy`, `edit`, and `update` require
-  creator-or-admin.
+- Edit: creator or admin. **Delete: admin only** (creators may not delete
+  their own tags).
+- Enforce the same rules server-side on `destroy`, `edit`, and `update`.
 
 ## Design
 
+### Schema
+
+Migration `2026_07_30_000000_add_created_by_to_tags_table` adds a nullable,
+indexed `created_by` (unsigned int, matching `users.id`) to `tags`. Existing
+tags keep `null` — they are admin-manageable only.
+
+`Tag::booted()` registers a `creating` hook that stamps
+`created_by = Auth::id()` when a user is signed in. This covers the ~15 inline
+`new Tag()` creation sites across web/API controllers without touching them.
+`created_by` is deliberately **not** in `$fillable`, so it cannot be spoofed
+via mass assignment.
+
 ### TagPolicy (single source of truth)
 
-New `app/Policies/TagPolicy.php`:
+`app/Policies/TagPolicy.php`, registered in `AuthServiceProvider::$policies`:
 
-- `update(User $user, Tag $tag): bool` — `$user->id === $tag->created_by || $user->hasGroup('super_admin')`
-- `delete(User $user, Tag $tag): bool` — same rule.
+- `update(User $user, Tag $tag)` — `$user->hasGroup('super_admin') || ($tag->created_by && $user->id === $tag->created_by)`
+- `delete(User $user, Tag $tag)` — `$user->hasGroup('super_admin')`
 
-The `admin` group is granted everything by the existing `Gate::before` in
-`AuthServiceProvider`, so the policy only needs to handle owner + `super_admin`.
-
-Register the policy in `AuthServiceProvider::$policies` alongside the existing
-`PostPolicy` and `ThreadPolicy` entries.
+The `admin` group passes both via the existing `Gate::before`.
 
 ### Controller
 
-In `TagsController`:
+`TagsController`:
 
-- `destroy`: `$this->authorize('delete', $tag);` before deleting.
-- `edit` and `update`: `$this->authorize('update', $tag);` at the top.
+- `destroy`: `$this->authorize('delete', $tag)`
+- `edit` / `update`: `$this->authorize('update', $tag)`
 
-Unauthenticated or unauthorized requests get 403 via the framework.
+Unauthenticated or unauthorized requests get 403.
 
 ### View
 
-`resources/views/tags/show-tw.blade.php` line ~67: replace
-
-```blade
-@if ($tagObject->created_by && $user->id === $tagObject->created_by)
-```
-
-with
-
-```blade
-@can('update', $tagObject)
-```
-
-The follow/unfollow star and the rest of the page are unchanged.
-
-### Edge cases
-
-- Tags with `created_by = null` (legacy data): only admins can manage them.
-- Guests: never see the menu (outer `$signedIn` check unchanged); direct
-  requests are denied by `authorize`.
+`show-tw.blade.php`: menu wrapped in `@can('update', $tagObject)`; the delete
+form additionally wrapped in `@can('delete', $tagObject)`. Route calls pass the
+model (slug binding) instead of `->id`. Follow star unchanged.
 
 ## Testing
 
-Feature tests (follow suite conventions: `$seed = true`,
-`withExceptionHandling()`):
+`tests/Feature/TagsPermissionsTest.php` (11 tests, green):
 
-1. Admin can delete a tag they did not create (tag gone, redirect to `/tags`).
-2. Creator can delete their own tag.
-3. Non-owner regular user gets 403 on `DELETE /tags/{tag}` and `GET /tags/{tag}/edit`.
-4. Guest `DELETE /tags/{tag}` is denied (403/redirect; tag still exists).
-5. Show page: action menu markup visible to admin, absent for an unrelated
-   signed-in user.
+1. admin / super_admin can delete a tag they did not create
+2. creator **cannot** delete their own tag (403)
+3. non-owner cannot delete (403); guest cannot delete (403); tag persists
+4. creator and admin can access edit page; non-owner gets 403
+5. show page: admin sees Edit + Delete; creator sees Edit but not Delete;
+   unrelated user sees neither
+
+## Revisions
+
+- **created_by column added**: original design assumed the column existed; it
+  did not, so a migration + creating-hook were added (user-approved).
+- **Delete narrowed to admin-only**: original design allowed creators to
+  delete their own tags; user revised mid-implementation to admin-only.
 
 ## Out of scope
 
-- API tag endpoints (`app/Http/Controllers/Api`) — separate surface, not
-  touched here.
+- API tag endpoints (`app/Http/Controllers/Api`) — already admin-gated
+  separately.
 - `store`/`create` authorization (unchanged: any verified user may create tags).
+- Backfilling `created_by` for existing tags.

--- a/docs/superpowers/specs/2026-07-30-tag-admin-actions-design.md
+++ b/docs/superpowers/specs/2026-07-30-tag-admin-actions-design.md
@@ -1,0 +1,90 @@
+# Tag show page: admin action menu + guarded edit/delete
+
+**Date:** 2026-07-30
+**Status:** Approved
+
+## Problem
+
+On the tag show page (`resources/views/tags/show-tw.blade.php`), the Edit/Delete
+action menu is only rendered when the signed-in user is the tag's creator
+(`$user->id === $tagObject->created_by`). Admins cannot see or use the menu on
+tags they didn't create.
+
+Worse, the server side does not enforce anything:
+
+- `TagsController::destroy` has no auth or ownership check — any request to
+  `DELETE /tags/{tag}` deletes the tag, even from a guest.
+- `edit` / `update` only require a verified login (`verified` middleware); any
+  verified user can edit any tag.
+
+## Goal
+
+- Show the tag action menu to the creator **and** to admins (`admin` or
+  `super_admin` group).
+- Allow admins to delete (and edit) tags they didn't create.
+- Enforce the same rule server-side: `destroy`, `edit`, and `update` require
+  creator-or-admin.
+
+## Design
+
+### TagPolicy (single source of truth)
+
+New `app/Policies/TagPolicy.php`:
+
+- `update(User $user, Tag $tag): bool` — `$user->id === $tag->created_by || $user->hasGroup('super_admin')`
+- `delete(User $user, Tag $tag): bool` — same rule.
+
+The `admin` group is granted everything by the existing `Gate::before` in
+`AuthServiceProvider`, so the policy only needs to handle owner + `super_admin`.
+
+Register the policy in `AuthServiceProvider::$policies` alongside the existing
+`PostPolicy` and `ThreadPolicy` entries.
+
+### Controller
+
+In `TagsController`:
+
+- `destroy`: `$this->authorize('delete', $tag);` before deleting.
+- `edit` and `update`: `$this->authorize('update', $tag);` at the top.
+
+Unauthenticated or unauthorized requests get 403 via the framework.
+
+### View
+
+`resources/views/tags/show-tw.blade.php` line ~67: replace
+
+```blade
+@if ($tagObject->created_by && $user->id === $tagObject->created_by)
+```
+
+with
+
+```blade
+@can('update', $tagObject)
+```
+
+The follow/unfollow star and the rest of the page are unchanged.
+
+### Edge cases
+
+- Tags with `created_by = null` (legacy data): only admins can manage them.
+- Guests: never see the menu (outer `$signedIn` check unchanged); direct
+  requests are denied by `authorize`.
+
+## Testing
+
+Feature tests (follow suite conventions: `$seed = true`,
+`withExceptionHandling()`):
+
+1. Admin can delete a tag they did not create (tag gone, redirect to `/tags`).
+2. Creator can delete their own tag.
+3. Non-owner regular user gets 403 on `DELETE /tags/{tag}` and `GET /tags/{tag}/edit`.
+4. Guest `DELETE /tags/{tag}` is denied (403/redirect; tag still exists).
+5. Show page: action menu markup visible to admin, absent for an unrelated
+   signed-in user.
+
+## Out of scope
+
+- API tag endpoints (`app/Http/Controllers/Api`) — separate surface, not
+  touched here.
+- `store`/`create` authorization (unchanged: any verified user may create tags).

--- a/resources/views/tags/show-tw.blade.php
+++ b/resources/views/tags/show-tw.blade.php
@@ -63,19 +63,20 @@ Tags
 					<i class="bi {{ $isFollowing ? 'bi-star-fill text-yellow-500' : 'bi-star text-muted-foreground' }} text-xl"></i>
 				</a>
 
-				<!-- Edit/Delete Menu (if owner) -->
-				@if ($tagObject->created_by && $user->id === $tagObject->created_by)
+				<!-- Edit/Delete Menu (creator or admin; delete is admin-only) -->
+				@can('update', $tagObject)
 				<div class="relative group">
 					<button class="p-2 rounded-md hover:bg-accent transition-colors text-muted-foreground hover:text-foreground">
 						<i class="bi bi-three-dots"></i>
 					</button>
 					<div class="absolute right-0 mt-1 w-48 bg-card border border-border rounded-lg shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-10">
 						<div class="py-1">
-							<a href="{{ route('tags.edit', $tagObject->id) }}" class="flex items-center gap-2 px-4 py-2 text-sm text-foreground hover:bg-accent transition-colors">
+							<a href="{{ route('tags.edit', $tagObject) }}" class="flex items-center gap-2 px-4 py-2 text-sm text-foreground hover:bg-accent transition-colors">
 								<i class="bi bi-pencil"></i>
 								Edit Tag
 							</a>
-							<form method="POST" action="{{ route('tags.destroy', $tagObject->id) }}" class="inline-block w-full" data-confirm="Are you sure you want to delete this tag?">
+							@can('delete', $tagObject)
+							<form method="POST" action="{{ route('tags.destroy', $tagObject) }}" class="inline-block w-full" data-confirm="Are you sure you want to delete this tag?">
 								@csrf
 								@method('DELETE')
 								<button type="submit" class="flex items-center gap-2 px-4 py-2 text-sm text-red-600 hover:bg-red-50 dark:hover:bg-red-950 transition-colors w-full text-left">
@@ -83,10 +84,11 @@ Tags
 									Delete Tag
 								</button>
 							</form>
+							@endcan
 						</div>
 					</div>
 				</div>
-				@endif
+				@endcan
 			</div>
 			@endif
 		</div>

--- a/tests/Feature/TagsPermissionsTest.php
+++ b/tests/Feature/TagsPermissionsTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Tag;
+use App\Models\User;
+use App\Models\UserStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TagsPermissionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    protected function makeUser(?string $group = null): User
+    {
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        if ($group) {
+            $user->assignGroup($group);
+        }
+
+        return $user;
+    }
+
+    protected function makeTagOwnedBy(User $owner): Tag
+    {
+        $tag = Tag::factory()->create();
+        $tag->created_by = $owner->id;
+        $tag->save();
+
+        return $tag;
+    }
+
+    /** @test */
+    public function admin_can_delete_a_tag_they_did_not_create()
+    {
+        $owner = $this->makeUser();
+        $tag = $this->makeTagOwnedBy($owner);
+        $admin = $this->makeUser('admin');
+
+        $response = $this->actingAs($admin)->delete("/tags/{$tag->slug}");
+
+        $response->assertRedirect('/tags');
+        $this->assertDatabaseMissing('tags', ['id' => $tag->id]);
+    }
+
+    /** @test */
+    public function super_admin_can_delete_a_tag_they_did_not_create()
+    {
+        $owner = $this->makeUser();
+        $tag = $this->makeTagOwnedBy($owner);
+        $superAdmin = $this->makeUser('super_admin');
+
+        $response = $this->actingAs($superAdmin)->delete("/tags/{$tag->slug}");
+
+        $response->assertRedirect('/tags');
+        $this->assertDatabaseMissing('tags', ['id' => $tag->id]);
+    }
+
+    /** @test */
+    public function creator_cannot_delete_their_own_tag()
+    {
+        $owner = $this->makeUser();
+        $tag = $this->makeTagOwnedBy($owner);
+
+        $response = $this->actingAs($owner)->delete("/tags/{$tag->slug}");
+
+        $response->assertForbidden();
+        $this->assertDatabaseHas('tags', ['id' => $tag->id]);
+    }
+
+    /** @test */
+    public function non_owner_cannot_delete_a_tag()
+    {
+        $owner = $this->makeUser();
+        $tag = $this->makeTagOwnedBy($owner);
+        $other = $this->makeUser();
+
+        $response = $this->actingAs($other)->delete("/tags/{$tag->slug}");
+
+        $response->assertForbidden();
+        $this->assertDatabaseHas('tags', ['id' => $tag->id]);
+    }
+
+    /** @test */
+    public function guest_cannot_delete_a_tag()
+    {
+        $owner = $this->makeUser();
+        $tag = $this->makeTagOwnedBy($owner);
+
+        $response = $this->delete("/tags/{$tag->slug}");
+
+        $response->assertForbidden();
+        $this->assertDatabaseHas('tags', ['id' => $tag->id]);
+    }
+
+    /** @test */
+    public function non_owner_cannot_access_edit_page()
+    {
+        $owner = $this->makeUser();
+        $tag = $this->makeTagOwnedBy($owner);
+        $other = $this->makeUser();
+
+        $response = $this->actingAs($other)->get("/tags/{$tag->slug}/edit");
+
+        $response->assertForbidden();
+    }
+
+    /** @test */
+    public function creator_can_access_edit_page_for_their_own_tag()
+    {
+        $owner = $this->makeUser();
+        $tag = $this->makeTagOwnedBy($owner);
+
+        $response = $this->actingAs($owner)->get("/tags/{$tag->slug}/edit");
+
+        $response->assertOk();
+    }
+
+    /** @test */
+    public function admin_can_access_edit_page_for_a_tag_they_did_not_create()
+    {
+        $owner = $this->makeUser();
+        $tag = $this->makeTagOwnedBy($owner);
+        $admin = $this->makeUser('admin');
+
+        $response = $this->actingAs($admin)->get("/tags/{$tag->slug}/edit");
+
+        $response->assertOk();
+    }
+
+    /** @test */
+    public function admin_sees_action_menu_on_tag_show_page()
+    {
+        $owner = $this->makeUser();
+        $tag = $this->makeTagOwnedBy($owner);
+        $admin = $this->makeUser('admin');
+
+        $response = $this->actingAs($admin)->get("/tags/{$tag->slug}");
+
+        $response->assertOk();
+        $response->assertSee('Delete Tag');
+    }
+
+    /** @test */
+    public function creator_sees_edit_but_not_delete_on_tag_show_page()
+    {
+        $owner = $this->makeUser();
+        $tag = $this->makeTagOwnedBy($owner);
+
+        $response = $this->actingAs($owner)->get("/tags/{$tag->slug}");
+
+        $response->assertOk();
+        $response->assertSee('Edit Tag');
+        $response->assertDontSee('Delete Tag');
+    }
+
+    /** @test */
+    public function unrelated_user_does_not_see_action_menu_on_tag_show_page()
+    {
+        $owner = $this->makeUser();
+        $tag = $this->makeTagOwnedBy($owner);
+        $other = $this->makeUser();
+
+        $response = $this->actingAs($other)->get("/tags/{$tag->slug}");
+
+        $response->assertOk();
+        $response->assertDontSee('Edit Tag');
+        $response->assertDontSee('Delete Tag');
+    }
+}


### PR DESCRIPTION
## Summary
- Tag show page action menu now displays for admins as well as the tag creator; the Delete item is admin-only
- Adds server-side authorization via a new `TagPolicy`: `update` = creator or `super_admin`, `delete` = `super_admin` only (the `admin` group passes both via the existing `Gate::before`)
- `TagsController::destroy` previously had **no auth check at all** (a guest could delete any tag via a crafted DELETE request); `edit`/`update` had no ownership check. All three now call `authorize()`

## Notable discoveries
- The `tags` table never had a `created_by` column — the old owner-only menu check was always false, so the menu never rendered for anyone. New migration adds a nullable, indexed `created_by`, stamped automatically by a `Tag::creating` hook (covers all ~15 inline tag-creation sites; intentionally not in `$fillable` so it can't be mass-assigned). Existing tags keep `null` → admin-manageable only
- The menu's edit/delete URLs were built from `->id` but tag routes bind by slug — they would have 404'd. Now pass the model

## Testing
- New `tests/Feature/TagsPermissionsTest.php`: 11 tests covering admin/super_admin/creator/non-owner/guest paths for delete, edit access, and menu visibility — all green
- Existing tag suites (ApiTagsDelete/Store/CrudExtra/RelatedTags, TagMorphAlias) still green (16 tests)
- PHPStan (Larastan level 3) clean

Design spec: `docs/superpowers/specs/2026-07-30-tag-admin-actions-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)