### PR TITLE
Limit popular-tags eager load to one event per tag to fix /popular OOM

### DIFF
--- a/app/Http/Controllers/PagesController.php
+++ b/app/Http/Controllers/PagesController.php
@@ -262,15 +262,17 @@ class PagesController extends Controller
             ->get();
 
         // Get popular tags - tags with most events.
-        // Eager-load each tag's visible events (newest first) plus their photos so the
-        // view can pick the latest event + its primary photo without issuing a fresh
-        // query per tag. Previously popular-tw.blade.php ran
-        // `$tag->events()->visible()->latest()->first()` (+ a primary-photo lookup)
-        // inside the tag loop, an N+1 flagged as EVENTREPO-WV.
+        // Eager-load each tag's latest visible event plus its photos so the
+        // view can show the latest event + its primary photo without issuing a
+        // fresh query per tag (N+1 flagged as EVENTREPO-WV). The limit(1) is
+        // applied per tag via a window function; without it every visible
+        // event for each top tag is hydrated (13k+ in prod), which exhausts
+        // php-fpm's memory_limit.
         $popularTags = Tag::withCount('events')
             ->with(['events' => function ($query) use ($user) {
                 $query->visible($user)
                     ->latest('start_at')
+                    ->limit(1)
                     ->with('photos');
             }])
             ->orderBy('events_count', 'desc')

--- a/tests/Feature/Web/PagesControllerTest.php
+++ b/tests/Feature/Web/PagesControllerTest.php
@@ -2,8 +2,11 @@
 
 namespace Tests\Feature\Web;
 
+use App\Models\Event;
+use App\Models\Tag;
 use App\Models\User;
 use App\Models\UserStatus;
+use App\Models\Visibility;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -52,6 +55,43 @@ class PagesControllerTest extends TestCase
     public function test_popular_page_loads(): void
     {
         $this->get('/popular')->assertOk();
+    }
+
+    public function test_popular_page_eager_loads_at_most_one_event_per_tag(): void
+    {
+        // Regression for a prod OOM: the popular-tags query eager-loaded every
+        // visible event (plus photos) for each of the top 24 tags — 13k+ events
+        // in prod — blowing php-fpm's memory_limit. The view only renders each
+        // tag's single latest event, so only that one should be hydrated.
+        $tag = Tag::factory()->create();
+
+        $older = Event::factory()->create([
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => now()->subDays(10),
+        ]);
+        $middle = Event::factory()->create([
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => now()->subDays(5),
+        ]);
+        $latest = Event::factory()->create([
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => now()->subDay(),
+        ]);
+        $tag->events()->attach([$older->id, $middle->id, $latest->id]);
+
+        $response = $this->get('/popular')->assertOk();
+
+        $popularTags = $response->viewData('popularTags');
+        $popularTag = $popularTags->firstWhere('id', $tag->id);
+
+        $this->assertNotNull($popularTag, 'Tag with most events should appear in popular tags');
+        $this->assertCount(1, $popularTag->events, 'Only the latest event should be eager-loaded per tag');
+        $this->assertTrue($popularTag->events->first()->is($latest));
+        $this->assertTrue($popularTag->events->first()->relationLoaded('photos'));
+
+        foreach ($popularTags as $anyTag) {
+            $this->assertLessThanOrEqual(1, $anyTag->events->count());
+        }
     }
 
     public function test_radar_page_requires_auth(): void


### PR DESCRIPTION
## Summary

`/popular` has been returning an empty 500 in prod. Root cause: the N+1 fix from #2003 eager-loads **every** visible event (plus photos) for each of the top 24 tags — 13,448 events in prod — which exhausts php-fpm's 128M `memory_limit`. The fatal bypasses Laravel's exception handler, so nothing appeared in `laravel.log`.

The view only renders each tag's single latest event and its primary photo, so this constrains the eager load with `limit(1)`, which Laravel 11+ applies per parent via a window function (MySQL 8). The EVENTREPO-WV N+1 fix stays intact — still one query for tags plus one for their events.

## Changes

- `PagesController::popular()` — add `->limit(1)` to the `events` eager-load constraint on the popular-tags query
- `PagesControllerTest` — regression test asserting each popular tag hydrates at most one event (the latest visible one, with photos loaded)

## Verification

- Regression test written first and confirmed failing (3 events hydrated) before the fix, passing after
- Read-only re-run of the original repro against prod data at `memory_limit=128M`: 24 events hydrated instead of 13,448, peak memory 45M (previously fatal OOM)
- PHPStan clean; `PagesControllerTest` + `TwPageRenderSmokeTest` green (26 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)