### PR TITLE
SEO: time-window landing pages (tonight/today/this-weekend/this-week) [#2002 series 3/6]

### DIFF
--- a/app/Console/Commands/GenerateSitemap.php
+++ b/app/Console/Commands/GenerateSitemap.php
@@ -43,6 +43,10 @@ class GenerateSitemap extends Command
     protected const PAGES = [
         '/',
         '/events',
+        '/events/tonight',
+        '/events/today',
+        '/events/this-weekend',
+        '/events/this-week',
         '/entities',
         '/series',
         '/tags',

--- a/app/Enums/EventTimeWindow.php
+++ b/app/Enums/EventTimeWindow.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace App\Enums;
+
+use Carbon\CarbonImmutable;
+
+/**
+ * The four time-window landing pages: /events/tonight, /events/today,
+ * /events/this-weekend, /events/this-week. Pure date/copy logic only —
+ * no queries, no HTTP. See app/Services/EventTimeWindowStats.php for
+ * counts and app/Http/Controllers/EventTimeWindowController.php for glue.
+ *
+ * All window math happens in America/New_York wall-clock time. Never use
+ * config('app.timezone') here — it's a fixed-offset 'EST' zone and will
+ * silently miscompute DST transitions.
+ */
+enum EventTimeWindow: string
+{
+    case Tonight = 'tonight';
+    case Today = 'today';
+    case ThisWeekend = 'this-weekend';
+    case ThisWeek = 'this-week';
+
+    protected const TIMEZONE = 'America/New_York';
+
+    /**
+     * Inclusive start/end naive 'Y-m-d H:i:s' strings, compared against
+     * events.start_at via Event::scopeBetween().
+     *
+     * @return array{start: string, end: string}
+     */
+    public function range(?CarbonImmutable $now = null): array
+    {
+        $now = $now ?? CarbonImmutable::now(self::TIMEZONE);
+
+        [$start, $end] = match ($this) {
+            self::Today => $this->todayBounds($now),
+            self::ThisWeek => $this->thisWeekBounds($now),
+            self::Tonight => $this->tonightBounds($now),
+            self::ThisWeekend => $this->thisWeekendBounds($now),
+        };
+
+        return [
+            'start' => $start->format('Y-m-d H:i:s'),
+            'end' => $end->format('Y-m-d H:i:s'),
+        ];
+    }
+
+    /**
+     * @return array{0: CarbonImmutable, 1: CarbonImmutable}
+     */
+    private function todayBounds(CarbonImmutable $now): array
+    {
+        $date = $now->startOfDay();
+
+        return [$date, $date->setTime(23, 59, 59)];
+    }
+
+    /**
+     * @return array{0: CarbonImmutable, 1: CarbonImmutable}
+     */
+    private function thisWeekBounds(CarbonImmutable $now): array
+    {
+        $start = $now->startOfDay();
+
+        return [$start, $start->addDays(6)->setTime(23, 59, 59)];
+    }
+
+    /**
+     * @return array{0: CarbonImmutable, 1: CarbonImmutable}
+     */
+    private function tonightBounds(CarbonImmutable $now): array
+    {
+        $anchor = $this->anchorDay($now);
+
+        return [$anchor->setTime(17, 0, 0), $anchor->addDay()->setTime(3, 0, 0)];
+    }
+
+    /**
+     * @return array{0: CarbonImmutable, 1: CarbonImmutable}
+     */
+    private function thisWeekendBounds(CarbonImmutable $now): array
+    {
+        $friday = $this->weekendFriday($now);
+
+        return [$friday->setTime(17, 0, 0), $friday->addDays(3)->setTime(3, 0, 0)];
+    }
+
+    /**
+     * The "anchor day" used by tonight/this-weekend: before 3am, we're still
+     * talking about last night, so the anchor rolls back to yesterday.
+     */
+    private function anchorDay(CarbonImmutable $now): CarbonImmutable
+    {
+        $day = $now->startOfDay();
+
+        return $now->hour < 3 ? $day->subDay() : $day;
+    }
+
+    /**
+     * Friday of the relevant weekend: if the anchor day already falls on
+     * Fri/Sat/Sun, it's that weekend's Friday; otherwise it's the next one.
+     */
+    private function weekendFriday(CarbonImmutable $now): CarbonImmutable
+    {
+        $anchor = $this->anchorDay($now);
+        $isoDow = $anchor->dayOfWeekIso; // 1 = Monday ... 7 = Sunday
+
+        if ($isoDow >= 5) {
+            // Fri (5), Sat (6), Sun (7) -> back up to that week's Friday.
+            return $anchor->subDays($isoDow - 5);
+        }
+
+        // Mon..Thu -> forward to the upcoming Friday.
+        return $anchor->addDays(5 - $isoDow);
+    }
+
+    /**
+     * SEO title, no brand suffix — the layout appends " | Arcane City".
+     */
+    public function title(): string
+    {
+        return match ($this) {
+            self::Tonight => 'Events in Pittsburgh Tonight — Live Music, Shows & More',
+            self::Today => 'Events in Pittsburgh Today — Live Music, Shows & More',
+            self::ThisWeekend => 'Events in Pittsburgh This Weekend — Live Music, Shows & More',
+            self::ThisWeek => 'Events in Pittsburgh This Week — Live Music, Shows & More',
+        };
+    }
+
+    public function h1(): string
+    {
+        return match ($this) {
+            self::Tonight => 'Events in Pittsburgh Tonight',
+            self::Today => 'Events in Pittsburgh Today',
+            self::ThisWeekend => 'Events in Pittsburgh This Weekend',
+            self::ThisWeek => 'Events in Pittsburgh This Week',
+        };
+    }
+
+    public function path(): string
+    {
+        return '/events/'.$this->value;
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Tonight => 'Tonight',
+            self::Today => 'Today',
+            self::ThisWeekend => 'This Weekend',
+            self::ThisWeek => 'This Week',
+        };
+    }
+
+    /**
+     * Window-appropriate adverbial phrase used mid-sentence, e.g.
+     * "5 shows {phrase} across 3 Pittsburgh venues".
+     */
+    private function phrase(): string
+    {
+        return match ($this) {
+            self::Tonight => 'tonight',
+            self::Today => 'today',
+            self::ThisWeekend => 'this weekend',
+            self::ThisWeek => 'this week',
+        };
+    }
+
+    /**
+     * @param array{events?: int, venues?: int, tags?: string[]} $stats
+     */
+    public function metaDescription(array $stats): string
+    {
+        $events = $stats['events'] ?? 0;
+        $venues = $stats['venues'] ?? 0;
+        $tags = $stats['tags'] ?? [];
+
+        if ($events === 0) {
+            return 'Live music, club nights and DIY shows in Pittsburgh — updated daily.';
+        }
+
+        $showWord = $events === 1 ? 'show' : 'shows';
+        $venueWord = $venues === 1 ? 'venue' : 'venues';
+
+        $desc = sprintf(
+            '%d %s %s across %d Pittsburgh %s',
+            $events,
+            $showWord,
+            $this->phrase(),
+            $venues,
+            $venueWord
+        );
+
+        if (! empty($tags)) {
+            $desc .= ' — '.implode(', ', $tags).' & more.';
+        } else {
+            $desc .= '.';
+        }
+
+        return $desc;
+    }
+}

--- a/app/Enums/EventTimeWindow.php
+++ b/app/Enums/EventTimeWindow.php
@@ -181,16 +181,13 @@ enum EventTimeWindow: string
         }
 
         $showWord = $events === 1 ? 'show' : 'shows';
