### PR TITLE
Fix: migration fails with duplicate column 'created_by' on tags [EVENTREPO-XA]

### DIFF
--- a/database/migrations/2026_07_30_000000_add_created_by_to_tags_table.php
+++ b/database/migrations/2026_07_30_000000_add_created_by_to_tags_table.php
@@ -8,6 +8,10 @@ return new class extends Migration
 {
     public function up(): void
     {
+        if (Schema::hasColumn('tags', 'created_by')) {
+            return;
+        }
+
         Schema::table('tags', function (Blueprint $table) {
             $table->unsignedInteger('created_by')->nullable()->after('tag_type_id')->index();
         });
@@ -15,6 +19,10 @@ return new class extends Migration
 
     public function down(): void
     {
+        if (! Schema::hasColumn('tags', 'created_by')) {
+            return;
+        }
+
         Schema::table('tags', function (Blueprint $table) {
             $table->dropIndex(['created_by']);
             $table->dropColumn('created_by');


### PR DESCRIPTION
## Sentry issue

[EVENTREPO-XA](https://sentry.io/organizations/geoff-maddock/issues/7641815628/) — `Illuminate\Database\QueryException: SQLSTATE[42S21]: Column already exists: 1060 Duplicate column name 'created_by' (Connection: mysql, SQL: alter table `tags` add `created_by` int unsigned null after `tag_type_id`)`

- Culprit: `database/migrations/2026_07_30_000000_add_created_by_to_tags_table.php`
- First/last seen: 2026-07-30 (1 occurrence)
- User feedback: none

## Error

The migration added in #2032 (tag edit/delete gating) runs `ALTER TABLE tags ADD created_by ...`. On at least one environment `tags.created_by` already existed, so the `ALTER` threw a duplicate-column error. Because a failing migration aborts the **entire** `php artisan migrate` batch, this blocks the deploy — higher impact than the single occurrence count suggests.

## Root cause (hypothesis)

The squashed schema dump (`database/schema/mysql-schema.sql`) does **not** define `tags.created_by`, so the column isn't coming from the dump. The most likely source is a prior partially-applied or re-run migration attempt that added the column without the row being recorded in the `migrations` table — so the next `migrate` re-attempts the `ADD` and collides. I could not identify the exact origin of the pre-existing column from the repo alone, hence **draft**.

## Change

Make the migration idempotent by guarding both directions with `Schema::hasColumn('tags', 'created_by')`:

- `up()` returns early if the column already exists.
- `down()` returns early if it doesn't.

This is the minimal, schema-neutral fix: fresh installs still get the column; environments that already have it skip the `ADD` instead of aborting. The resulting schema is identical everywhere, so no already-migrated database is affected.

## Note on editing an existing migration

`CLAUDE.md` says "don't edit existing migrations — always add a new one." This is the deliberate exception: a *new* migration can't prevent the *existing* one from throwing during `migrate`, and because this migration failed it was never recorded as run — so the edited (guarded) version will simply be retried and succeed. The guard changes no successfully-migrated schema. Flagging it for reviewer awareness.

## Testing

`php -l` passes. The sandbox has no Composer vendor dir, so the full `composer tests` / PHPStan pipeline could not be run here — please let CI validate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdoNpsKpBFKiF5UGF2GU8H)_