### PR TITLE
Default app.frontend_url to APP_URL so email links can't point at localhost

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@ APP_ENV=local
 APP_DEBUG=false
 APP_KEY=SomeRandomString
 APP_URL=your-domain-url
+# Base URL for links in transactional email; leave unset to use APP_URL.
+# Only set this when a separate frontend origin (SPA) handles those links.
+#FRONTEND_URL=
 APP_NAME="Event Repo"
 APP_TAGLINE="Event Repository"
 APP_FEEDBACK_EMAIL=your-feedback-email-address

--- a/config/app.php
+++ b/config/app.php
@@ -31,6 +31,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Frontend URL
+    |--------------------------------------------------------------------------
+    |
+    | Base URL for links in transactional email (verification, password
+    | reset). Overrides the framework default of http://localhost:3000,
+    | which would otherwise leak into emails whenever FRONTEND_URL is
+    | unset. Only set FRONTEND_URL when a separate frontend origin (SPA)
+    | should receive these links; otherwise the app URL is used.
+    |
+    */
+
+    'frontend_url' => env('FRONTEND_URL') ?: env('APP_URL', 'http://localhost/'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Timezone
     |--------------------------------------------------------------------------
     |

--- a/tests/Feature/VerificationEmailUrlTest.php
+++ b/tests/Feature/VerificationEmailUrlTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Auth\Notifications\VerifyEmail;
+use Tests\TestCase;
+
+/**
+ * The email link base comes from app.frontend_url, which must fall back to
+ * the app URL when no separate frontend origin is configured. The framework
+ * default for frontend_url is http://localhost:3000, which leaked into
+ * production emails when FRONTEND_URL was unset (see config/app.php).
+ */
+class VerificationEmailUrlTest extends TestCase
+{
+    protected function makeUnsavedUser(): User
+    {
+        $user = new User();
+        $user->id = 12345;
+        $user->email = 'verify-url-test@example.com';
+
+        return $user;
+    }
+
+    public function testVerificationUrlFallsBackToAppUrlWhenNoFrontendUrlConfigured(): void
+    {
+        $mail = (new VerifyEmail())->toMail($this->makeUnsavedUser());
+
+        $this->assertStringStartsWith(
+            rtrim(config('app.url'), '/').'/email/verify/',
+            $mail->actionUrl
+        );
+    }
+
+    public function testVerificationUrlUsesConfiguredFrontendUrl(): void
+    {
+        config(['app.frontend_url' => 'https://spa.example.com']);
+
+        $mail = (new VerifyEmail())->toMail($this->makeUnsavedUser());
+
+        $this->assertStringStartsWith('https://spa.example.com/email/verify/', $mail->actionUrl);
+    }
+
+    public function testResetPasswordUrlFallsBackToAppUrlWhenNoFrontendUrlConfigured(): void
+    {
+        $mail = (new ResetPassword('dummy-token'))->toMail($this->makeUnsavedUser());
+
+        $this->assertStringStartsWith(
+            rtrim(config('app.url'), '/').'/password/reset/dummy-token',
+            $mail->actionUrl
+        );
+    }
+}


### PR DESCRIPTION
## Bug

Registration-verification and password-reset emails on production linked to `http://localhost:3000/...`.

`AuthServiceProvider` builds these links from `config('app.frontend_url', config('app.url'))`, intending to fall back to `APP_URL`. But since Laravel 11, framework config defaults are merged in, and `vendor/laravel/framework/config/app.php` defines `'frontend_url' => env('FRONTEND_URL', 'http://localhost:3000')` — so the key always exists, the fallback is dead code, and any install without `FRONTEND_URL` in its `.env` sends `localhost:3000` links. (Production has been hotfixed by setting `FRONTEND_URL`; this PR makes the fallback real so the class of bug can't recur.)

## Fix

- `config/app.php`: define `'frontend_url' => env('FRONTEND_URL') ?: env('APP_URL', 'http://localhost/')` — overrides the framework default; unset/empty `FRONTEND_URL` now falls back to the app URL.
- `.env.example`: document `FRONTEND_URL` (commented out — only for installs serving a separate SPA origin).
- `tests/Feature/VerificationEmailUrlTest.php`: renders `VerifyEmail`/`ResetPassword` notifications for an unsaved user (no DB) and asserts the action URL starts with `config('app.url')` when no frontend URL is configured, and with the configured frontend URL when one is set. Both fallback tests fail on `main` with exactly the production symptom (`http://localhost:3000/...`).

## Verification

- New test: 3 passing (2 of which fail before the config change)
- `./vendor/bin/phpstan analyse` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)