### PR TITLE
SEO: query-forward page titles sitewide [#2002 series 2/6]

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -15,7 +15,7 @@
 	@yield('google.event.json')
 	<meta name="theme-color" content="#0f172a"/>
 	<meta name="csrf-token" content="{{ csrf_token() }}">
-	<title>@yield('title','Event Guide') • {{ config('app.app_name')}}</title>
+	<title>@yield('title','Event Guide') | {{ config('app.app_name')}}</title>
 
 	<!-- Theme initialization script - must run before page renders to prevent flash -->
 	<script>

--- a/resources/views/entities/title-crumbs.blade.php
+++ b/resources/views/entities/title-crumbs.blade.php
@@ -1,12 +1,12 @@
 @if (isset($tag))
-• {{ ucfirst($tag->name)}}
+— {{ ucfirst($tag->name)}}
 @endif
 @if (isset($role))
-• {{ ucfirst($role) }}
+— {{ ucfirst($role) }}
 @endif
 @if (isset($type))
-• {{ ucfirst($type) }}
+— {{ ucfirst($type) }}
 @endif
 @if (isset($slug))
-• {{ strtoupper($name) }}
+— {{ strtoupper($name) }}
 @endif 

--- a/resources/views/events/index-tw.blade.php
+++ b/resources/views/events/index-tw.blade.php
@@ -1,7 +1,11 @@
 @extends('layouts.app-tw')
 
 @section('title')
+@if (isset($tag) || isset($related) || isset($type) || isset($slug) || isset($cdate))
 Events @include('events.title-crumbs')
+@else
+Pittsburgh Events Calendar — Concerts, Shows & More
+@endif
 @endsection
 
 @if (isset($events) && count($events) > 0)

--- a/resources/views/events/title-crumbs.blade.php
+++ b/resources/views/events/title-crumbs.blade.php
@@ -1,15 +1,15 @@
 @if (isset($tag))
-• {{ ucfirst($tag->name) }}
+— {{ ucfirst($tag->name) }}
 @endif
 @if (isset($related))
-• {{ ucfirst($related->name) }}
+— {{ ucfirst($related->name) }}
 @endif
 @if (isset($type))
-• {{ ucfirst($type) }}
+— {{ ucfirst($type) }}
 @endif
 @if (isset($slug))
-• {{ ucfirst($slug) }}
+— {{ ucfirst($slug) }}
 @endif
 @if (isset($cdate))
-• {{ $cdate->toDateString() }}
+— {{ $cdate->toDateString() }}
 @endif

--- a/resources/views/layouts/app-tw.blade.php
+++ b/resources/views/layouts/app-tw.blade.php
@@ -27,7 +27,7 @@
 	@yield('page.json')
 	<meta name="theme-color" content="#0f172a"/>
 	<meta name="csrf-token" content="{{ csrf_token() }}">
-	<title>@yield('title','Event Guide') • {{ config('app.app_name')}}</title>
+	<title>@yield('title','Event Guide') | {{ config('app.app_name')}}</title>
 
 	<!-- Theme initialization script - must run before page renders to prevent flash -->
 	<script>

--- a/resources/views/minimal.blade.php
+++ b/resources/views/minimal.blade.php
@@ -10,7 +10,7 @@
 	<meta property="og:image" content="@yield('og-image', url('/').'/apple-icon-180x180.png')">
 	<meta property="og:description" content="@yield('og-description', 'A calender of events, concerts, club nights, weekly and monthly events series, promoters, artists, producers, djs, venues and other entities.')">
 	<meta name="description" content="A calender of events, concerts, club nights, weekly and monthly events series, promoters, artists, producers, djs, venues and other entities.">
-	<title>@yield('title','Event Guide') • {{ config('app.app_name')}}</title>
+	<title>@yield('title','Event Guide') | {{ config('app.app_name')}}</title>
 	
 	<link rel="manifest" href="/manifest.json">
     <link rel="apple-touch-icon" href="/apple-icon-180x180.png">

--- a/resources/views/tags/index.blade.php
+++ b/resources/views/tags/index.blade.php
@@ -2,7 +2,7 @@
 
 @section('title')
 @if (isset($tag))
-Keyword Tag • {{ $tag }}
+Keyword Tag — {{ $tag }}
 @else
 Keyword Tags
 @endif

--- a/resources/views/tags/show-tw.blade.php
+++ b/resources/views/tags/show-tw.blade.php
@@ -9,7 +9,7 @@
 
 @section('title')
 @if (isset($tag))
-{{ $tag }} Events, Artists & Series in Pittsburgh
+{{ Str::ucfirst($tag) }} Events, Artists & Series in Pittsburgh
 @else
 Tags
 @endif

--- a/resources/views/tags/show-tw.blade.php
+++ b/resources/views/tags/show-tw.blade.php
@@ -9,7 +9,7 @@
 
 @section('title')
 @if (isset($tag))
-{{ $tag }} • Tag
+{{ $tag }} Events, Artists & Series in Pittsburgh
 @else
 Tags
 @endif
@@ -41,8 +41,8 @@ Tags
 					@if ($tagObject->tagType)
 					<p class="text-xl text-muted-foreground mt-1">{{ $tagObject->tagType->name }}</p>
 					@endif
-					@if ($tagObject->tag_definition)
-					<p class="mt-2 text-muted-foreground">{{ $tagObject->tag_definition }}</p>
+					@if ($tagObject->description)
+					<p class="mt-2 text-muted-foreground">{{ $tagObject->description }}</p>
 					@endif
 				@endif
 			</div>

--- a/resources/views/users/title-crumbs.blade.php
+++ b/resources/views/users/title-crumbs.blade.php
@@ -1,6 +1,6 @@
 @if (isset($user))
-• {{ ucfirst($user->name) }}
+— {{ ucfirst($user->name) }}
 @endif
 @if (isset($slug))
-• {{ ucfirst($slug) }}
+— {{ ucfirst($slug) }}
 @endif

--- a/tests/Feature/SeoTitlePatternTest.php
+++ b/tests/Feature/SeoTitlePatternTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\Tag;
+use App\Models\Visibility;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SeoTitlePatternTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    protected function appName(): string
+    {
+        return config('app.app_name');
+    }
+
+    public function test_home_page_title_is_query_forward(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertOk();
+        $response->assertSee('| '.$this->appName().'</title>', false);
+        $response->assertDontSee("\u{2022} ".$this->appName().'</title>', false);
+    }
+
+    public function test_events_index_title_is_query_forward_and_generic(): void
+    {
+        $response = $this->get('/events');
+
+        $response->assertOk();
+        $response->assertSee('| '.$this->appName().'</title>', false);
+        $response->assertDontSee("\u{2022} ".$this->appName().'</title>', false);
+        $response->assertSee('Pittsburgh Events Calendar', false);
+    }
+
+    public function test_event_show_title_is_query_forward(): void
+    {
+        $event = Event::factory()->create(['visibility_id' => Visibility::VISIBILITY_PUBLIC]);
+
+        $response = $this->get('/events/'.$event->id);
+
+        $response->assertOk();
+        $response->assertSee('| '.$this->appName().'</title>', false);
+        $response->assertDontSee("\u{2022} ".$this->appName().'</title>', false);
+    }
+
+    public function test_tag_show_page_renders_tag_description(): void
+    {
+        $tag = Tag::factory()->create([
+            'name' => 'Description Probe',
+            'slug' => 'description-probe',
+            'description' => 'A tag used only to verify the description renders.',
+        ]);
+
+        $response = $this->get('/tags/'.$tag->slug);
+
+        $response->assertOk();
+        $response->assertSee('A tag used only to verify the description renders.', false);
+    }
+}

