### PR TITLE
Enable TrustHosts; build page canonicals from app.url (#2006)

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -12,7 +12,7 @@ class Kernel extends HttpKernel
      * @var array<int, string>
      */
     protected $middleware = [
-        // \App\Http\Middleware\TrustHosts::class,
+        \App\Http\Middleware\TrustHosts::class,
         \App\Http\Middleware\TrustProxies::class,
         \Illuminate\Http\Middleware\HandleCors::class,
         \App\Http\Middleware\PreventRequestsDuringMaintenance::class,

--- a/app/Services/SeoMeta.php
+++ b/app/Services/SeoMeta.php
@@ -42,6 +42,14 @@ class SeoMeta
     }
 
     /**
+     * Canonical URL for a known path, on the configured app host.
+     */
+    public static function canonicalFor(string $path): string
+    {
+        return rtrim(config('app.url'), '/').'/'.ltrim($path, '/');
+    }
+
+    /**
      * Whether the current request carries list-state query params and should
      * be noindexed (with follow, so link equity still flows).
      */

--- a/resources/views/events/show-tw.blade.php
+++ b/resources/views/events/show-tw.blade.php
@@ -2,7 +2,7 @@
 
 {{-- the id-based URL also resolves; the slug route is the canonical one --}}
 @section('canonical')
-<link rel="canonical" href="{{ url('/events/'.$event->slug) }}">
+<link rel="canonical" href="{{ \App\Services\SeoMeta::canonicalFor('/events/'.$event->slug) }}">
 @endsection
 
 @section('google.event.json')

--- a/resources/views/events/upcoming-tw.blade.php
+++ b/resources/views/events/upcoming-tw.blade.php
@@ -5,7 +5,7 @@
 {{-- dated variants are navigation state, not distinct pages --}}
 @if (($date ?? '') !== '')
 @section('canonical')
-<link rel="canonical" href="{{ url('/events/upcoming') }}">
+<link rel="canonical" href="{{ \App\Services\SeoMeta::canonicalFor('/events/upcoming') }}">
 @endsection
 @section('meta.robots')
 <meta name="robots" content="noindex, follow">

--- a/resources/views/series/show-tw.blade.php
+++ b/resources/views/series/show-tw.blade.php
@@ -2,7 +2,7 @@
 
 {{-- the id-based URL also resolves; the slug route is the canonical one --}}
 @section('canonical')
-<link rel="canonical" href="{{ url('/series/'.$series->slug) }}">
+<link rel="canonical" href="{{ \App\Services\SeoMeta::canonicalFor('/series/'.$series->slug) }}">
 @endsection
 
 @section('title', $series->getTitleFormat())

--- a/resources/views/tags/show-tw.blade.php
+++ b/resources/views/tags/show-tw.blade.php
@@ -3,7 +3,7 @@
 {{-- name-based links also resolve here; the slug form is the canonical one --}}
 @if (isset($tagObject) && $tagObject)
 @section('canonical')
-<link rel="canonical" href="{{ url('/tags/'.$tagObject->slug) }}">
+<link rel="canonical" href="{{ \App\Services\SeoMeta::canonicalFor('/tags/'.$tagObject->slug) }}">
 @endsection
 @endif
 


### PR DESCRIPTION
Part of #2006 (SEO: dev/beta/api subdomains crawled and indexed).

## App-side changes

- **Enable `TrustHosts`** in the global middleware stack (`app/Http/Kernel.php`). It was commented out, so Laravel built absolute URLs (password-reset links etc.) from whatever `Host` header arrived — a host-header-injection vector and a way for junk hostnames to leak into generated URLs. The existing `allSubdomainsOfApplicationUrl()` implementation is kept because `api.arcane.city` serves this same checkout.
- **Per-page canonicals from `config('app.url')`** (issue item 2e): the `@section('canonical')` overrides on event/series/tag show pages and `/events/upcoming` used `url(...)`, which emits the *request* host — so pages served on `www.arcane.city` / `api.arcane.city` self-canonicalized to the wrong host. Added `SeoMeta::canonicalFor()` (same `config('app.url')` base the layout canonical already uses) and switched the four views to it.

The webserver-side items from the issue (www→apex 301, api/stage noindex headers, beta cert) are being handled directly in nginx on the server, not in this PR.

## Verification

- `./vendor/bin/phpstan analyse` — no errors
- `SeoMeta::canonicalFor('/events/some-slug')` → `https://arcane.city/events/some-slug` (trailing-slash `APP_URL` handled)
- Full test suite runs in CI (not run locally — local `.env` points at the production DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)