-        $venueWord = $venues === 1 ? 'venue' : 'venues';
 
-        $desc = sprintf(
-            '%d %s %s across %d Pittsburgh %s',
-            $events,
-            $showWord,
-            $this->phrase(),
-            $venues,
-            $venueWord
-        );
+        $desc = sprintf('%d %s %s', $events, $showWord, $this->phrase());
+
+        if ($venues > 0) {
+            $venueWord = $venues === 1 ? 'venue' : 'venues';
+            $desc .= sprintf(' across %d Pittsburgh %s', $venues, $venueWord);
+        }
 
         if (! empty($tags)) {
             $desc .= ' — '.implode(', ', $tags).' & more.';

--- a/app/Http/Controllers/EventTimeWindowController.php
+++ b/app/Http/Controllers/EventTimeWindowController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Enums\EventTimeWindow;
+use App\Models\Event;
+use App\Services\EventTimeWindowStats;
+use Illuminate\Contracts\View\View;
+
+/**
+ * Stable, crawlable time-window landing pages: /events/tonight,
+ * /events/today, /events/this-weekend, /events/this-week.
+ *
+ * Deliberately does NOT use ListParameterSessionStore / ListEntityResultBuilder
+ * — these pages must render the same content for every visitor and must not
+ * inherit session filter/sort/tab state from the main /events listing.
+ */
+class EventTimeWindowController extends Controller
+{
+    public function show(string $window, EventTimeWindowStats $stats): View
+    {
+        $timeWindow = EventTimeWindow::tryFrom($window) ?? abort(404);
+
+        $range = $timeWindow->range();
+
+        $events = Event::query()
+            ->visible($this->user)
+            ->between($range['start'], $range['end'])
+            ->with(EventsController::cardEventEagerLoad($this->user))
+            ->paginate(48);
+
+        return view('events.time-window-tw', [
+            'window' => $timeWindow,
+            'events' => $events,
+            'stats' => $stats->stats($timeWindow),
+        ]);
+    }
+}

--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -319,7 +319,7 @@ class EventsController extends Controller
             })
             ->orderBy('start_at', 'ASC')
             ->orderBy('name', 'ASC')
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->paginate($listResultSet->getLimit());
 
         // saves the updated session
@@ -359,17 +359,20 @@ class EventsController extends Controller
      * Eager-loading these keeps each index/filter page a fixed number of queries
      * instead of running venue/type/tag/photo/entity/thread lookups once per card (N+1).
      *
+     * Shared with EventTimeWindowController so the /events/tonight-style
+     * landing pages don't drift from the canonical card eager-load list.
+     *
      * @return array<int|string, string|\Closure>
      */
-    protected function cardEventEagerLoad(): array
+    public static function cardEventEagerLoad(?User $user = null): array
     {
         // venue.locations avoids an N+1 in card-tw's getPrimaryLocationMap()/getPrimaryLocationAddress() (EVENTREPO-W5).
         $eager = ['visibility', 'venue.locations', 'eventType', 'tags', 'photos', 'entities', 'threads'];
 
-        if ($this->user) {
+        if ($user) {
             // The attend/unattend button reads getEventResponse($user)->responseType per card.
-            $eager['eventResponses'] = function ($query) {
-                $query->where('user_id', $this->user->id)->with('responseType');
+            $eager['eventResponses'] = function ($query) use ($user) {
+                $query->where('user_id', $user->id)->with('responseType');
             };
         }
 
@@ -439,7 +442,7 @@ class EventsController extends Controller
         // get the events
         // @phpstan-ignore-next-line
         $events = $query->visible($this->user)
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->paginate($listResultSet->getLimit());
 
         // persist resolved sort values so subsequent requests don't revert to a different default
@@ -896,7 +899,7 @@ class EventsController extends Controller
                 /* @phpstan-ignore-next-line */
                 $query->visible($this->user);
             })
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->paginate($listResultSet->getLimit());
 
         // saves the updated session
@@ -1080,76 +1083,6 @@ class EventsController extends Controller
     }
 
     /**
-     * Display a listing of today's events.
-     *
-     * @return Response|View
-     */
-    public function indexToday(
-        Request $request,
-        ListParameterSessionStore $listParamSessionStore,
-        ListEntityResultBuilder $listEntityResultBuilder
-    ) {
-        // initialized listParamSessionStore with baseindex key
-        $listParamSessionStore->setBaseIndex('internal_event');
-        $listParamSessionStore->setKeyPrefix('internal_event_today');
-
-        // set the index tab in the session
-        $listParamSessionStore->setIndexTab(action([EventsController::class, 'index']));
-
-        // get the base query for today's events and add any necessary joins for sorting
-        $baseQuery = Event::today()->leftJoin('event_types', 'events.event_type_id', '=', 'event_types.id')->select('events.*');
-
-        $listEntityResultBuilder
-            ->setFilter($this->filter)
-            ->setQueryBuilder($baseQuery)
-            ->setDefaultSort(['events.start_at' => 'desc']);
-
-        // get the result set from the builder
-        $listResultSet = $listEntityResultBuilder->listResultSetFactory();
-
-        // get the query builder
-        $query = $listResultSet->getList();
-
-        $query
-            // public or where created by
-            ->where(function ($query) {
-                $query->whereIn('visibility_id', [1, 2])
-                    ->where('created_by', '=', $this->user ? $this->user->id : null);
-                // if logged in, can see guarded
-                if ($this->user) {
-                    $query->orWhere('visibility_id', '=', 4);
-                }
-                $query->orWhere('visibility_id', '=', 3);
-
-                return $query;
-            });
-
-        // get the events
-        $events = $query
-            ->with($this->cardEventEagerLoad())
-            ->paginate($listResultSet->getLimit());
-
-        // saves the updated session
-        $listParamSessionStore->save();
-
-        $this->hasFilter = $listResultSet->getFilters() != $listResultSet->getDefaultFilters() || $listResultSet->getIsEmptyFilter();
-
-        return view('events.index-tw')
-            ->with(array_merge(
-                [
-                    'limit' => $listResultSet->getLimit(),
-                    'sort' => $listResultSet->getSort(),
-                    'direction' => $listResultSet->getSortDirection(),
-                    'hasFilter' => $this->hasFilter,
-                    'filters' => $listResultSet->getFilters(),
-                ],
-                $this->getFilterOptions(),
-                $this->getListControlOptions()
-            ))
-            ->with(compact('events'));
-    }
-
-    /**
      * Display a listing of only past events.
      *
      * @return Response|View
@@ -1186,7 +1119,7 @@ class EventsController extends Controller
                 /* @phpstan-ignore-next-line */
                 $query->visible($this->user);
             })
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->paginate($listResultSet->getLimit());
 
         // saves the updated session
