### PR TITLE
Guard reset-route redirect param against 500s; make reset-user-attending POST-only

### DIFF
--- a/app/Http/Controllers/ActivityController.php
+++ b/app/Http/Controllers/ActivityController.php
@@ -432,7 +432,7 @@ class ActivityController extends Controller
         $listParamSessionStore->clearFilter();
         $listParamSessionStore->clearSort();
 
-        return redirect()->route($request->get('redirect') ?? 'activities.index');
+        return redirect()->route($this->resolveRedirectRoute($request, 'activities.index'));
     }
 
     protected function getGraphOptions(): array

--- a/app/Http/Controllers/BlogsController.php
+++ b/app/Http/Controllers/BlogsController.php
@@ -468,7 +468,7 @@ class BlogsController extends Controller
         $listParamSessionStore->clearFilter();
         $listParamSessionStore->clearSort();
 
-        return redirect()->route($request->get('redirect') ?? 'blogs.index');
+        return redirect()->route($this->resolveRedirectRoute($request, 'blogs.index'));
     }
 
     protected function unauthorized(Request $request): RedirectResponse | Response

--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -207,7 +207,7 @@ class CalendarController extends Controller
         // clear
         $listParamSessionStore->clearSort();
 
-        return redirect()->route($request->get('redirect') ?? 'events.index');
+        return redirect()->route($this->resolveRedirectRoute($request, 'events.index'));
     }
 
     /**
@@ -228,7 +228,7 @@ class CalendarController extends Controller
         $listParamSessionStore->clearFilter();
         $listParamSessionStore->clearSort();
 
-        return redirect()->route($request->get('redirect') ?? 'events.index');
+        return redirect()->route($this->resolveRedirectRoute($request, 'events.index'));
     }
 
     /**

--- a/app/Http/Controllers/CategoriesController.php
+++ b/app/Http/Controllers/CategoriesController.php
@@ -367,7 +367,7 @@ class CategoriesController extends Controller
         $listParamSessionStore->clearFilter();
         $listParamSessionStore->clearSort();
 
-        return redirect()->route($request->get('redirect') ?? 'categories.index');
+        return redirect()->route($this->resolveRedirectRoute($request, 'categories.index'));
     }
 
     protected function unauthorized(Request $request): RedirectResponse | Response

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -6,8 +6,10 @@ use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\View;
 use App\Models\User;
 
@@ -47,5 +49,17 @@ abstract class Controller extends BaseController
         }
 
         return null;
+    }
+
+    /**
+     * Resolve the `redirect` request param (a route name) used by the
+     * reset/rpp-reset actions, falling back to $default when it is missing
+     * or does not name a real route.
+     */
+    protected function resolveRedirectRoute(Request $request, string $default): string
+    {
+        $redirect = $request->get('redirect');
+
+        return is_string($redirect) && Route::has($redirect) ? $redirect : $default;
     }
 }

--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -1384,7 +1384,7 @@ class EventsController extends Controller
         // clear
         $listParamSessionStore->clearSort();
 