--- a/tests/Feature/SeoTitlePatternTest.php
+++ b/tests/Feature/SeoTitlePatternTest.php
@@ -68,4 +68,18 @@ class SeoTitlePatternTest extends TestCase
         $response->assertOk();
         $response->assertSee('A tag used only to verify the description renders.', false);
     }
+
+    public function test_tag_show_page_title_capitalizes_lowercase_tag_name(): void
+    {
+        $tag = Tag::factory()->create([
+            'name' => 'lowercase tag',
+            'slug' => 'lowercase-tag',
+        ]);
+
+        $response = $this->get('/tags/'.$tag->slug);
+
+        $response->assertOk();
+        $response->assertSee('<title>Lowercase Tag Events, Artists & Series in Pittsburgh', false);
+        $response->assertDontSee('<title>lowercase Tag Events', false);
+    }
 }


### PR DESCRIPTION
## Summary

Part 2 of 6 of the issue #2002 SEO series (base: `2002-fix-empty-listing-pages`).

Flips brand-forward page titles ("X • Arcane City") to query-forward ("X | Arcane City") sitewide, and makes the highest-volume generic titles query-forward. Per Search Console data, at positions 3–8 this alone lifts CTR.

## Changes

- `layouts/app-tw.blade.php`: title separator ` • ` → ` | ` (og:title stays unsuffixed, as og convention requires). Same flip in the legacy heads that actually carry the pattern: `resources/views/app.blade.php` and `minimal.blade.php` (the brief's `layouts/app.blade.php` turned out to be a stock scaffold with no separator).
- Bare `/events` title → `Pittsburgh Events Calendar — Concerts, Shows & More`; crumb separators in title partials → `—`.
- Tag pages: title → `{Tag} Events, Artists & Series in Pittsburgh` (capitalized), and a bug fix — the view read the nonexistent `$tagObject->tag_definition`; it now renders the real `tags.description` column, which was silently never displayed.
- Sweep of remaining `•` occurrences feeding `@section('title')`; body-copy bullets untouched.

## Notes

- Other `events.index-tw` call sites that set no crumb vars (e.g. `/events/past`) now also render the generic query-forward title — intentional.

## Test plan

- New `tests/Feature/SeoTitlePatternTest.php` (title pattern on `/`, `/events`, event page; tag description render; lowercase-tag capitalization).
- `SeoMetaLayoutTest` + `SeoGuardsTest` green; `composer phpstan` clean.

Part of #2002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