@@ -1248,7 +1181,7 @@ class EventsController extends Controller
 
         // get the events
         $events = $query
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->paginate($listResultSet->getLimit());
 
         // saves the updated session
@@ -2497,7 +2430,7 @@ class EventsController extends Controller
         // @phpstan-ignore-next-line
         $events = $query
             ->visible($this->user)
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->orderBy('events.start_at', 'DESC')
             ->orderBy('events.name', 'ASC')
             ->paginate($listResultSet->getLimit());
@@ -2560,7 +2493,7 @@ class EventsController extends Controller
         // @phpstan-ignore-next-line
         $events = $query
             ->visible($this->user)
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->orderBy('events.start_at', 'ASC')
             ->orderBy('events.name', 'ASC')
             ->paginate($listResultSet->getLimit());
@@ -2629,7 +2562,7 @@ class EventsController extends Controller
         $cdate_tomorrow = $cdate->copy()->addDay();
 
         $events = Event::where('events.start_at', '>', $cdate_yesterday->toDateString())
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->where('events.start_at', '<', $cdate_tomorrow->toDateString())
             ->where(function ($query) {
                 /* @phpstan-ignore-next-line */
@@ -2692,7 +2625,7 @@ class EventsController extends Controller
         $query = $listResultSet->getList();
 
         $events = Event::getByVenue(strtolower($slug))
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->future()
             ->where(function ($query) {
                 /* @phpstan-ignore-next-line */
@@ -2703,7 +2636,7 @@ class EventsController extends Controller
             ->paginate($this->limit);
 
         $past_events = Event::getByVenue(strtolower($slug))
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->past()
             ->where(function ($query) {
                 /* @phpstan-ignore-next-line */
@@ -2769,7 +2702,7 @@ class EventsController extends Controller
         // @phpstan-ignore-next-line
         $events = $query
             ->select('events.*')
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->orderBy('events.start_at', 'ASC')
             ->orderBy('events.name', 'ASC')
             ->paginate($listResultSet->getLimit());
@@ -2832,7 +2765,7 @@ class EventsController extends Controller
         // @phpstan-ignore-next-line
         $events = $futureQuery
             ->visible($this->user)
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->future()
             ->orderBy('events.start_at', 'ASC')
             ->orderBy('events.name', 'ASC')
@@ -2841,7 +2774,7 @@ class EventsController extends Controller
         // @phpstan-ignore-next-line
         $past_events = $pastQuery
             ->visible($this->user)
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->past()
             ->orderBy('events.start_at', 'ASC')
             ->orderBy('events.name', 'ASC')
@@ -3239,7 +3172,7 @@ class EventsController extends Controller
 
         // get the events
         $events = $query
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->paginate($listResultSet->getLimit());
 
         // saves the updated session

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -327,6 +327,19 @@ class Event extends Model
     }
 
     /**
+     * Events with a start_at inside the given naive datetime bounds
+     * (inclusive), ordered earliest-first. Used by the time-window landing
+     * pages (/events/tonight, /today, /this-weekend, /this-week).
+     *
+     * @param Builder<Event> $query
+     */
+    public function scopeBetween(Builder $query, string $start, string $end): Builder
+    {
+        return $query->whereBetween('events.start_at', [$start, $end])
+            ->orderBy('events.start_at', 'asc');
+    }
+
+    /**
      * @param Builder<Event> $query 
      */
     public function scopeFuture(Builder $query): Builder

--- a/app/Services/EventTimeWindowStats.php
+++ b/app/Services/EventTimeWindowStats.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\EventTimeWindow;
+use App\Models\Event;
+use App\Models\Visibility;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Live counts backing the /events/tonight, /today, /this-weekend,
+ * /this-week landing pages: event count, distinct venue count, and the
+ * top tags for the window. Counts are computed against public events only
+ * so the cached value is safe to share across all visitors regardless of
+ * who's signed in.
+ */
+class EventTimeWindowStats
+{
+    protected const CACHE_TTL = 900;
+
+    /**
+     * @return array{events: int, venues: int, tags: string[]}
+     */
+    public function stats(EventTimeWindow $window): array
+    {
+        $range = $window->range();
+
+        $cacheKey = sprintf(
+            'event-window-stats:%s:%s',
+            $window->value,
+            substr($range['start'], 0, 10)
+        );
+
+        return Cache::remember($cacheKey, self::CACHE_TTL, function () use ($range): array {
+            $counts = Event::query()
+                ->where('visibility_id', Visibility::VISIBILITY_PUBLIC)
+                ->between($range['start'], $range['end'])
+                ->selectRaw('COUNT(*) as event_count, COUNT(DISTINCT venue_id) as venue_count')
+                ->toBase()
+                ->first();
+
+            $tags = DB::table('event_tag')
+                ->join('events', 'events.id', '=', 'event_tag.event_id')
+                ->join('tags', 'tags.id', '=', 'event_tag.tag_id')
+                ->where('events.visibility_id', Visibility::VISIBILITY_PUBLIC)
+                ->whereBetween('events.start_at', [$range['start'], $range['end']])
+                ->select('tags.name')
+                ->selectRaw('COUNT(*) as frequency')
+                ->groupBy('tags.name')
+                ->orderByDesc('frequency')
+                ->limit(3)
+                ->pluck('tags.name')
+                ->all();
+
+            return [
+                'events' => $counts ? (int) $counts->event_count : 0,
+                'venues' => $counts ? (int) $counts->venue_count : 0,
+                'tags' => $tags,
+            ];
+        });
+    }
+}

--- a/resources/views/events/index-json-ld.blade.php
+++ b/resources/views/events/index-json-ld.blade.php
@@ -36,11 +36,11 @@
     }
 
     $isTagPage  = isset($tag);
-    $pageUrl    = $isTagPage ? route('events.tag', $tag->slug) : route('events.index');
-    $pageName   = $isTagPage ? (ucfirst($tag->name) . ' Events') : 'Events';
-    $pageDesc   = $isTagPage
+    $pageUrl    = $pageUrl ?? ($isTagPage ? route('events.tag', $tag->slug) : route('events.index'));
+    $pageName   = $pageName ?? ($isTagPage ? (ucfirst($tag->name) . ' Events') : 'Events');
+    $pageDesc   = $pageDesc ?? ($isTagPage
         ? ('Events tagged with ' . $tag->name . ' in Pittsburgh')
-        : 'Upcoming events, concerts and shows in Pittsburgh';
+        : 'Upcoming events, concerts and shows in Pittsburgh');
 
     $jsonLd = [
         '@context'    => 'https://schema.org',
@@ -62,6 +62,13 @@
             '@type'    => 'ListItem',
             'position' => 2,
             'name'     => ucfirst($tag->name),
+            'item'     => $pageUrl,
+        ];
+    } elseif ($pageUrl !== route('events.index')) {
+        $breadcrumbItems[] = [
+            '@type'    => 'ListItem',
+            'position' => 2,
+            'name'     => $pageName,
             'item'     => $pageUrl,
         ];
     }

--- a/resources/views/events/time-window-tw.blade.php
+++ b/resources/views/events/time-window-tw.blade.php
@@ -1,0 +1,65 @@
+@extends('layouts.app-tw')
+
+@section('title', $window->title())
+
+@php
+    $desc = $window->metaDescription($stats);
+@endphp
+
+@section('description', $desc)
+@section('og-description', $desc)
+
+@if ($events->isNotEmpty())
+@section('page.json')
+@include('events.index-json-ld', [
+    'pageUrl' => url($window->path()),
+    'pageName' => $window->h1(),
+    'pageDesc' => $desc,
+])
+@endsection
+@endif
+
+@section('content')
+
+<!-- Page Header -->
+<div class="mb-6">
+	<h1 class="text-3xl font-bold text-primary mb-2">{{ $window->h1() }}</h1>
+	<p class="text-muted-foreground">{{ $desc }}</p>
+</div>
+
+<!-- Other windows -->
+<div class="mb-6 flex flex-wrap gap-2">
+	@foreach (\App\Enums\EventTimeWindow::cases() as $otherWindow)
+	<a href="{{ url($otherWindow->path()) }}"
+		class="inline-flex items-center px-3 py-1 rounded-full text-sm border transition-colors {{ $otherWindow === $window ? 'bg-primary text-primary-foreground border-primary' : 'border-border text-muted-foreground hover:bg-accent' }}">
+		{{ $otherWindow->label() }}
+	</a>
+	@endforeach
+</div>
+
+@if ($events->isNotEmpty())
+<div class="mb-4">
+	{!! $events->onEachSide(2)->links('vendor.pagination.tailwind') !!}
+</div>
+
+<div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-6">
+	@foreach ($events as $event)
+	@include('events.card-tw', ['event' => $event])
+	@endforeach
+</div>
+
+<div class="mt-4">
+	{!! $events->onEachSide(2)->links('vendor.pagination.tailwind') !!}
+</div>
+@else
+<div class="text-center py-12">
+	<i class="bi bi-calendar-x text-6xl text-muted-foreground/60 mb-4"></i>
+	<p class="text-muted-foreground">No events found for this window yet.</p>
+	<a href="{{ url('/events') }}" class="mt-4 inline-flex items-center text-primary hover:text-primary/90">
+		<i class="bi bi-arrow-left mr-2"></i>
+		View all events
+	</a>
+</div>
+@endif
+
+@endsection

--- a/resources/views/layouts/app-tw.blade.php
+++ b/resources/views/layouts/app-tw.blade.php
@@ -107,6 +107,8 @@
 			<!-- Main Content Area -->
 			<main class="flex-1 min-w-0 w-full mx-auto p-4 md:p-6 overflow-x-hidden overflow-y-auto bg-background max-w-[2400px]">
 				@yield('content')
+
+				@include('partials.footer-tw')
 			</main>
 		</div>
 	</div>

--- a/resources/views/pages/home-tw.blade.php
+++ b/resources/views/pages/home-tw.blade.php
@@ -132,13 +132,22 @@
 
 <!-- Upcoming Events Section -->
 <section id="upcoming-events" class="space-y-6">
-	<div class="flex items-center justify-between">
+	<div class="flex flex-wrap items-center justify-between gap-2">
 		<h2 class="text-2xl md:text-3xl font-bold text-foreground">Upcoming Events</h2>
 		<a href="{!! URL::route('events.index') !!}"
 			class="text-sm font-medium text-primary hover:text-primary/90 transition-colors inline-flex items-center gap-1">
 			View All
 			<i class="bi bi-arrow-right"></i>
 		</a>
+	</div>
+
+	<div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
+		@foreach (\App\Enums\EventTimeWindow::cases() as $window)
+		<a href="{{ url($window->path()) }}" class="hover:text-primary transition-colors">{{ $window->label() }}</a>
+		@if (!$loop->last)
+		<span aria-hidden="true">&middot;</span>
+		@endif
+		@endforeach
 	</div>
 
 	@include('events.4days-tw')

--- a/resources/views/partials/footer-tw.blade.php
+++ b/resources/views/partials/footer-tw.blade.php
@@ -1,0 +1,17 @@
+<footer class="mt-12 border-t border-border py-6 text-sm text-muted-foreground">
+	<div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+		<span class="font-semibold text-foreground">{{ config('app.app_name') }}</span>
+		@foreach (\App\Enums\EventTimeWindow::cases() as $window)
+		<span aria-hidden="true">&middot;</span>
+		<a href="{{ url($window->path()) }}" class="hover:text-primary transition-colors">{{ $window->label() }}</a>
+		@endforeach
+		<span aria-hidden="true">&middot;</span>
+		<a href="{{ url('/events') }}" class="hover:text-primary transition-colors">Events</a>
+		<span aria-hidden="true">&middot;</span>
+		<a href="{{ url('/entities') }}" class="hover:text-primary transition-colors">Entities</a>
+		<span aria-hidden="true">&middot;</span>
+		<a href="{{ url('/series') }}" class="hover:text-primary transition-colors">Series</a>
+		<span aria-hidden="true">&middot;</span>
+		<a href="{{ url('/tags') }}" class="hover:text-primary transition-colors">Tags</a>
+	</div>
+</footer>

--- a/resources/views/partials/sidebar-tw.blade.php
+++ b/resources/views/partials/sidebar-tw.blade.php
@@ -32,6 +32,18 @@
                 <span>Events</span>
             </a>
             <div class="ml-8 space-y-1 mt-1">
+                <a href="{{ url('/events/tonight') }}" class="nav-item-tw text-sm {{ Request::is('events/tonight') ? 'nav-item-active-tw' : '' }}">
+                    <i class="bi bi-moon-stars text-sm"></i>
+                    <span>Tonight</span>
+                </a>
+                <a href="{{ url('/events/this-weekend') }}" class="nav-item-tw text-sm {{ Request::is('events/this-weekend') ? 'nav-item-active-tw' : '' }}">
+                    <i class="bi bi-calendar-week text-sm"></i>
+                    <span>This Weekend</span>
+                </a>
+                <a href="{{ url('/events/this-week') }}" class="nav-item-tw text-sm {{ Request::is('events/this-week') ? 'nav-item-active-tw' : '' }}">
+                    <i class="bi bi-calendar-range text-sm"></i>
+                    <span>This Week</span>
+                </a>
                 <a href="{{ url('/events/grid') }}" class="nav-item-tw text-sm {{ Request::is('events/grid') ? 'nav-item-active-tw' : '' }}">
                     <i class="bi bi-grid text-sm"></i>
                     <span>Event Grid</span>
@@ -189,6 +201,18 @@
                 <span>Events</span>
             </a>
             <div class="ml-8 space-y-1 mt-1">
+                <a href="{{ url('/events/tonight') }}" class="nav-item-tw text-sm {{ Request::is('events/tonight') ? 'nav-item-active-tw' : '' }}">
+                    <i class="bi bi-moon-stars text-sm"></i>
+                    <span>Tonight</span>
+                </a>
+                <a href="{{ url('/events/this-weekend') }}" class="nav-item-tw text-sm {{ Request::is('events/this-weekend') ? 'nav-item-active-tw' : '' }}">
+                    <i class="bi bi-calendar-week text-sm"></i>
+                    <span>This Weekend</span>
+                </a>
+                <a href="{{ url('/events/this-week') }}" class="nav-item-tw text-sm {{ Request::is('events/this-week') ? 'nav-item-active-tw' : '' }}">
+                    <i class="bi bi-calendar-range text-sm"></i>
+                    <span>This Week</span>
+                </a>
                 <a href="{{ url('/events/grid') }}" class="nav-item-tw text-sm {{ Request::is('events/grid') ? 'nav-item-active-tw' : '' }}">
                     <i class="bi bi-grid text-sm"></i>
                     <span>Event Grid</span>

--- a/routes/web.php
+++ b/routes/web.php
@@ -243,7 +243,10 @@ Route::get('update', function () {
     EventUpdated::dispatch(new Event());
 });
 
-Route::get('events/today', [\App\Http\Controllers\EventsController::class, 'indexToday']);
+Route::get('events/tonight', [\App\Http\Controllers\EventTimeWindowController::class, 'show'])->defaults('window', 'tonight')->name('events.tonight');
+Route::get('events/today', [\App\Http\Controllers\EventTimeWindowController::class, 'show'])->defaults('window', 'today')->name('events.today');
+Route::get('events/this-weekend', [\App\Http\Controllers\EventTimeWindowController::class, 'show'])->defaults('window', 'this-weekend')->name('events.thisWeekend');
+Route::get('events/this-week', [\App\Http\Controllers\EventTimeWindowController::class, 'show'])->defaults('window', 'this-week')->name('events.thisWeek');
 Route::match(['get', 'post'], 'events/grid', [\App\Http\Controllers\EventsController::class, 'indexGrid'])->name('events.grid');
 Route::get('events/grid/tag/{slug}', [\App\Http\Controllers\EventsController::class, 'indexGridTags'])->name('events.grid.tag');
 Route::get('events/grid/by-date/{year}/{month?}/{day?}', [\App\Http\Controllers\EventsController::class, 'indexGridByDate'])->name('events.grid.byDate')

--- a/tests/Feature/Console/GenerateSitemapCommandTest.php
+++ b/tests/Feature/Console/GenerateSitemapCommandTest.php
@@ -67,6 +67,17 @@ class GenerateSitemapCommandTest extends TestCase
         }
     }
 
+    public function test_includes_the_time_window_landing_pages(): void
+    {
+        $content = $this->generate();
+
+        $base = rtrim(config('app.url'), '/');
+        $this->assertStringContainsString($base.'/events/tonight', $content);
+        $this->assertStringContainsString($base.'/events/today', $content);
+        $this->assertStringContainsString($base.'/events/this-weekend', $content);
+        $this->assertStringContainsString($base.'/events/this-week', $content);
+    }
+
     public function test_includes_public_content_and_excludes_non_public(): void
     {
         $public = Event::factory()->create([

--- a/tests/Feature/Services/EventTimeWindowStatsTest.php
+++ b/tests/Feature/Services/EventTimeWindowStatsTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Feature\Services;
+
+use App\Enums\EventTimeWindow;
+use App\Models\Entity;
+use App\Models\Event;
+use App\Models\Tag;
+use App\Models\User;
+use App\Models\Visibility;
+use App\Services\EventTimeWindowStats;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class EventTimeWindowStatsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+    }
+
+    protected function insideStart(EventTimeWindow $window): string
+    {
+        $range = $window->range();
+
+        return Carbon::parse($range['start'])->addMinutes(10)->format('Y-m-d H:i:s');
+    }
+
+    public function test_stats_count_public_events_only(): void
+    {
+        $window = EventTimeWindow::Today;
+        $start = $this->insideStart($window);
+
+        Event::factory()->create([
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => $start,
+            'created_by' => User::factory()->create()->id,
+        ]);
+        Event::factory()->create([
+            'visibility_id' => Visibility::VISIBILITY_PRIVATE,
+            'start_at' => $start,
+            'created_by' => User::factory()->create()->id,
+        ]);
+        Event::factory()->create([
+            'visibility_id' => Visibility::VISIBILITY_PROPOSAL,
+            'start_at' => $start,
+            'created_by' => User::factory()->create()->id,
+        ]);
+
+        $stats = app(EventTimeWindowStats::class)->stats($window);
+
+        $this->assertSame(1, $stats['events']);
+    }
+
+    public function test_stats_counts_distinct_venues_and_top_tags(): void
+    {
+        $window = EventTimeWindow::Today;
+        $start = $this->insideStart($window);
+
+        $venue = Entity::factory()->create();
+        $tagA = Tag::factory()->create(['name' => 'Techno']);
+        $tagB = Tag::factory()->create(['name' => 'Punk']);
+
+        $eventOne = Event::factory()->create([
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => $start,
+            'venue_id' => $venue->id,
+            'created_by' => User::factory()->create()->id,
+        ]);
+        $eventTwo = Event::factory()->create([
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => $start,
+            'venue_id' => $venue->id,
+            'created_by' => User::factory()->create()->id,
+        ]);
+
+        $eventOne->tags()->attach([$tagA->id, $tagB->id]);
+        $eventTwo->tags()->attach([$tagA->id]);
+
+        $stats = app(EventTimeWindowStats::class)->stats($window);
+
+        $this->assertSame(2, $stats['events']);
+        $this->assertSame(1, $stats['venues']); // same venue for both events
+        $this->assertSame('Techno', $stats['tags'][0]); // most frequent first
+        $this->assertContains('Punk', $stats['tags']);
+    }
+
+    public function test_cache_key_varies_by_window_start_date(): void
+    {
+        $stats = app(EventTimeWindowStats::class);
+
+        $today = $stats->stats(EventTimeWindow::Today);
+
+        $todayRange = EventTimeWindow::Today->range();
+        $cacheKey = 'event-window-stats:today:'.substr($todayRange['start'], 0, 10);
+
+        $this->assertTrue(Cache::has($cacheKey));
+
+        // A different window (this-week) starts on the same date but is a
+        // distinct cache entry keyed by window value + start date.
+        $weekRange = EventTimeWindow::ThisWeek->range();
+        $weekCacheKey = 'event-window-stats:this-week:'.substr($weekRange['start'], 0, 10);
+
+        $this->assertNotSame($cacheKey, $weekCacheKey);
+    }
+}

--- a/tests/Feature/Web/EventTimeWindowPagesTest.php
+++ b/tests/Feature/Web/EventTimeWindowPagesTest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Tests\Feature\Web;
+
+use App\Enums\EventTimeWindow;
+use App\Models\Event;
+use App\Models\User;
+use App\Models\Visibility;
+use App\Services\EventTimeWindowStats;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class EventTimeWindowPagesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+        Cache::flush();
+    }
+
+    protected function appName(): string
+    {
+        return config('app.app_name');
+    }
+
+    public static function windowProvider(): array
+    {
+        return [
+            'tonight' => ['tonight', '/events/tonight', 'Tonight'],
+            'today' => ['today', '/events/today', 'Today'],
+            'this-weekend' => ['this-weekend', '/events/this-weekend', 'This Weekend'],
+            'this-week' => ['this-week', '/events/this-week', 'This Week'],
+        ];
+    }
+
+    protected function eventInside(EventTimeWindow $window, array $overrides = []): Event
+    {
+        $range = $window->range();
+        $start = Carbon::parse($range['start'])->addMinutes(10)->format('Y-m-d H:i:s');
+
+        return Event::factory()->create(array_merge([
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => $start,
+            'created_by' => User::factory()->create()->id,
+        ], $overrides));
+    }
+
+    protected function eventOutside(EventTimeWindow $window, array $overrides = []): Event
+    {
+        $range = $window->range();
+        $start = Carbon::parse($range['start'])->subDays(3)->format('Y-m-d H:i:s');
+
+        return Event::factory()->create(array_merge([
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => $start,
+            'created_by' => User::factory()->create()->id,
+        ], $overrides));
+    }
+
+    /**
+     * @dataProvider windowProvider
+     */
+    public function test_page_returns_200_with_expected_title(string $windowValue, string $path, string $phrase): void
+    {
+        $window = EventTimeWindow::from($windowValue);
+
+        $response = $this->get($path);
+
+        $response->assertOk();
+        // The layout's inline @section('title', ...) form runs content through
+        // e(), so '&' in the copy renders as '&amp;' in the compiled <title>.
+        $response->assertSee('<title>'.e($window->title()).' | '.$this->appName().'</title>', false);
+        $response->assertSee($phrase, false);
+    }
+
+    /**
+     * @dataProvider windowProvider
+     */
+    public function test_canonical_is_the_clean_window_path(string $windowValue, string $path, string $phrase): void
+    {
+        $response = $this->get($path);
+
+        $response->assertOk();
+        $base = rtrim(config('app.url'), '/');
+        $response->assertSee('<link rel="canonical" href="'.$base.$path.'">', false);
+    }
+
+    /**
+     * @dataProvider windowProvider
+     */
+    public function test_sort_param_variant_is_noindexed(string $windowValue, string $path, string $phrase): void
+    {
+        $response = $this->get($path.'?sort=name');
+
+        $response->assertOk();
+        $response->assertSee('<meta name="robots" content="noindex, follow">', false);
+    }
+
+    /**
+     * @dataProvider windowProvider
+     */
+    public function test_event_inside_window_is_shown_and_outside_window_is_absent(string $windowValue, string $path, string $phrase): void
+    {
+        $window = EventTimeWindow::from($windowValue);
+
+        $inside = $this->eventInside($window, ['name' => 'Inside Window Test Event']);
+        $outside = $this->eventOutside($window, ['name' => 'Outside Window Test Event']);
+
+        $response = $this->get($path);
+
+        $response->assertOk();
+        $response->assertSee($inside->name);
+        $response->assertDontSee($outside->name);
+    }
+
+    /**
+     * @dataProvider windowProvider
+     */
+    public function test_private_event_inside_window_is_absent_for_guests(string $windowValue, string $path, string $phrase): void
+    {
+        $window = EventTimeWindow::from($windowValue);
+
+        $private = $this->eventInside($window, [
+            'name' => 'Private Window Test Event',
+            'visibility_id' => Visibility::VISIBILITY_PRIVATE,
+        ]);
+
+        $response = $this->get($path);
+
+        $response->assertOk();
+        $response->assertDontSee($private->name);
+    }
+
+    /**
+     * @dataProvider windowProvider
+     */
+    public function test_meta_description_contains_the_computed_event_count(string $windowValue, string $path, string $phrase): void
+    {
+        $window = EventTimeWindow::from($windowValue);
+
+        $this->eventInside($window, ['name' => 'Count Test Event']);
+
+        $response = $this->get($path);
+        $response->assertOk();
+
+        $stats = app(EventTimeWindowStats::class)->stats($window);
+        $desc = $window->metaDescription($stats);
+
+        // Inline @section(..., $desc) runs content through e(), so '&' renders as '&amp;'.
+        $response->assertSee('<meta name="description" content="'.e($desc).'">', false);
+        $response->assertSee((string) $stats['events'], false);
+    }
+
+    /**
+     * @dataProvider windowProvider
+     */
+    public function test_response_contains_item_list_json_ld_when_events_present(string $windowValue, string $path, string $phrase): void
+    {
+        $window = EventTimeWindow::from($windowValue);
+
+        $this->eventInside($window, ['name' => 'JSON LD Test Event']);
+
+        $response = $this->get($path);
+
+        $response->assertOk();
+        $response->assertSee('"@type": "ItemList"', false);
+    }
+
+    /**
+     * @dataProvider windowProvider
+     */
+    public function test_empty_state_has_no_json_ld(string $windowValue, string $path, string $phrase): void
+    {
+        // No events created inside the window: only whatever the seeder
+        // happens to leave inside this real-time window, if anything.
+        $window = EventTimeWindow::from($windowValue);
+        $stats = app(EventTimeWindowStats::class)->stats($window);
+
+        $response = $this->get($path);
+        $response->assertOk();
+
+        if ($stats['events'] === 0) {
+            $response->assertDontSee('"@type": "ItemList"', false);
+            $response->assertSee('No events found for this window yet.', false);
+        } else {
+            $this->assertTrue(true); // seeded data already populates this window; nothing to assert
+        }
+    }
+
+    public function test_other_window_pill_links_are_present(): void
+    {
+        $response = $this->get('/events/tonight');
+
+        $response->assertOk();
+        $response->assertSee('href="'.url('/events/today').'"', false);
+        $response->assertSee('href="'.url('/events/this-weekend').'"', false);
+        $response->assertSee('href="'.url('/events/this-week').'"', false);
+    }
+}