-        return redirect()->route($request->get('redirect') ?? 'events.index');
+        return redirect()->route($this->resolveRedirectRoute($request, 'events.index'));
     }
 
     /**
@@ -1405,7 +1405,7 @@ class EventsController extends Controller
         $listParamSessionStore->clearFilter();
         $listParamSessionStore->clearSort();
 
-        return redirect()->route($request->get('redirect') ?? 'events.index');
+        return redirect()->route($this->resolveRedirectRoute($request, 'events.index'));
     }
 
     /**

--- a/app/Http/Controllers/ForumsController.php
+++ b/app/Http/Controllers/ForumsController.php
@@ -468,7 +468,7 @@ class ForumsController extends Controller
         $listParamSessionStore->clearFilter();
         $listParamSessionStore->clearSort();
 
-        return redirect()->route($request->get('redirect') ?? 'forums.index');
+        return redirect()->route($this->resolveRedirectRoute($request, 'forums.index'));
     }
 
     /**

--- a/app/Http/Controllers/GroupsController.php
+++ b/app/Http/Controllers/GroupsController.php
@@ -203,7 +203,7 @@ class GroupsController extends Controller
         $listParamSessionStore->clearFilter();
         $listParamSessionStore->clearSort();
 
-        return redirect()->route($request->get('redirect') ?? 'groups.index');
+        return redirect()->route($this->resolveRedirectRoute($request, 'groups.index'));
     }
 
     /**

--- a/app/Http/Controllers/MenusController.php
+++ b/app/Http/Controllers/MenusController.php
@@ -204,7 +204,7 @@ class MenusController extends Controller
         $listParamSessionStore->clearFilter();
         $listParamSessionStore->clearSort();
 
-        return redirect()->route($request->get('redirect') ?? 'menus.index');
+        return redirect()->route($this->resolveRedirectRoute($request, 'menus.index'));
     }
 
     /**

--- a/app/Http/Controllers/PermissionsController.php
+++ b/app/Http/Controllers/PermissionsController.php
@@ -219,7 +219,7 @@ class PermissionsController extends Controller
         $listParamSessionStore->clearFilter();
         $listParamSessionStore->clearSort();
 
-        return redirect()->route($request->get('redirect') ?? 'permissions.index');
+        return redirect()->route($this->resolveRedirectRoute($request, 'permissions.index'));
     }
 
     /**

--- a/app/Http/Controllers/PhotosController.php
+++ b/app/Http/Controllers/PhotosController.php
@@ -446,7 +446,7 @@ class PhotosController extends Controller
         $listParamSessionStore->clearFilter();
         $listParamSessionStore->clearSort();
 
-        return redirect()->route($request->get('redirect') ?? 'photos.index');
+        return redirect()->route($this->resolveRedirectRoute($request, 'photos.index'));
     }
 
     /**

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -709,7 +709,7 @@ class PostsController extends Controller
         $listParamSessionStore->clearFilter();
         $listParamSessionStore->clearSort();
 
-        return redirect()->route($request->get('redirect') ?? 'posts.index');
+        return redirect()->route($this->resolveRedirectRoute($request, 'posts.index'));
     }
 
     protected function getFilterOptions(): array

--- a/app/Http/Controllers/ReviewsController.php
+++ b/app/Http/Controllers/ReviewsController.php
@@ -240,7 +240,7 @@ class ReviewsController extends Controller
         $listParamSessionStore->clearFilter();
         $listParamSessionStore->clearSort();
 
-        return redirect()->route($request->get('redirect') ?? 'reviews.index');
+        return redirect()->route($this->resolveRedirectRoute($request, 'reviews.index'));
     }
 
     /**

--- a/app/Http/Controllers/SeriesController.php
+++ b/app/Http/Controllers/SeriesController.php
@@ -198,7 +198,7 @@ class SeriesController extends Controller
         $listParamSessionStore->clearFilter();
         $listParamSessionStore->clearSort();
 
-        return redirect()->route($request->get('redirect') ?? 'series.index');
+        return redirect()->route($this->resolveRedirectRoute($request, 'series.index'));
     }
 
     /**

--- a/app/Http/Controllers/ThreadsController.php
+++ b/app/Http/Controllers/ThreadsController.php
@@ -325,7 +325,7 @@ class ThreadsController extends Controller
         $listParamSessionStore->clearFilter();
         $listParamSessionStore->clearSort();
 
-        return redirect()->route($request->get('redirect') ?? 'threads.index');
+        return redirect()->route($this->resolveRedirectRoute($request, 'threads.index'));
     }
 
     /**

--- a/routes/web.php
+++ b/routes/web.php
@@ -189,7 +189,7 @@ Route::post('purge', [\App\Http\Controllers\UsersController::class, 'purge'])->n
 Route::match(['get', 'post'], 'users/{id}/attending', [\App\Http\Controllers\EventsController::class, 'indexUserAttending'])->name('users.attending');
 Route::match(['get', 'post'], 'users/{id}/attending-ical', [\App\Http\Controllers\EventsController::class, 'indexUserAttendingIcal'])->name('users.attendingIcal');
 Route::match(['get', 'post'], 'users/{id}/interested-ical', [\App\Http\Controllers\EventsController::class, 'indexUserInterestedIcal'])->name('users.interestedIcal');
-Route::match(['get', 'post'], 'users/{id}/reset-user-attending', ['as' => 'users.resetUserAttending', 'uses' => '\App\Http\Controllers\EventsController@resetUserAttending']);
+Route::post('users/{id}/reset-user-attending', ['as' => 'users.resetUserAttending', 'uses' => '\App\Http\Controllers\EventsController@resetUserAttending']);
 Route::get('users/{id}/rpp-reset-user-attending', ['as' => 'users.rppResetUserAttending', 'uses' => '\App\Http\Controllers\EventsController@rppResetUserAttending']);
 
 Route::match(['get', 'post'], 'users/filter', ['as' => 'users.filter', 'uses' => '\App\Http\Controllers\UsersController@filter']);

--- a/tests/Feature/Web/ResetRedirectGuardTest.php
+++ b/tests/Feature/Web/ResetRedirectGuardTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature\Web;
+
+use App\Models\User;
+use App\Models\UserStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ResetRedirectGuardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    public function test_events_reset_with_invalid_redirect_falls_back_to_index(): void
+    {
+        $this->withExceptionHandling();
+
+        $this->get('/events/reset?redirect=nonexistent.route')
+            ->assertRedirect(route('events.index'));
+    }
+
+    public function test_events_reset_with_valid_redirect_is_honored(): void
+    {
+        $this->get('/events/reset?redirect=events.grid')
+            ->assertRedirect(route('events.grid'));
+    }
+
+    public function test_events_rpp_reset_with_invalid_redirect_falls_back_to_index(): void
+    {
+        $this->withExceptionHandling();
+
+        $this->get('/events/rpp-reset?redirect=nonexistent.route')
+            ->assertRedirect(route('events.index'));
+    }
+
+    public function test_blogs_reset_with_invalid_redirect_falls_back_to_index(): void
+    {
+        $this->withExceptionHandling();
+
+        $this->get('/blogs/reset?redirect=nonexistent.route')
+            ->assertRedirect(route('blogs.index'));
+    }
+
+    public function test_reset_user_attending_no_longer_accepts_get(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        $this->actingAs($user)
+            ->get('/users/'.$user->id.'/reset-user-attending')
+            ->assertStatus(405);
+    }
+
+    public function test_reset_user_attending_accepts_post(): void
+    {
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        $this->actingAs($user)
+            ->post('/users/'.$user->id.'/reset-user-attending')
+            ->assertRedirect(route('users.attending', ['id' => $user->id]));
+    }
+}


### PR DESCRIPTION
Resolves #2013 with a deliberately reduced scope (discussed during planning).

## Why not the full GET→POST conversion

The reset/rpp-reset routes only clear the *requester's own* session list-state — no DB writes, no cross-user effect — and #2007's robots.txt already blocks the crawl side (`Disallow: /*/reset`, `/*/rpp-reset`). Converting all 35 routes to POST would have meant reworking ~25 view call sites for what is mostly HTTP-semantics hygiene, at real regression risk in the highest-traffic index views.

The one live defect in this route family was different: 14 of the methods passed the `redirect` request param **unvalidated** into `redirect()->route()`, so `GET /events/reset?redirect=garbage` threw `RouteNotFoundException` → **500**. That's reachable by anyone regardless of robots.txt and feeds the "Server error (5xx)" bucket from #2001 item 5.

## Changes

- New `Controller::resolveRedirectRoute()` helper: honors the `redirect` param only when `Route::has()` confirms it names a real route, else falls back to the default index route. Applied to all 16 call sites (14 routed methods across 13 controllers, plus the two unrouted `CalendarController` siblings for consistency).
- `users/{id}/reset-user-attending` was `Route::match(['get','post'])`; its only caller (`events/indexUserAttending-tw.blade.php`) already POSTs with `@csrf`, so it's now POST-only.
- Everything else intentionally unchanged: the 34 reset/rpp-reset route verbs, all Blade views, `routes/api.php`, robots.txt, `key`-param handling.

## Tests

New `tests/Feature/Web/ResetRedirectGuardTest.php` (6 tests): invalid `redirect` falls back to index on `/events/reset`, `/events/rpp-reset`, `/blogs/reset` (all 500'd before this change); valid `redirect=events.grid` still honored; `reset-user-attending` GET → 405, POST → redirect to `users.attending`.

Full suite: 1084/1100 green; the 16 failing are pre-existing on main (15 × the `storage/framework/cache` www-data ownership issue, 1 × `ActivityTest` CSRF mismatch, reproduced identically on clean main). PHPStan level 3 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)