### PR TITLE
Fix empty event-listing pages ($events variable bug) [#2002 series 1/6]

### DIFF
--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -891,7 +891,7 @@ class EventsController extends Controller
         $query = $listResultSet->getList();
 
         // get the events
-        $future_events = $query
+        $events = $query
             ->where(function ($query) {
                 /* @phpstan-ignore-next-line */
                 $query->visible($this->user);
@@ -917,7 +917,7 @@ class EventsController extends Controller
                 $this->getFilterOptions(),
                 $this->getListControlOptions()
             ))
-            ->with(compact('future_events'));
+            ->with(compact('events'));
     }
 
     /*
@@ -1181,7 +1181,7 @@ class EventsController extends Controller
         $query = $listResultSet->getList();
 
         // get the events
-        $past_events = $query
+        $events = $query
             ->where(function ($query) {
                 /* @phpstan-ignore-next-line */
                 $query->visible($this->user);
@@ -1206,7 +1206,7 @@ class EventsController extends Controller
                 $this->getFilterOptions(),
                 $this->getListControlOptions()
             ))
-            ->with(compact('past_events'));
+            ->with(compact('events'));
     }
 
     /**
@@ -2628,7 +2628,7 @@ class EventsController extends Controller
         $cdate_yesterday = $cdate->copy()->subDay();
         $cdate_tomorrow = $cdate->copy()->addDay();
 
-        $future_events = Event::where('events.start_at', '>', $cdate_yesterday->toDateString())
+        $events = Event::where('events.start_at', '>', $cdate_yesterday->toDateString())
             ->with($this->cardEventEagerLoad())
             ->where('events.start_at', '<', $cdate_tomorrow->toDateString())
             ->where(function ($query) {
@@ -2658,7 +2658,7 @@ class EventsController extends Controller
                     $this->getListControlOptions()
                 )
             )
-            ->with(compact('future_events'))
+            ->with(compact('events'))
             ->with(compact('cdate'));
     }
 
@@ -2691,7 +2691,7 @@ class EventsController extends Controller
         // get the query builder
         $query = $listResultSet->getList();
 
-        $future_events = Event::getByVenue(strtolower($slug))
+        $events = Event::getByVenue(strtolower($slug))
             ->with($this->cardEventEagerLoad())
             ->future()
             ->where(function ($query) {
@@ -2732,7 +2732,7 @@ class EventsController extends Controller
                     $this->getListControlOptions()
                 )
             )
-            ->with(compact('future_events'))
+            ->with(compact('events'))
             ->with(compact('past_events'))
             ->with(compact('slug'));
     }
@@ -2830,7 +2830,7 @@ class EventsController extends Controller
         $futureQuery = clone $pastQuery;
 
         // @phpstan-ignore-next-line
-        $future_events = $futureQuery
+        $events = $futureQuery
             ->visible($this->user)
             ->with($this->cardEventEagerLoad())
             ->future()
@@ -2866,7 +2866,7 @@ class EventsController extends Controller
                     $this->getListControlOptions()
                 )
             )
-            ->with(compact('future_events'))
+            ->with(compact('events'))
             ->with(compact('past_events'))
             ->with(compact('slug'));
     }

--- a/tests/Feature/Web/EventsControllerTest.php
+++ b/tests/Feature/Web/EventsControllerTest.php
@@ -2,8 +2,10 @@
 
 namespace Tests\Feature\Web;
 
+use App\Models\Entity;
 use App\Models\Event;
 use App\Models\Photo;
+use App\Models\Series;
 use App\Models\Tag;
 use App\Models\User;
 use App\Models\UserStatus;
@@ -137,6 +139,101 @@ class EventsControllerTest extends TestCase
         $response->assertOk();
         $response->assertSee('Public Tag Probe Event');
         $response->assertDontSee('Secret Private Tag Probe Event');
+    }
+
+    /**
+     * The future listing compacted its paginated result under the wrong
+     * variable name ($future_events), so the view (which only reads $events)
+     * always rendered "No matching events found." A public future event must
+     * actually appear on the page.
+     */
+    public function test_index_future_shows_created_event(): void
+    {
+        $event = Event::factory()->create([
+            'name' => 'Future Listing Probe Event',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => now()->addWeek(),
+        ]);
+
+        $response = $this->get('/events/future');
+
+        $response->assertOk();
+        $response->assertSee('Future Listing Probe Event');
+    }
+
+    /**
+     * Same bug as indexFuture, but for $past_events.
+     */
+    public function test_index_past_shows_created_event(): void
+    {
+        $event = Event::factory()->create([
+            'name' => 'Past Listing Probe Event',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => now()->subWeek(),
+        ]);
+
+        $response = $this->get('/events/past');
+
+        $response->assertOk();
+        $response->assertSee('Past Listing Probe Event');
+    }
+
+    /**
+     * Same bug as indexFuture, but for the "starting on this day" listing.
+     */
+    public function test_index_starting_shows_created_event(): void
+    {
+        $event = Event::factory()->create([
+            'name' => 'Starting Listing Probe Event',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => now()->startOfDay()->addHours(12),
+        ]);
+
+        $response = $this->get('/events/starting/'.now()->format('Ymd'));
+
+        $response->assertOk();
+        $response->assertSee('Starting Listing Probe Event');
+    }
+
+    /**
+     * Same bug as indexFuture, but for the by-venue listing.
+     */
+    public function test_index_venue_shows_created_event(): void
+    {
+        $venue = Entity::factory()->venue()->create(['slug' => 'listing-probe-venue']);
+        $event = Event::factory()->create([
+            'name' => 'Venue Listing Probe Event',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => now()->addWeek(),
+            'venue_id' => $venue->id,
+        ]);
+
+        $response = $this->get('/events/venue/listing-probe-venue');
+
+        $response->assertOk();
+        $response->assertSee('Venue Listing Probe Event');
+    }
+
+    /**
+     * Same bug as indexFuture, but for the by-series listing.
+     */
+    public function test_index_series_shows_created_event(): void
+    {
+        $series = Series::factory()->create([
+            'name' => 'Listing Probe Series',
+            'slug' => 'listing-probe-series',
+        ]);
+        $event = Event::factory()->create([
+            'name' => 'Series Listing Probe Event',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => now()->addWeek(),
+            'series_id' => $series->id,
+        ]);
+
+        $response = $this->get('/events/series/listing-probe-series');
+
+        $response->assertOk();
+        $response->assertSee('Series Listing Probe Event');
     }
 
     /**


### PR DESCRIPTION
## Summary

Part 1 of 6 of the issue #2002 SEO series (merge these PRs in order; each is based on the previous branch).

Fixes a long-standing bug where five public listing pages rendered "No matching events found" regardless of data: `indexFuture`, `indexPast`, `indexStarting`, `indexVenues`, and `indexSeries` passed their paginated results as `$future_events`/`$past_events`, but `events/index-tw.blade.php` only reads `$events`.

## Changes

- Rename the compacted variable to `$events` in the five actions (queries, routes, and the view untouched).
- Five regression tests in `tests/Feature/Web/EventsControllerTest.php`, one per route, asserting the seeded event's name actually renders (these went RED against the unfixed code).

## Notes

- `indexVenues`/`indexSeries` still compact a (provably dead) `$past_events` — left in place to keep this strictly a variable-name fix.

## Test plan

- `./vendor/bin/phpunit tests/Feature/Web/EventsControllerTest.php` (19/19)
- `composer phpstan` clean; full suite green at branch tip.

Part of #2002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
