### PR TITLE
Fix: Data truncated for column 'alias_id' on entity update [EVENTREPO-XB]

### DIFF
--- a/app/Http/Controllers/EntitiesController.php
+++ b/app/Http/Controllers/EntitiesController.php
@@ -1187,7 +1187,7 @@ class EntitiesController extends Controller
 
         // check the elements in the alias list, and if any don't match, add the alias
         foreach ($aliasArray as $key => $alias) {
-            if (!Alias::find($alias)) {
+            if (!is_numeric($alias) || !$newAlias = Alias::find($alias)) {
                 $newAlias = new Alias();
                 $newAlias->name = ucwords(strtolower($alias));
                 $newAlias->save();

--- a/tests/Feature/Web/EntityUpdateAliasSyncTest.php
+++ b/tests/Feature/Web/EntityUpdateAliasSyncTest.php
@@ -48,14 +48,18 @@ class EntityUpdateAliasSyncTest extends TestCase
         // An existing alias whose id the coerced string will collide with.
         $existing = Alias::create(['name' => 'The Original Alias']);
 
-        $entity = Entity::factory()->create(['created_by' => $this->user->id]);
+        $entity = Entity::factory()->create([
+            'created_by' => $this->user->id,
+            // The factory's faker->name slug fails EntityRequest's ^[a-z0-9-]+$ rule.
+            'slug' => 'alias-sync-test-entity',
+        ]);
 
         // A free-text alias name beginning with the existing alias id, e.g. "7D".
         // is_numeric() is false, but MySQL coerces "7D" -> 7 in an id lookup.
         $aliasName = $existing->id.'D';
         $aliasCountBefore = Alias::count();
 
-        $response = $this->put('/entities/'.$entity->id, [
+        $response = $this->put(route('entities.update', $entity), [
             'name' => $entity->name,
             'slug' => $entity->slug,
             'short' => $entity->short ?? 'short',

--- a/tests/Feature/Web/EntityUpdateAliasSyncTest.php
+++ b/tests/Feature/Web/EntityUpdateAliasSyncTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature\Web;
+
+use App\Models\Alias;
+use App\Models\Entity;
+use App\Models\User;
+use App\Models\UserStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Regression test for EVENTREPO-XB.
+ *
+ * EntitiesController::update looked up submitted alias values with
+ * Alias::find($alias) without first checking is_numeric($alias) (unlike
+ * the tag loop directly above it and the store() method). When a user
+ * submitted a free-text alias name that begins with digits (e.g. "7D"),
+ * MySQL coerced the string to an integer for the id lookup, so the value
+ * coincidentally matched an existing alias id. The code then skipped
+ * creating a new Alias and tried to sync the raw string as the pivot
+ * alias_id, producing:
+ *
+ *   SQLSTATE[01000]: Warning: 1265 Data truncated for column 'alias_id'
+ *
+ * The fix adds the is_numeric() guard so non-numeric names always create a
+ * new alias row and are synced by their integer id.
+ */
+class EntityUpdateAliasSyncTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+        $this->user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $this->actingAs($this->user);
+    }
+
+    /** @test */
+    public function updating_with_a_non_numeric_alias_name_creates_a_new_alias_without_truncation(): void
+    {
+        // An existing alias whose id the coerced string will collide with.
+        $existing = Alias::create(['name' => 'The Original Alias']);
+
+        $entity = Entity::factory()->create(['created_by' => $this->user->id]);
+
+        // A free-text alias name beginning with the existing alias id, e.g. "7D".
+        // is_numeric() is false, but MySQL coerces "7D" -> 7 in an id lookup.
+        $aliasName = $existing->id.'D';
+        $aliasCountBefore = Alias::count();
+
+        $response = $this->put('/entities/'.$entity->id, [
+            'name' => $entity->name,
+            'slug' => $entity->slug,
+            'short' => $entity->short ?? 'short',
+            'description' => $entity->description ?? 'description',
+            'entity_type_id' => $entity->entity_type_id,
+            'entity_status_id' => $entity->entity_status_id,
+            'alias_list' => [$aliasName],
+        ]);
+
+        // Pre-fix this path threw a QueryException (HTTP 500) instead of redirecting.
+        $response->assertRedirect(route('entities.show', $entity));
+
+        // A brand-new alias row was created for the free-text name...
+        $this->assertSame($aliasCountBefore + 1, Alias::count());
+
+        // ...and it is attached to the entity by its integer id.
+        $entity->refresh();
+        $newAlias = Alias::where('name', ucwords(strtolower($aliasName)))->firstOrFail();
+        $this->assertTrue(
+            $entity->aliases->contains('id', $newAlias->id),
+            'The newly created alias should be attached to the entity.'
+        );
+
+        // The unrelated existing alias must NOT have been attached by coercion.
+        $this->assertFalse(
+            $entity->aliases->contains('id', $existing->id),
+            'The coincidentally-coerced existing alias should not be attached.'
+        );
+    }
+}


### PR DESCRIPTION
## Sentry issue

[EVENTREPO-XB](https://geoff-maddock.sentry.io/issues/7643299275/) — `Illuminate\Database\QueryException: SQLSTATE[01000]: Warning: 1265 Data truncated for column 'alias_id' at row 1`

```
insert into `alias_entity` (`alias_id`, `created_at`, `entity_id`, `updated_at`)
values (7D, 2026-07-30 17:30:41, 1620, 2026-07-30 17:30:41)
```

Culprit: `App\Http\Controllers\EntitiesController::update` (`/entities/{entity}`). No user feedback attached.

## Root cause

In `EntitiesController::update`, the alias loop looked up submitted values with `Alias::find($alias)` **without** the `is_numeric($alias)` guard that the tag loop directly above it — and the `store()` method — both use:

```php
// update() — before (buggy)
foreach ($aliasArray as $key => $alias) {
    if (!Alias::find($alias)) {
        // create new alias...
    } else {
        $aliasSyncArray[$key] = $alias; // syncs the raw submitted string
    }
}
```

When a user submits a **free-text alias name that begins with digits** (e.g. `7D`), `is_numeric()` would be false, but the missing guard means `Alias::find('7D')` runs `where id = '7D'`. MySQL coerces `'7D'` → `7`, so it coincidentally matches an existing alias (id 7). The code then takes the `else` branch and tries to sync the raw string `'7D'` as the pivot `alias_id`, which truncates and raises `SQLSTATE[01000] 1265`.

`store()` (line ~765) already guards correctly with `!is_numeric($alias) || …`, so only the update path was affected.

## What changed

- **`app/Http/Controllers/EntitiesController.php`** — added the `is_numeric()` guard so the update alias loop matches `store()` and the sibling tag loop:

  ```php
  if (!is_numeric($alias) || !$newAlias = Alias::find($alias)) {
  ```

  Non-numeric alias names now always create a new `Alias` row and are synced by their integer id; only genuine numeric ids are synced directly. Minimal, single-line behavioral change.

- **`tests/Feature/Web/EntityUpdateAliasSyncTest.php`** — regression test that updates an entity with a non-numeric alias name colliding (by coercion) with an existing alias id, asserting the request redirects (not 500), a new alias row is created, it is attached, and the coincidentally-matched existing alias is **not** attached.

## Verification

`php -l` passes on both files. The full PHPUnit suite requires MySQL + `composer install` and runs in CI (this sandbox is a fresh clone with no `vendor/`).

---
_Generated by [Claude Code](https://claude.ai/code/session_018EkMnixbg4GsLPpxMFbRc6)_