--- a/tests/Unit/EventTimeWindowTest.php
+++ b/tests/Unit/EventTimeWindowTest.php
@@ -237,4 +237,13 @@ class EventTimeWindowTest extends TestCase
 
         $this->assertSame('Live music, club nights and DIY shows in Pittsburgh — updated daily.', $desc);
     }
+
+    public function test_meta_description_omits_venue_clause_when_no_venues(): void
+    {
+        $desc = EventTimeWindow::Tonight->metaDescription(['events' => 5, 'venues' => 0, 'tags' => []]);
+
+        $this->assertSame('5 shows tonight.', $desc);
+        $this->assertStringNotContainsString('Pittsburgh venues', $desc);
+        $this->assertStringNotContainsString('across 0', $desc);
+    }
 }

--- a/tests/Unit/EventTimeWindowTest.php
+++ b/tests/Unit/EventTimeWindowTest.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Enums\EventTimeWindow;
+use Carbon\CarbonImmutable;
+use Tests\TestCase;
+
+/**
+ * Boundary matrix for the /events/tonight, /today, /this-weekend, /this-week
+ * landing pages. All times are America/New_York wall-clock, expressed as
+ * naive 'Y-m-d H:i:s' strings compared against events.start_at.
+ */
+class EventTimeWindowTest extends TestCase
+{
+    protected function now(string $dateTime): CarbonImmutable
+    {
+        return CarbonImmutable::parse($dateTime, 'America/New_York');
+    }
+
+    public function test_today_window_is_the_calendar_day(): void
+    {
+        $range = EventTimeWindow::Today->range($this->now('2026-08-04 12:00:00')); // Tuesday
+
+        $this->assertSame('2026-08-04 00:00:00', $range['start']);
+        $this->assertSame('2026-08-04 23:59:59', $range['end']);
+    }
+
+    public function test_this_week_window_rolls_six_days_forward(): void
+    {
+        $range = EventTimeWindow::ThisWeek->range($this->now('2026-08-04 12:00:00')); // Tuesday
+
+        $this->assertSame('2026-08-04 00:00:00', $range['start']);
+        $this->assertSame('2026-08-10 23:59:59', $range['end']);
+    }
+
+    public function test_this_week_window_crosses_a_month_boundary(): void
+    {
+        $range = EventTimeWindow::ThisWeek->range($this->now('2026-08-28 09:00:00')); // Friday
+
+        $this->assertSame('2026-08-28 00:00:00', $range['start']);
+        $this->assertSame('2026-09-03 23:59:59', $range['end']);
+    }
+
+    // --- Tuesday noon: plain day, weekend is the upcoming Friday ---
+
+    public function test_tuesday_noon_tonight_is_tuesday_evening(): void
+    {
+        $range = EventTimeWindow::Tonight->range($this->now('2026-08-04 12:00:00')); // Tuesday
+
+        $this->assertSame('2026-08-04 17:00:00', $range['start']);
+        $this->assertSame('2026-08-05 03:00:00', $range['end']);
+    }
+
+    public function test_tuesday_noon_weekend_is_upcoming_friday(): void
+    {
+        $range = EventTimeWindow::ThisWeekend->range($this->now('2026-08-04 12:00:00')); // Tuesday
+
+        $this->assertSame('2026-08-07 17:00:00', $range['start']); // Friday
+        $this->assertSame('2026-08-10 03:00:00', $range['end']); // Monday
+    }
+
+    // --- Friday 18:00: tonight and weekend both anchor to this Friday ---
+
+    public function test_friday_evening_tonight_is_friday_night(): void
+    {
+        $range = EventTimeWindow::Tonight->range($this->now('2026-08-07 18:00:00')); // Friday
+
+        $this->assertSame('2026-08-07 17:00:00', $range['start']);
+        $this->assertSame('2026-08-08 03:00:00', $range['end']);
+    }
+
+    public function test_friday_evening_weekend_is_current_weekend(): void
+    {
+        $range = EventTimeWindow::ThisWeekend->range($this->now('2026-08-07 18:00:00')); // Friday
+
+        $this->assertSame('2026-08-07 17:00:00', $range['start']);
+        $this->assertSame('2026-08-10 03:00:00', $range['end']);
+    }
+
+    // --- Saturday 01:00: still "Friday night" per the <3am hangover rule ---
+
+    public function test_saturday_1am_tonight_is_still_fridays_window(): void
+    {
+        $range = EventTimeWindow::Tonight->range($this->now('2026-08-08 01:00:00')); // Saturday
+
+        $this->assertSame('2026-08-07 17:00:00', $range['start']);
+        $this->assertSame('2026-08-08 03:00:00', $range['end']);
+    }
+
+    public function test_saturday_1am_weekend_is_still_current(): void
+    {
+        $range = EventTimeWindow::ThisWeekend->range($this->now('2026-08-08 01:00:00')); // Saturday
+
+        $this->assertSame('2026-08-07 17:00:00', $range['start']);
+        $this->assertSame('2026-08-10 03:00:00', $range['end']);
+    }
+
+    // --- Sunday 20:00: still within the Fri->Mon weekend window ---
+
+    public function test_sunday_evening_weekend_is_still_current(): void
+    {
+        $range = EventTimeWindow::ThisWeekend->range($this->now('2026-08-09 20:00:00')); // Sunday
+
+        $this->assertSame('2026-08-07 17:00:00', $range['start']);
+        $this->assertSame('2026-08-10 03:00:00', $range['end']);
+    }
+
+    public function test_sunday_evening_tonight_is_sunday_night(): void
+    {
+        $range = EventTimeWindow::Tonight->range($this->now('2026-08-09 20:00:00')); // Sunday
+
+        $this->assertSame('2026-08-09 17:00:00', $range['start']);
+        $this->assertSame('2026-08-10 03:00:00', $range['end']);
+    }
+
+    // --- Monday 02:00: hangover from Sunday night; weekend is the one that just ended ---
+
+    public function test_monday_2am_tonight_is_sundays_window(): void
+    {
+        $range = EventTimeWindow::Tonight->range($this->now('2026-08-10 02:00:00')); // Monday
+
+        $this->assertSame('2026-08-09 17:00:00', $range['start']);
+        $this->assertSame('2026-08-10 03:00:00', $range['end']);
+    }
+
+    public function test_monday_2am_weekend_is_the_just_ended_one(): void
+    {
+        $range = EventTimeWindow::ThisWeekend->range($this->now('2026-08-10 02:00:00')); // Monday
+
+        $this->assertSame('2026-08-07 17:00:00', $range['start']);
+        $this->assertSame('2026-08-10 03:00:00', $range['end']);
+    }
+
+    // --- Monday 12:00: fully into the new week; weekend is next Friday ---
+
+    public function test_monday_noon_tonight_is_monday_night(): void
+    {
+        $range = EventTimeWindow::Tonight->range($this->now('2026-08-10 12:00:00')); // Monday
+
+        $this->assertSame('2026-08-10 17:00:00', $range['start']);
+        $this->assertSame('2026-08-11 03:00:00', $range['end']);
+    }
+
+    public function test_monday_noon_weekend_is_next_friday(): void
+    {
+        $range = EventTimeWindow::ThisWeekend->range($this->now('2026-08-10 12:00:00')); // Monday
+
+        $this->assertSame('2026-08-14 17:00:00', $range['start']); // Friday
+        $this->assertSame('2026-08-17 03:00:00', $range['end']); // Monday
+    }
+
+    // --- default $now (no argument) resolves without throwing ---
+
+    public function test_range_defaults_to_current_time_when_now_is_not_injected(): void
+    {
+        $range = EventTimeWindow::Today->range();
+
+        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2} 00:00:00$/', $range['start']);
+        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2} 23:59:59$/', $range['end']);
+    }
+
+    // --- copy / label / path / title / h1 ---
+
+    public function test_paths_and_labels(): void
+    {
+        $this->assertSame('/events/tonight', EventTimeWindow::Tonight->path());
+        $this->assertSame('Tonight', EventTimeWindow::Tonight->label());
+        $this->assertSame('/events/today', EventTimeWindow::Today->path());
+        $this->assertSame('Today', EventTimeWindow::Today->label());
+        $this->assertSame('/events/this-weekend', EventTimeWindow::ThisWeekend->path());
+        $this->assertSame('This Weekend', EventTimeWindow::ThisWeekend->label());
+        $this->assertSame('/events/this-week', EventTimeWindow::ThisWeek->path());
+        $this->assertSame('This Week', EventTimeWindow::ThisWeek->label());
+    }
+
+    public function test_title_has_no_brand_suffix(): void
+    {
+        $this->assertSame('Events in Pittsburgh Tonight — Live Music, Shows & More', EventTimeWindow::Tonight->title());
+        $this->assertSame('Events in Pittsburgh Today — Live Music, Shows & More', EventTimeWindow::Today->title());
+        $this->assertSame('Events in Pittsburgh This Weekend — Live Music, Shows & More', EventTimeWindow::ThisWeekend->title());
+        $this->assertSame('Events in Pittsburgh This Week — Live Music, Shows & More', EventTimeWindow::ThisWeek->title());
+
+        foreach (EventTimeWindow::cases() as $window) {
+            $this->assertStringNotContainsString('Arcane City', $window->title());
+        }
+    }
+
+    public function test_h1(): void
+    {
+        $this->assertSame('Events in Pittsburgh Tonight', EventTimeWindow::Tonight->h1());
+        $this->assertSame('Events in Pittsburgh Today', EventTimeWindow::Today->h1());
+        $this->assertSame('Events in Pittsburgh This Weekend', EventTimeWindow::ThisWeekend->h1());
+        $this->assertSame('Events in Pittsburgh This Week', EventTimeWindow::ThisWeek->h1());
+    }
+
+    // --- meta description grammar ---
+
+    public function test_meta_description_plural_counts(): void
+    {
+        $desc = EventTimeWindow::Tonight->metaDescription([
+            'events' => 5,
+            'venues' => 3,
+            'tags' => ['Techno', 'Punk', 'DIY'],
+        ]);
+
+        $this->assertSame('5 shows tonight across 3 Pittsburgh venues — Techno, Punk, DIY & more.', $desc);
+    }
+
+    public function test_meta_description_singular_counts(): void
+    {
+        $desc = EventTimeWindow::Today->metaDescription([
+            'events' => 1,
+            'venues' => 1,
+            'tags' => ['Jazz'],
+        ]);
+
+        $this->assertSame('1 show today across 1 Pittsburgh venue — Jazz & more.', $desc);
+    }
+
+    public function test_meta_description_weekend_and_week_phrases(): void
+    {
+        $this->assertSame(
+            '2 shows this weekend across 2 Pittsburgh venues — Rock & more.',
+            EventTimeWindow::ThisWeekend->metaDescription(['events' => 2, 'venues' => 2, 'tags' => ['Rock']])
+        );
+
+        $this->assertSame(
+            '10 shows this week across 6 Pittsburgh venues — Rock & more.',
+            EventTimeWindow::ThisWeek->metaDescription(['events' => 10, 'venues' => 6, 'tags' => ['Rock']])
+        );
+    }
+
+    public function test_meta_description_falls_back_when_no_events(): void
+    {
+        $desc = EventTimeWindow::Tonight->metaDescription(['events' => 0, 'venues' => 0, 'tags' => []]);
+
+        $this->assertSame('Live music, club nights and DIY shows in Pittsburgh — updated daily.', $desc);
+    }
+}


