### PR TITLE
Add per-section paging to onboarding follow modal

### DIFF
--- a/app/Http/Controllers/OnboardingController.php
+++ b/app/Http/Controllers/OnboardingController.php
@@ -28,6 +28,20 @@ class OnboardingController extends Controller
     private const FOLLOWABLE_TYPES = ['entity', 'tag', 'event'];
 
     /**
+     * The modal pages through each list client-side, up to this many pages.
+     */
+    private const MAX_PAGES = 10;
+
+    /**
+     * Items shown per page in the modal, per section.
+     */
+    private const ENTITIES_PER_PAGE = 8;
+
+    private const TAGS_PER_PAGE = 12;
+
+    private const EVENTS_PER_PAGE = 6;
+
+    /**
      * Return the popular entities, tags, and events to seed the prompt with.
      */
     public function data(): JsonResponse
@@ -154,7 +168,7 @@ class OnboardingController extends Controller
             ->with(['photos', 'entityType'])
             ->orderByDesc(DB::raw('follows_count + events_count'))
             ->orderBy('name')
-            ->limit(8)
+            ->limit(self::ENTITIES_PER_PAGE * self::MAX_PAGES)
             ->get();
 
         return $entities->map(fn (Entity $entity) => [
@@ -176,7 +190,7 @@ class OnboardingController extends Controller
             ->withCount(['events', 'follows'])
             ->orderByDesc(DB::raw('events_count + follows_count'))
             ->orderBy('name')
-            ->limit(12)
+            ->limit(self::TAGS_PER_PAGE * self::MAX_PAGES)
             ->get();
 
         return $tags->map(fn (Tag $tag) => [
@@ -199,7 +213,7 @@ class OnboardingController extends Controller
             ->with(['venue'])
             ->orderByDesc('attendees_count')
             ->orderBy('start_at')
-            ->limit(6)
+            ->limit(self::EVENTS_PER_PAGE * self::MAX_PAGES)
             ->get();
 
         return $events->map(fn (Event $event) => [

--- a/resources/views/partials/onboarding-modal.blade.php
+++ b/resources/views/partials/onboarding-modal.blade.php
@@ -2,9 +2,11 @@
     Post-signup "Getting To Know You" onboarding prompt (issue #901).
 
     Shown to verified users who follow nothing yet. Lets them pick popular
-    entities, tags, and events to follow. Selecting "Follow selected" creates
-    the follows and marks onboarding complete; "Skip for now" permanently
-    dismisses it. Either way it never auto-shows again.
+    entities, tags, and events to follow. Each section pages client-side
+    (up to 10 pages of options from the data endpoint) and selections are
+    kept across pages. Selecting "Follow selected" creates the follows and
+    marks onboarding complete; "Skip for now" permanently dismisses it.
+    Either way it never auto-shows again.
 --}}
 <style>[x-cloak]{display:none!important}</style>
 <div x-data="onboarding()" x-init="init()" x-show="open" x-cloak
@@ -37,9 +39,25 @@
                 <div class="space-y-6">
                     <!-- Entities -->
                     <section x-show="entities.length">
-                        <h3 class="text-sm font-semibold text-foreground mb-2">Popular artists &amp; venues</h3>
+                        <div class="flex items-center justify-between mb-2">
+                            <h3 class="text-sm font-semibold text-foreground">Popular artists &amp; venues</h3>
+                            <div class="flex items-center gap-1" x-show="pageCount('entities') > 1">
+                                <button type="button" @click="prevPage('entities')" :disabled="page.entities === 0"
+                                        aria-label="Previous artists and venues"
+                                        class="p-1 rounded-md border border-border text-muted-foreground hover:text-foreground hover:bg-background disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+                                    <i class="bi bi-chevron-left text-xs"></i>
+                                </button>
+                                <span class="text-xs text-muted-foreground tabular-nums"
+                                      x-text="(page.entities + 1) + ' / ' + pageCount('entities')"></span>
+                                <button type="button" @click="nextPage('entities')" :disabled="page.entities >= pageCount('entities') - 1"
+                                        aria-label="More artists and venues"
+                                        class="p-1 rounded-md border border-border text-muted-foreground hover:text-foreground hover:bg-background disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+                                    <i class="bi bi-chevron-right text-xs"></i>
+                                </button>
+                            </div>
+                        </div>
                         <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                            <template x-for="item in entities" :key="'entity-' + item.id">
+                            <template x-for="item in paged('entities')" :key="'entity-' + item.id">
                                 <label class="flex items-center gap-3 p-2 rounded-md border border-border hover:bg-background cursor-pointer">
                                     <input type="checkbox" :value="item.id" x-model.number="selected.entities" class="rounded border-border">
                                     <img x-show="item.image" :src="item.image" alt="" class="w-8 h-8 rounded object-cover">
@@ -54,9 +72,25 @@
 
                     <!-- Tags -->
                     <section x-show="tags.length">
-                        <h3 class="text-sm font-semibold text-foreground mb-2">Popular genres &amp; tags</h3>
+                        <div class="flex items-center justify-between mb-2">
+                            <h3 class="text-sm font-semibold text-foreground">Popular genres &amp; tags</h3>
+                            <div class="flex items-center gap-1" x-show="pageCount('tags') > 1">
+                                <button type="button" @click="prevPage('tags')" :disabled="page.tags === 0"
+                                        aria-label="Previous genres and tags"
+                                        class="p-1 rounded-md border border-border text-muted-foreground hover:text-foreground hover:bg-background disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+                                    <i class="bi bi-chevron-left text-xs"></i>
+                                </button>
+                                <span class="text-xs text-muted-foreground tabular-nums"
+                                      x-text="(page.tags + 1) + ' / ' + pageCount('tags')"></span>
+                                <button type="button" @click="nextPage('tags')" :disabled="page.tags >= pageCount('tags') - 1"
+                                        aria-label="More genres and tags"
+                                        class="p-1 rounded-md border border-border text-muted-foreground hover:text-foreground hover:bg-background disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+                                    <i class="bi bi-chevron-right text-xs"></i>
+                                </button>
+                            </div>
+                        </div>
                         <div class="flex flex-wrap gap-2">
-                            <template x-for="item in tags" :key="'tag-' + item.id">
+                            <template x-for="item in paged('tags')" :key="'tag-' + item.id">
                                 <label class="cursor-pointer">
                                     <input type="checkbox" :value="item.id" x-model.number="selected.tags" class="sr-only peer">
                                     <span class="inline-block px-3 py-1 rounded-full text-sm border border-border text-muted-foreground peer-checked:bg-primary peer-checked:text-primary-foreground peer-checked:border-primary transition-colors"
@@ -68,9 +102,25 @@
 
                     <!-- Events -->
                     <section x-show="events.length">
-                        <h3 class="text-sm font-semibold text-foreground mb-2">Upcoming events</h3>
+                        <div class="flex items-center justify-between mb-2">
+                            <h3 class="text-sm font-semibold text-foreground">Upcoming events</h3>
+                            <div class="flex items-center gap-1" x-show="pageCount('events') > 1">
+                                <button type="button" @click="prevPage('events')" :disabled="page.events === 0"
+                                        aria-label="Previous events"
+                                        class="p-1 rounded-md border border-border text-muted-foreground hover:text-foreground hover:bg-background disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+                                    <i class="bi bi-chevron-left text-xs"></i>
+                                </button>
+                                <span class="text-xs text-muted-foreground tabular-nums"
+                                      x-text="(page.events + 1) + ' / ' + pageCount('events')"></span>
+                                <button type="button" @click="nextPage('events')" :disabled="page.events >= pageCount('events') - 1"
+                                        aria-label="More events"
+                                        class="p-1 rounded-md border border-border text-muted-foreground hover:text-foreground hover:bg-background disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+                                    <i class="bi bi-chevron-right text-xs"></i>
+                                </button>
+                            </div>
+                        </div>
                         <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                            <template x-for="item in events" :key="'event-' + item.id">
+                            <template x-for="item in paged('events')" :key="'event-' + item.id">
                                 <label class="flex items-center gap-3 p-2 rounded-md border border-border hover:bg-background cursor-pointer">
                                     <input type="checkbox" :value="item.id" x-model.number="selected.events" class="rounded border-border">
                                     <span class="min-w-0">
@@ -114,6 +164,23 @@
             tags: [],
             events: [],
             selected: { entities: [], tags: [], events: [] },
+            // Client-side paging per section; selections persist across pages
+            // because checkbox state lives in `selected`, not in the DOM.
+            page: { entities: 0, tags: 0, events: 0 },
+            perPage: { entities: 8, tags: 12, events: 6 },
+            paged(kind) {
+                const start = this.page[kind] * this.perPage[kind];
+                return this[kind].slice(start, start + this.perPage[kind]);
+            },
+            pageCount(kind) {
+                return Math.max(1, Math.ceil(this[kind].length / this.perPage[kind]));
+            },
+            prevPage(kind) {
+                if (this.page[kind] > 0) this.page[kind]--;
+            },
+            nextPage(kind) {
+                if (this.page[kind] < this.pageCount(kind) - 1) this.page[kind]++;
+            },
             get totalSelected() {
                 return this.selected.entities.length + this.selected.tags.length + this.selected.events.length;
             },

--- a/tests/Feature/OnboardingTest.php
+++ b/tests/Feature/OnboardingTest.php
@@ -189,6 +189,31 @@ class OnboardingTest extends TestCase
     }
 
     /** @test */
+    public function data_endpoint_returns_enough_options_for_multiple_pages(): void
+    {
+        $user = User::factory()->create(['user_status_id' => 1]);
+
+        $activeStatusId = \App\Models\EntityStatus::where('name', 'Active')->first()->id;
+        Entity::factory()->count(20)->create(['entity_status_id' => $activeStatusId]);
+        Tag::factory()->count(20)->create();
+        Event::factory()->count(10)->create(['start_at' => now()->addWeek()]);
+
+        $response = $this->actingAs($user)->getJson(route('onboarding.data'));
+        $response->assertOk();
+
+        // More than one page's worth (8 entities / 12 tags / 6 events per page)
+        // must come back so the modal's per-section paging has content, capped
+        // at 10 pages per section.
+        $data = $response->json();
+        $this->assertGreaterThan(8, count($data['entities']));
+        $this->assertGreaterThan(12, count($data['tags']));
+        $this->assertGreaterThan(6, count($data['events']));
+        $this->assertLessThanOrEqual(80, count($data['entities']));
+        $this->assertLessThanOrEqual(120, count($data['tags']));
+        $this->assertLessThanOrEqual(60, count($data['events']));
+    }
+
+    /** @test */
     public function onboarding_routes_require_authentication(): void
     {
         $this->withExceptionHandling();


### PR DESCRIPTION
## Summary

The first-login "Get to know your scene" onboarding modal only had room for a single screenful of suggestions per section (8 entities, 12 tags, 6 events). This adds small back/forward paging controls to each section so new users can browse up to 10 pages of options per section, with selections retained as they page around.

### Changes

- **`OnboardingController`** — the `onboarding/data` endpoint now returns up to 10 pages worth of options per section: 80 entities, 120 tags, 60 events. Limits are expressed as `PER_PAGE × MAX_PAGES` constants so the page size and cap live in one place. Popularity ordering is unchanged.
- **`onboarding-modal.blade.php`** — each section header gets compact chevron prev/next buttons with a "2 / 10" page indicator. The pager only renders when a section has more than one page, and each button disables at its end of the range. Paging is client-side slicing in the Alpine component — no extra network requests. Checkbox state lives in the Alpine `selected` arrays rather than the DOM, so selections persist across page flips and the "Follow N selected" count reflects picks from all pages.
- **`OnboardingTest`** — new test seeding 20 entities / 20 tags / 10 future events and asserting the data endpoint returns more than one page's worth per section, capped at the 80/120/60 maximums.

### How to test

Automated (CI runs this):
```bash
./vendor/bin/phpunit tests/Feature/OnboardingTest.php
```
The new test is `data_endpoint_returns_enough_options_for_multiple_pages`; it fails against the old fixed limits and passes with this change.

Manual:
1. Log in as a user who qualifies for onboarding — easiest is an existing account via the **restart onboarding** action on your user page (`POST users/{id}/restart-onboarding`), which clears the completed/dismissed flags and re-shows the modal on the next page load.
2. In each section with enough data, confirm small `‹ ›` buttons and a `1 / N` indicator appear to the right of the heading (on a small/dev database with one page of results, the pager should be hidden).
3. Check a few items, page forward, check more, page back — earlier selections should still be checked and the footer button should read "Follow N selected" with the combined count.
4. Click "Follow selected" and confirm follows are created for picks made across multiple pages, then that the modal doesn't reappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)