### PR DESCRIPTION
## Summary

Part 3 of 6 of the issue #2002 SEO series (base: `2002-seo-title-flip`). The biggest single win of the series: ~18–20k monthly impressions sit on "pittsburgh events {tonight,today,this weekend,this week}" at position 9–13 with ~1% CTR.

Adds four stable, server-rendered, crawlable landing pages: `/events/tonight`, `/events/today`, `/events/this-weekend`, `/events/this-week`.

## Changes

- **`app/Enums/EventTimeWindow.php`** — window boundary logic (America/New_York, injectable clock):
  - today = calendar day; tonight = 17:00 → 03:00 with a <3 AM anchor shift (at 1 AM Saturday, "tonight" is still Friday's shows); this-weekend = Fri 17:00 → Mon 03:00, current weekend through Sunday night; this-week = rolling 7 days. Plus SEO title/h1/meta-description copy with live counts and singular/plural/zero handling.
- **`app/Services/EventTimeWindowStats.php`** — cached (900s, public-only, user-independent key) counts: events, distinct venues, top-3 tags, used in the meta description ("N shows tonight across M Pittsburgh venues — punk, techno, DIY & more.").
- **`app/Http/Controllers/EventTimeWindowController.php`** — slim controller that deliberately bypasses the session-persisted list-parameter stack so crawled output is stable; `Event::visible($user)->between(...)`, shared card eager loads (extracted from `EventsController::cardEventEagerLoad`).
- **View** `events/time-window-tw.blade.php` — h1, intro line matching the meta description, cross-links to sibling windows, card grid, pagination, empty state.
- **JSON-LD** — `events/index-json-ld.blade.php` generalized (backward-compatibly) to accept `$pageUrl/$pageName/$pageDesc`; the pages emit CollectionPage + ItemList of Event + BreadcrumbList.
- **Routes** — 4 explicit named routes above the events resource; `/events/today` repointed here and the old `indexToday` action removed; `/events/week` (visual day grid) untouched.
- **Wiring** — sitemap `PAGES`, sidebar nav (desktop + mobile; Today omitted from nav for space — it's on the homepage row and footer), homepage link row, and a new site footer partial (`partials/footer-tw.blade.php`).

## Test plan

- `tests/Unit/EventTimeWindowTest.php` — boundary matrix with exact-string assertions (Fri 6 PM, Sat 1 AM → Friday's window, Sun 8 PM → current weekend, Mon 2 AM → Sunday anchor, month-boundary crossing, zero-venue meta description).
- `tests/Feature/Web/EventTimeWindowPagesTest.php` — per route: title/meta/JSON-LD/canonical, in-window visible, out-of-window and private absent, `?sort=` noindexed.
- Sitemap command test updated; `composer phpstan` clean; full suite green at branch tip.

## Deploy notes

- `php artisan route:clear` on deploy (new routes).
- Re-run `php artisan sitemap:generate` (or wait for the weekly cron) to pick up the new URLs.

Part of #2002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
