### PR TITLE
SEO: festival year titles + Lineup/Schedule sections [#2002 series 5/6]

### DIFF
--- a/app/Console/Commands/GenerateSitemap.php
+++ b/app/Console/Commands/GenerateSitemap.php
@@ -43,6 +43,10 @@ class GenerateSitemap extends Command
     protected const PAGES = [
         '/',
         '/events',
+        '/events/tonight',
+        '/events/today',
+        '/events/this-weekend',
+        '/events/this-week',
         '/entities',
         '/series',
         '/tags',

--- a/app/Enums/EventTimeWindow.php
+++ b/app/Enums/EventTimeWindow.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace App\Enums;
+
+use Carbon\CarbonImmutable;
+
+/**
+ * The four time-window landing pages: /events/tonight, /events/today,
+ * /events/this-weekend, /events/this-week. Pure date/copy logic only —
+ * no queries, no HTTP. See app/Services/EventTimeWindowStats.php for
+ * counts and app/Http/Controllers/EventTimeWindowController.php for glue.
+ *
+ * All window math happens in America/New_York wall-clock time. Never use
+ * config('app.timezone') here — it's a fixed-offset 'EST' zone and will
+ * silently miscompute DST transitions.
+ */
+enum EventTimeWindow: string
+{
+    case Tonight = 'tonight';
+    case Today = 'today';
+    case ThisWeekend = 'this-weekend';
+    case ThisWeek = 'this-week';
+
+    protected const TIMEZONE = 'America/New_York';
+
+    /**
+     * Inclusive start/end naive 'Y-m-d H:i:s' strings, compared against
+     * events.start_at via Event::scopeBetween().
+     *
+     * @return array{start: string, end: string}
+     */
+    public function range(?CarbonImmutable $now = null): array
+    {
+        $now = $now ?? CarbonImmutable::now(self::TIMEZONE);
+
+        [$start, $end] = match ($this) {
+            self::Today => $this->todayBounds($now),
+            self::ThisWeek => $this->thisWeekBounds($now),
+            self::Tonight => $this->tonightBounds($now),
+            self::ThisWeekend => $this->thisWeekendBounds($now),
+        };
+
+        return [
+            'start' => $start->format('Y-m-d H:i:s'),
+            'end' => $end->format('Y-m-d H:i:s'),
+        ];
+    }
+
+    /**
+     * @return array{0: CarbonImmutable, 1: CarbonImmutable}
+     */
+    private function todayBounds(CarbonImmutable $now): array
+    {
+        $date = $now->startOfDay();
+
+        return [$date, $date->setTime(23, 59, 59)];
+    }
+
+    /**
+     * @return array{0: CarbonImmutable, 1: CarbonImmutable}
+     */
+    private function thisWeekBounds(CarbonImmutable $now): array
+    {
+        $start = $now->startOfDay();
+
+        return [$start, $start->addDays(6)->setTime(23, 59, 59)];
+    }
+
+    /**
+     * @return array{0: CarbonImmutable, 1: CarbonImmutable}
+     */
+    private function tonightBounds(CarbonImmutable $now): array
+    {
+        $anchor = $this->anchorDay($now);
+
+        return [$anchor->setTime(17, 0, 0), $anchor->addDay()->setTime(3, 0, 0)];
+    }
+
+    /**
+     * @return array{0: CarbonImmutable, 1: CarbonImmutable}
+     */
+    private function thisWeekendBounds(CarbonImmutable $now): array
+    {
+        $friday = $this->weekendFriday($now);
+
+        return [$friday->setTime(17, 0, 0), $friday->addDays(3)->setTime(3, 0, 0)];
+    }
+
+    /**
+     * The "anchor day" used by tonight/this-weekend: before 3am, we're still
+     * talking about last night, so the anchor rolls back to yesterday.
+     */
+    private function anchorDay(CarbonImmutable $now): CarbonImmutable
+    {
+        $day = $now->startOfDay();
+
+        return $now->hour < 3 ? $day->subDay() : $day;
+    }
+
+    /**
+     * Friday of the relevant weekend: if the anchor day already falls on
+     * Fri/Sat/Sun, it's that weekend's Friday; otherwise it's the next one.
+     */
+    private function weekendFriday(CarbonImmutable $now): CarbonImmutable
+    {
+        $anchor = $this->anchorDay($now);
+        $isoDow = $anchor->dayOfWeekIso; // 1 = Monday ... 7 = Sunday
+
+        if ($isoDow >= 5) {
+            // Fri (5), Sat (6), Sun (7) -> back up to that week's Friday.
+            return $anchor->subDays($isoDow - 5);
+        }
+
+        // Mon..Thu -> forward to the upcoming Friday.
+        return $anchor->addDays(5 - $isoDow);
+    }
+
+    /**
+     * SEO title, no brand suffix — the layout appends " | Arcane City".
+     */
+    public function title(): string
+    {
+        return match ($this) {
+            self::Tonight => 'Events in Pittsburgh Tonight — Live Music, Shows & More',
+            self::Today => 'Events in Pittsburgh Today — Live Music, Shows & More',
+            self::ThisWeekend => 'Events in Pittsburgh This Weekend — Live Music, Shows & More',
+            self::ThisWeek => 'Events in Pittsburgh This Week — Live Music, Shows & More',
+        };
+    }
+
+    public function h1(): string
+    {
+        return match ($this) {
+            self::Tonight => 'Events in Pittsburgh Tonight',
+            self::Today => 'Events in Pittsburgh Today',
+            self::ThisWeekend => 'Events in Pittsburgh This Weekend',
+            self::ThisWeek => 'Events in Pittsburgh This Week',
+        };
+    }
+
+    public function path(): string
+    {
+        return '/events/'.$this->value;
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Tonight => 'Tonight',
+            self::Today => 'Today',
+            self::ThisWeekend => 'This Weekend',
+            self::ThisWeek => 'This Week',
+        };
+    }
+
+    /**
+     * Window-appropriate adverbial phrase used mid-sentence, e.g.
+     * "5 shows {phrase} across 3 Pittsburgh venues".
+     */
+    private function phrase(): string
+    {
+        return match ($this) {
+            self::Tonight => 'tonight',
+            self::Today => 'today',
+            self::ThisWeekend => 'this weekend',
+            self::ThisWeek => 'this week',
+        };
+    }
+
+    /**
+     * @param array{events?: int, venues?: int, tags?: string[]} $stats
+     */
+    public function metaDescription(array $stats): string
+    {
+        $events = $stats['events'] ?? 0;
+        $venues = $stats['venues'] ?? 0;
+        $tags = $stats['tags'] ?? [];
+
+        if ($events === 0) {
+            return 'Live music, club nights and DIY shows in Pittsburgh — updated daily.';
+        }
+
+        $showWord = $events === 1 ? 'show' : 'shows';
+        $venueWord = $venues === 1 ? 'venue' : 'venues';
+
+        $desc = sprintf(
+            '%d %s %s across %d Pittsburgh %s',
+            $events,
+            $showWord,
+            $this->phrase(),
+            $venues,
+            $venueWord
+        );
+
+        if (! empty($tags)) {
+            $desc .= ' — '.implode(', ', $tags).' & more.';
+        } else {
+            $desc .= '.';
+        }
+
+        return $desc;
+    }
+}

--- a/app/Enums/EventTimeWindow.php
+++ b/app/Enums/EventTimeWindow.php
@@ -181,16 +181,13 @@ enum EventTimeWindow: string
         }
 
         $showWord = $events === 1 ? 'show' : 'shows';
-        $venueWord = $venues === 1 ? 'venue' : 'venues';
 
-        $desc = sprintf(
-            '%d %s %s across %d Pittsburgh %s',
-            $events,
-            $showWord,
-            $this->phrase(),
-            $venues,
-            $venueWord
-        );
+        $desc = sprintf('%d %s %s', $events, $showWord, $this->phrase());
+
+        if ($venues > 0) {
+            $venueWord = $venues === 1 ? 'venue' : 'venues';
+            $desc .= sprintf(' across %d Pittsburgh %s', $venues, $venueWord);
+        }
 
         if (! empty($tags)) {
             $desc .= ' — '.implode(', ', $tags).' & more.';

--- a/app/Http/Controllers/EntitiesController.php
+++ b/app/Http/Controllers/EntitiesController.php
@@ -962,7 +962,9 @@ class EntitiesController extends Controller
                 $query->whereHas('entities', function ($q) use ($entity) {
                     $q->where('entities.id', $entity->id);
                 })->orWhere('venue_id', $entity->id);
-            })->distinct();
+            })
+                ->where(fn ($q) => $q->visible($this->user))
+                ->distinct();
         } else {
             $venueEventsBase = fn () => $entity->events();
         }

--- a/app/Http/Controllers/EntitiesController.php
+++ b/app/Http/Controllers/EntitiesController.php
@@ -11,6 +11,7 @@ use App\Models\Alias;
 use App\Models\Entity;
 use App\Models\EntityStatus;
 use App\Models\EntityType;
+use App\Models\Event;
 use App\Models\Follow;
 use App\Models\Role;
 use App\Models\Tag;
@@ -951,8 +952,23 @@ class EntitiesController extends Controller
             $filterStartAt = Carbon::today()->startOfDay();
         }
 
+        // Venue pages need events found either through the entity_event pivot
+        // (billed as a performer/promoter at their own room) OR via the event's
+        // direct venue_id — many events are only ever linked by venue_id, so a
+        // pivot-only query silently drops them from the venue's own page.
+        // Non-venue entities keep the original pivot-only relation.
+        if ($entity->hasRole('Venue')) {
+            $venueEventsBase = fn () => Event::where(function ($query) use ($entity) {
+                $query->whereHas('entities', function ($q) use ($entity) {
+                    $q->where('entities.id', $entity->id);
+                })->orWhere('venue_id', $entity->id);
+            })->distinct();
+        } else {
+            $venueEventsBase = fn () => $entity->events();
+        }
+
         // get related events (up to 16, sorted by date ascending from the filter date)
-        $relatedEventsQuery = $entity->events()
+        $relatedEventsQuery = $venueEventsBase()
             ->with([
                 'venue.locations',
                 'venue.links',
@@ -973,7 +989,7 @@ class EntitiesController extends Controller
         // get past events (prior to today, most recent first); fetch 21 to detect overflow past the 20 shown
         // Eager-load the relations the past-events grid card reads per event
         // (primary photo, venue, event type, tags) to avoid an N+1.
-        $pastEvents = $entity->events()
+        $pastEvents = $venueEventsBase()
             ->with(['eventType', 'tags', 'venue', 'photos'])
             ->where('start_at', '<', Carbon::today()->startOfDay())
             ->orderBy('start_at', 'desc')

--- a/app/Http/Controllers/EventTimeWindowController.php
+++ b/app/Http/Controllers/EventTimeWindowController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Enums\EventTimeWindow;
+use App\Models\Event;
+use App\Services\EventTimeWindowStats;
+use Illuminate\Contracts\View\View;
+
+/**
+ * Stable, crawlable time-window landing pages: /events/tonight,
+ * /events/today, /events/this-weekend, /events/this-week.
+ *
+ * Deliberately does NOT use ListParameterSessionStore / ListEntityResultBuilder
+ * — these pages must render the same content for every visitor and must not
+ * inherit session filter/sort/tab state from the main /events listing.
+ */
+class EventTimeWindowController extends Controller
+{
+    public function show(string $window, EventTimeWindowStats $stats): View
+    {
+        $timeWindow = EventTimeWindow::tryFrom($window) ?? abort(404);
+
+        $range = $timeWindow->range();
+
+        $events = Event::query()
+            ->visible($this->user)
+            ->between($range['start'], $range['end'])
+            ->with(EventsController::cardEventEagerLoad($this->user))
+            ->paginate(48);
+
+        return view('events.time-window-tw', [
+            'window' => $timeWindow,
+            'events' => $events,
+            'stats' => $stats->stats($timeWindow),
+        ]);
+    }
+}

--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -319,7 +319,7 @@ class EventsController extends Controller
             })
             ->orderBy('start_at', 'ASC')
             ->orderBy('name', 'ASC')
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->paginate($listResultSet->getLimit());
 
         // saves the updated session
@@ -359,17 +359,20 @@ class EventsController extends Controller
      * Eager-loading these keeps each index/filter page a fixed number of queries
      * instead of running venue/type/tag/photo/entity/thread lookups once per card (N+1).
      *
+     * Shared with EventTimeWindowController so the /events/tonight-style
+     * landing pages don't drift from the canonical card eager-load list.
+     *
      * @return array<int|string, string|\Closure>
      */
-    protected function cardEventEagerLoad(): array
+    public static function cardEventEagerLoad(?User $user = null): array
     {
         // venue.locations avoids an N+1 in card-tw's getPrimaryLocationMap()/getPrimaryLocationAddress() (EVENTREPO-W5).
         $eager = ['visibility', 'venue.locations', 'eventType', 'tags', 'photos', 'entities', 'threads'];
 
-        if ($this->user) {
+        if ($user) {
             // The attend/unattend button reads getEventResponse($user)->responseType per card.
-            $eager['eventResponses'] = function ($query) {
-                $query->where('user_id', $this->user->id)->with('responseType');
+            $eager['eventResponses'] = function ($query) use ($user) {
+                $query->where('user_id', $user->id)->with('responseType');
             };
         }
 
@@ -439,7 +442,7 @@ class EventsController extends Controller
         // get the events
         // @phpstan-ignore-next-line
         $events = $query->visible($this->user)
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->paginate($listResultSet->getLimit());
 
         // persist resolved sort values so subsequent requests don't revert to a different default
@@ -896,7 +899,7 @@ class EventsController extends Controller
                 /* @phpstan-ignore-next-line */
                 $query->visible($this->user);
             })
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->paginate($listResultSet->getLimit());
 
         // saves the updated session
@@ -1080,76 +1083,6 @@ class EventsController extends Controller
     }
 
     /**
-     * Display a listing of today's events.
-     *
-     * @return Response|View
-     */
-    public function indexToday(
-        Request $request,
-        ListParameterSessionStore $listParamSessionStore,
-        ListEntityResultBuilder $listEntityResultBuilder
-    ) {
-        // initialized listParamSessionStore with baseindex key
-        $listParamSessionStore->setBaseIndex('internal_event');
-        $listParamSessionStore->setKeyPrefix('internal_event_today');
-
-        // set the index tab in the session
-        $listParamSessionStore->setIndexTab(action([EventsController::class, 'index']));
-
-        // get the base query for today's events and add any necessary joins for sorting
-        $baseQuery = Event::today()->leftJoin('event_types', 'events.event_type_id', '=', 'event_types.id')->select('events.*');
-
-        $listEntityResultBuilder
-            ->setFilter($this->filter)
-            ->setQueryBuilder($baseQuery)
-            ->setDefaultSort(['events.start_at' => 'desc']);
-
-        // get the result set from the builder
-        $listResultSet = $listEntityResultBuilder->listResultSetFactory();
-
-        // get the query builder
-        $query = $listResultSet->getList();
-
-        $query
-            // public or where created by
-            ->where(function ($query) {
-                $query->whereIn('visibility_id', [1, 2])
-                    ->where('created_by', '=', $this->user ? $this->user->id : null);
-                // if logged in, can see guarded
-                if ($this->user) {
-                    $query->orWhere('visibility_id', '=', 4);
-                }
-                $query->orWhere('visibility_id', '=', 3);
-
-                return $query;
-            });
-
-        // get the events
-        $events = $query
-            ->with($this->cardEventEagerLoad())
-            ->paginate($listResultSet->getLimit());
-
-        // saves the updated session
-        $listParamSessionStore->save();
-
-        $this->hasFilter = $listResultSet->getFilters() != $listResultSet->getDefaultFilters() || $listResultSet->getIsEmptyFilter();
-
-        return view('events.index-tw')
-            ->with(array_merge(
-                [
-                    'limit' => $listResultSet->getLimit(),
-                    'sort' => $listResultSet->getSort(),
-                    'direction' => $listResultSet->getSortDirection(),
-                    'hasFilter' => $this->hasFilter,
-                    'filters' => $listResultSet->getFilters(),
-                ],
-                $this->getFilterOptions(),
-                $this->getListControlOptions()
-            ))
-            ->with(compact('events'));
-    }
-
-    /**
      * Display a listing of only past events.
      *
      * @return Response|View
@@ -1186,7 +1119,7 @@ class EventsController extends Controller
                 /* @phpstan-ignore-next-line */
                 $query->visible($this->user);
             })
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->paginate($listResultSet->getLimit());
 
         // saves the updated session
@@ -1248,7 +1181,7 @@ class EventsController extends Controller
 
         // get the events
         $events = $query
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->paginate($listResultSet->getLimit());
 
         // saves the updated session
@@ -2497,7 +2430,7 @@ class EventsController extends Controller
         // @phpstan-ignore-next-line
         $events = $query
             ->visible($this->user)
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->orderBy('events.start_at', 'DESC')
             ->orderBy('events.name', 'ASC')
             ->paginate($listResultSet->getLimit());
@@ -2560,7 +2493,7 @@ class EventsController extends Controller
         // @phpstan-ignore-next-line
         $events = $query
             ->visible($this->user)
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->orderBy('events.start_at', 'ASC')
             ->orderBy('events.name', 'ASC')
             ->paginate($listResultSet->getLimit());
@@ -2629,7 +2562,7 @@ class EventsController extends Controller
         $cdate_tomorrow = $cdate->copy()->addDay();
 
         $events = Event::where('events.start_at', '>', $cdate_yesterday->toDateString())
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->where('events.start_at', '<', $cdate_tomorrow->toDateString())
             ->where(function ($query) {
                 /* @phpstan-ignore-next-line */
@@ -2692,7 +2625,7 @@ class EventsController extends Controller
         $query = $listResultSet->getList();
 
         $events = Event::getByVenue(strtolower($slug))
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->future()
             ->where(function ($query) {
                 /* @phpstan-ignore-next-line */
@@ -2703,7 +2636,7 @@ class EventsController extends Controller
             ->paginate($this->limit);
 
         $past_events = Event::getByVenue(strtolower($slug))
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->past()
             ->where(function ($query) {
                 /* @phpstan-ignore-next-line */
@@ -2769,7 +2702,7 @@ class EventsController extends Controller
         // @phpstan-ignore-next-line
         $events = $query
             ->select('events.*')
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->orderBy('events.start_at', 'ASC')
             ->orderBy('events.name', 'ASC')
             ->paginate($listResultSet->getLimit());
@@ -2832,7 +2765,7 @@ class EventsController extends Controller
         // @phpstan-ignore-next-line
         $events = $futureQuery
             ->visible($this->user)
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->future()
             ->orderBy('events.start_at', 'ASC')
             ->orderBy('events.name', 'ASC')
@@ -2841,7 +2774,7 @@ class EventsController extends Controller
         // @phpstan-ignore-next-line
         $past_events = $pastQuery
             ->visible($this->user)
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->past()
             ->orderBy('events.start_at', 'ASC')
             ->orderBy('events.name', 'ASC')
@@ -3239,7 +3172,7 @@ class EventsController extends Controller
 
         // get the events
         $events = $query
-            ->with($this->cardEventEagerLoad())
+            ->with(self::cardEventEagerLoad($this->user))
             ->paginate($listResultSet->getLimit());
 
         // saves the updated session

--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -891,7 +891,7 @@ class EventsController extends Controller
         $query = $listResultSet->getList();
 
         // get the events
-        $future_events = $query
+        $events = $query
             ->where(function ($query) {
                 /* @phpstan-ignore-next-line */
                 $query->visible($this->user);
@@ -917,7 +917,7 @@ class EventsController extends Controller
                 $this->getFilterOptions(),
                 $this->getListControlOptions()
             ))
-            ->with(compact('future_events'));
+            ->with(compact('events'));
     }
 
     /*
@@ -1181,7 +1181,7 @@ class EventsController extends Controller
         $query = $listResultSet->getList();
 
         // get the events
-        $past_events = $query
+        $events = $query
             ->where(function ($query) {
                 /* @phpstan-ignore-next-line */
                 $query->visible($this->user);
@@ -1206,7 +1206,7 @@ class EventsController extends Controller
                 $this->getFilterOptions(),
                 $this->getListControlOptions()
             ))
-            ->with(compact('past_events'));
+            ->with(compact('events'));
     }
 
     /**
@@ -2628,7 +2628,7 @@ class EventsController extends Controller
         $cdate_yesterday = $cdate->copy()->subDay();
         $cdate_tomorrow = $cdate->copy()->addDay();
 
-        $future_events = Event::where('events.start_at', '>', $cdate_yesterday->toDateString())
+        $events = Event::where('events.start_at', '>', $cdate_yesterday->toDateString())
             ->with($this->cardEventEagerLoad())
             ->where('events.start_at', '<', $cdate_tomorrow->toDateString())
             ->where(function ($query) {
@@ -2658,7 +2658,7 @@ class EventsController extends Controller
                     $this->getListControlOptions()
                 )
             )
-            ->with(compact('future_events'))
+            ->with(compact('events'))
             ->with(compact('cdate'));
     }
 
@@ -2691,7 +2691,7 @@ class EventsController extends Controller
         // get the query builder
         $query = $listResultSet->getList();
 
-        $future_events = Event::getByVenue(strtolower($slug))
+        $events = Event::getByVenue(strtolower($slug))
             ->with($this->cardEventEagerLoad())
             ->future()
             ->where(function ($query) {
@@ -2732,7 +2732,7 @@ class EventsController extends Controller
                     $this->getListControlOptions()
                 )
             )
-            ->with(compact('future_events'))
+            ->with(compact('events'))
             ->with(compact('past_events'))
             ->with(compact('slug'));
     }
@@ -2830,7 +2830,7 @@ class EventsController extends Controller
         $futureQuery = clone $pastQuery;
 
         // @phpstan-ignore-next-line
-        $future_events = $futureQuery
+        $events = $futureQuery
             ->visible($this->user)
             ->with($this->cardEventEagerLoad())
             ->future()
@@ -2866,7 +2866,7 @@ class EventsController extends Controller
                     $this->getListControlOptions()
                 )
             )
-            ->with(compact('future_events'))
+            ->with(compact('events'))
             ->with(compact('past_events'))
             ->with(compact('slug'));
     }

--- a/app/Http/Controllers/SeriesController.php
+++ b/app/Http/Controllers/SeriesController.php
@@ -651,8 +651,11 @@ class SeriesController extends Controller
 
     public function show(Series $series, OembedExtractor $embedExtractor): View
     {
-        // eager-load relations consumed by the page + JSON-LD
-        $series->loadMissing(['photos', 'venue.locations']);
+        // eager-load relations consumed by the page + JSON-LD; upcomingEvent lets
+        // Series::nextEvent() (used by getSeoTitleFormat()/getFestivalYear() below,
+        // for both this request and the view's own title render) reuse the cached
+        // relation instead of re-querying.
+        $series->loadMissing(['photos', 'venue.locations', 'upcomingEvent']);
 
         // Each event renders through events/card-tw, which touches venue, eventType,
         // visibility, tags, photos (getPrimaryPhoto), entities and threads per card —
@@ -666,6 +669,42 @@ class SeriesController extends Controller
         }
         $events = $series->events()->with($eventEager)->paginate($this->childLimit);
 
+        // Upcoming events for the Schedule section: same eager loads as the
+        // archive grid above, but ascending and unpaginated. Built from
+        // Event::query() (rather than $series->events()) so ->visible()'s
+        // local scope type-resolves against Builder<Event> for phpstan.
+        $upcomingEvents = Event::where('series_id', $series->id)
+            ->with($eventEager)
+            ->visible($this->user)
+            ->where('start_at', '>=', now())
+            ->orderBy('start_at', 'asc')
+            ->get();
+
+        // Same year the SEO title uses (next upcoming event, else most recent
+        // past event) — keeps the Schedule heading's year in sync with the title.
+        $festivalYear = $series->getFestivalYear();
+
+        // Lineup: entities attached to the upcoming events above, or — when
+        // there aren't any — entities attached to the most recent edition's
+        // events (those sharing $festivalYear, which falls back to the most
+        // recent past event's year). Two queries at most beyond $upcomingEvents.
+        $lineupEventIds = $upcomingEvents->pluck('id');
+        if ($lineupEventIds->isEmpty() && $festivalYear) {
+            $lineupEventIds = $series->events()->whereYear('start_at', $festivalYear)->pluck('id');
+        }
+
+        $lineupEntities = $lineupEventIds->isEmpty()
+            ? collect()
+            : Entity::select('entities.*')
+                ->selectRaw('COUNT(entity_event.event_id) as frequency')
+                ->join('entity_event', 'entities.id', '=', 'entity_event.entity_id')
+                ->whereIn('entity_event.event_id', $lineupEventIds)
+                ->with('roles')
+                ->groupBy('entities.id')
+                ->orderByDesc('frequency')
+                ->limit(24)
+                ->get();
+
         // posts/briefList renders each thread's posts with their user/tags/entities.
         $threads = $series->threads()
             ->with(['posts.user', 'posts.tags', 'posts.entities'])
@@ -674,7 +713,7 @@ class SeriesController extends Controller
         // Embeds are deferred to an AJAX call via the playlist-tw placeholder.
         $embeds = [];
 
-        return view('series.show-tw', compact('series', 'events', 'threads', 'embeds'));
+        return view('series.show-tw', compact('series', 'events', 'threads', 'embeds', 'upcomingEvents', 'lineupEntities', 'festivalYear'));
     }
 
     public function store(SeriesRequest $request, Series $series): RedirectResponse

--- a/app/Http/Controllers/SeriesController.php
+++ b/app/Http/Controllers/SeriesController.php
@@ -680,17 +680,22 @@ class SeriesController extends Controller
             ->orderBy('start_at', 'asc')
             ->get();
 
-        // Same year the SEO title uses (next upcoming event, else most recent
-        // past event) — keeps the Schedule heading's year in sync with the title.
-        $festivalYear = $series->getFestivalYear();
+        // Edition year (next upcoming event, else most recent past event) —
+        // used to scope the "most recent edition" lineup fallback below for
+        // ANY series. $festivalYear (passed to the view for the Schedule
+        // heading) is the same value, but only for festivals: an ordinary
+        // weekly/monthly series' recurring events aren't "editions" and
+        // shouldn't get a fabricated year in their heading.
+        $editionYear = $series->getFestivalYear();
+        $festivalYear = $series->isFestival() ? $editionYear : null;
 
         // Lineup: entities attached to the upcoming events above, or — when
         // there aren't any — entities attached to the most recent edition's
-        // events (those sharing $festivalYear, which falls back to the most
+        // events (those sharing $editionYear, which falls back to the most
         // recent past event's year). Two queries at most beyond $upcomingEvents.
         $lineupEventIds = $upcomingEvents->pluck('id');
-        if ($lineupEventIds->isEmpty() && $festivalYear) {
-            $lineupEventIds = $series->events()->whereYear('start_at', $festivalYear)->pluck('id');
+        if ($lineupEventIds->isEmpty() && $editionYear) {
+            $lineupEventIds = $series->events()->whereYear('start_at', $editionYear)->pluck('id');
         }
 
         $lineupEntities = $lineupEventIds->isEmpty()

--- a/app/Models/Entity.php
+++ b/app/Models/Entity.php
@@ -854,7 +854,12 @@ class Entity extends Eloquent
 
         if ($this->hasRole('Venue')) {
             $location = $this->getPrimaryLocation();
-            $neighborhoodClause = ($location && !empty($location->neighborhood)) ? ' in ' . $location->neighborhood : '';
+            // Meta descriptions are public (crawlers, guests, everyone) — omit the
+            // neighborhood when the primary location is Guarded, matching the
+            // Guarded-gating the Locations card / facts panel apply for guests.
+            // @phpstan-ignore-next-line (same undefined-property pattern accepted at getPrimaryLocationAddress() above)
+            $locationIsGuarded = $location && isset($location->visibility) && $location->visibility->name === 'Guarded';
+            $neighborhoodClause = ($location && !$locationIsGuarded && !empty($location->neighborhood)) ? ' in ' . $location->neighborhood : '';
 
             return 'See upcoming shows and concerts at ' . $this->name . $neighborhoodClause . ' — full event calendar, capacity, address and photos on Arcane City.';
         }

--- a/app/Models/Entity.php
+++ b/app/Models/Entity.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Collection as SupportCollection;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
 use Str;
 use Storage;
 
@@ -820,6 +821,13 @@ class Entity extends Eloquent
 
     public function getSeoTitleFormat(): string
     {
+        if ($this->hasRole('Venue')) {
+            $location = $this->getPrimaryLocation();
+            $city = ($location && !empty($location->city)) ? $location->city : 'Pittsburgh';
+
+            return $this->name . ' — Upcoming Events & Concerts in ' . $city;
+        }
+
         $format = $this->name;
 
         $roles = $this->roles->take(2)->pluck('name')->toArray();
@@ -844,6 +852,13 @@ class Entity extends Eloquent
             return $this->short;
         }
 
+        if ($this->hasRole('Venue')) {
+            $location = $this->getPrimaryLocation();
+            $neighborhoodClause = ($location && !empty($location->neighborhood)) ? ' in ' . $location->neighborhood : '';
+
+            return 'See upcoming shows and concerts at ' . $this->name . $neighborhoodClause . ' — full event calendar, capacity, address and photos on Arcane City.';
+        }
+
         $sentence = $this->name;
         $roleStr = $this->getRoleString();
         $location = $this->getPrimaryLocation();
@@ -862,6 +877,46 @@ class Entity extends Eloquent
         $sentence .= '. See upcoming shows, past performances, music links, and scene connections on Arcane City.';
 
         return $sentence;
+    }
+
+    /**
+     * Derive an all-ages/entry-age policy from the venue's most recent events.
+     *
+     * Looks at the last 20 events tied to this entity (either via the direct
+     * pivot or as the event's venue_id) ordered by start_at desc, and buckets
+     * their min_age values. Returns null when there is nothing to derive from,
+     * so the facts panel can omit the row entirely.
+     */
+    public function getAgePolicy(): ?string
+    {
+        return Cache::remember('entity-age-policy:' . $this->id, 21600, function () {
+            $minAges = Event::where(function ($query) {
+                $query->whereHas('entities', function ($q) {
+                    $q->where('entities.id', $this->id);
+                })->orWhere('venue_id', $this->id);
+            })
+                ->orderBy('start_at', 'desc')
+                ->limit(20)
+                ->pluck('min_age');
+
+            if ($minAges->isEmpty()) {
+                return null;
+            }
+
+            if ($minAges->every(fn ($age) => empty($age))) {
+                return 'All ages';
+            }
+
+            if ($minAges->every(fn ($age) => !empty($age) && $age >= 21)) {
+                return '21+';
+            }
+
+            if ($minAges->every(fn ($age) => !empty($age) && $age >= 18)) {
+                return '18+';
+            }
+
+            return 'Varies by event';
+        });
     }
 
     public function getSchemaType(): string
@@ -984,6 +1039,10 @@ class Entity extends Eloquent
                 $cityState = $location->city . (!empty($location->state) ? ', ' . $location->state : '');
                 $data['homeLocation'] = ['@type' => 'Place', 'name' => $cityState];
             }
+        }
+
+        if ($schemaType === 'MusicVenue' && $location && !empty($location->capacity)) {
+            $data['maximumAttendeeCapacity'] = (int) $location->capacity;
         }
 
         $sameAs = $this->getSameAsLinks();

--- a/app/Models/Entity.php
+++ b/app/Models/Entity.php
@@ -1030,7 +1030,14 @@ class Entity extends Eloquent
         }
 
         $location = $this->getPrimaryLocation();
-        if ($location && !empty($location->city)) {
+        // JSON-LD is rendered from the model with no request/auth context, so
+        // match getSeoDescriptionFormat()'s convention: treat a Guarded
+        // location as not publicly disclosable and omit it, same as the
+        // facts panel / Locations card do for guests.
+        // @phpstan-ignore-next-line (same undefined-property pattern accepted at getSeoDescriptionFormat() above)
+        $locationIsGuarded = $location && isset($location->visibility) && $location->visibility->name === 'Guarded';
+
+        if ($location && !empty($location->city) && !($schemaType === 'MusicVenue' && $locationIsGuarded)) {
             if ($schemaType === 'MusicVenue' && !empty($location->address_one)) {
                 $data['address'] = [
                     '@type'           => 'PostalAddress',
@@ -1046,7 +1053,7 @@ class Entity extends Eloquent
             }
         }
 
-        if ($schemaType === 'MusicVenue' && $location && !empty($location->capacity)) {
+        if ($schemaType === 'MusicVenue' && $location && !empty($location->capacity) && !$locationIsGuarded) {
             $data['maximumAttendeeCapacity'] = (int) $location->capacity;
         }
 

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -327,6 +327,19 @@ class Event extends Model
     }
 
     /**
+     * Events with a start_at inside the given naive datetime bounds
+     * (inclusive), ordered earliest-first. Used by the time-window landing
+     * pages (/events/tonight, /today, /this-weekend, /this-week).
+     *
+     * @param Builder<Event> $query
+     */
+    public function scopeBetween(Builder $query, string $start, string $end): Builder
+    {
+        return $query->whereBetween('events.start_at', [$start, $end])
+            ->orderBy('events.start_at', 'asc');
+    }
+
+    /**
      * @param Builder<Event> $query 
      */
     public function scopeFuture(Builder $query): Builder

--- a/app/Models/Series.php
+++ b/app/Models/Series.php
@@ -627,6 +627,14 @@ class Series extends Eloquent
             case 'Biweekly':
                 $repeat = $day;
                 break;
+            case 'Yearly':
+                // Yearly series don't repeat on a week/day cadence; the SEO
+                // title (getSeoTitleFormat()) doesn't use this value for
+                // Yearly series at all, but callers that do concatenate it
+                // (e.g. getTitleFormat()) must trim() the result so an empty
+                // string here doesn't leave a dangling space.
+                $repeat = '';
+                break;
         }
 
         return $repeat;
@@ -961,6 +969,77 @@ class Series extends Eloquent
         if ($this->venue) {
             $format .= ' at ';
             $format .= $this->venue->name ?? 'No venue specified';
+        }
+
+        return $format;
+    }
+
+    /**
+     * Whether this series reads as a festival for SEO purposes: an explicit
+     * Festival event type, or a Yearly occurrence (covers annual events —
+     * e.g. "Skull Fest" — that were never tagged with the Festival event
+     * type but only ever happen once a year).
+     */
+    public function isFestival(): bool
+    {
+        if ($this->eventType && 'festival' === $this->eventType->slug) {
+            return true;
+        }
+
+        return (bool) ($this->occurrenceType && 'Yearly' === $this->occurrenceType->name);
+    }
+
+    /**
+     * The year to surface in a festival title/heading: the next upcoming
+     * event's year, else the most recent past event's year, else null when
+     * the series has no events at all.
+     */
+    public function getFestivalYear(): ?int
+    {
+        if ($next = $this->nextEvent()) {
+            return $next->start_at->year;
+        }
+
+        if ($last = $this->lastEvent()) {
+            return $last->start_at->year;
+        }
+
+        return null;
+    }
+
+    /**
+     * SEO-friendly title (does NOT include the site brand — the layout
+     * appends that). Festival series get "{name} {year} — Lineup,
+     * Schedule & Tickets in Pittsburgh" with the year omitted cleanly when
+     * unknown. Non-festival series fall back to "{name} — {OccurrenceType}
+     * {occurrence_repeat} at {venue}", with each clause dropped cleanly
+     * (no dangling separators) when its data is missing. Kept separate
+     * from getTitleFormat(), which other callers still use unchanged.
+     */
+    public function getSeoTitleFormat(): string
+    {
+        if ($this->isFestival()) {
+            $year = $this->getFestivalYear();
+
+            return $this->name.($year ? ' '.$year : '').' — Lineup, Schedule & Tickets in Pittsburgh';
+        }
+
+        $format = $this->name;
+        $clauses = [];
+
+        if ($this->occurrenceType && 'No Schedule' !== $this->occurrenceType->name) {
+            $occurrenceClause = trim($this->occurrenceType->name.' '.$this->occurrence_repeat);
+            if ('' !== $occurrenceClause) {
+                $clauses[] = $occurrenceClause;
+            }
+        }
+
+        if ($this->venue) {
+            $clauses[] = 'at '.($this->venue->name ?? 'No venue specified');
+        }
+
+        if (!empty($clauses)) {
+            $format .= ' — '.implode(' ', $clauses);
         }
 
         return $format;

--- a/app/Services/EventTimeWindowStats.php
+++ b/app/Services/EventTimeWindowStats.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\EventTimeWindow;
+use App\Models\Event;
+use App\Models\Visibility;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Live counts backing the /events/tonight, /today, /this-weekend,
+ * /this-week landing pages: event count, distinct venue count, and the
+ * top tags for the window. Counts are computed against public events only
+ * so the cached value is safe to share across all visitors regardless of
+ * who's signed in.
+ */
+class EventTimeWindowStats
+{
+    protected const CACHE_TTL = 900;
+
+    /**
+     * @return array{events: int, venues: int, tags: string[]}
+     */
+    public function stats(EventTimeWindow $window): array
+    {
+        $range = $window->range();
+
+        $cacheKey = sprintf(
+            'event-window-stats:%s:%s',
+            $window->value,
+            substr($range['start'], 0, 10)
+        );
+
+        return Cache::remember($cacheKey, self::CACHE_TTL, function () use ($range): array {
+            $counts = Event::query()
+                ->where('visibility_id', Visibility::VISIBILITY_PUBLIC)
+                ->between($range['start'], $range['end'])
+                ->selectRaw('COUNT(*) as event_count, COUNT(DISTINCT venue_id) as venue_count')
+                ->toBase()
+                ->first();
+
+            $tags = DB::table('event_tag')
+                ->join('events', 'events.id', '=', 'event_tag.event_id')
+                ->join('tags', 'tags.id', '=', 'event_tag.tag_id')
+                ->where('events.visibility_id', Visibility::VISIBILITY_PUBLIC)
+                ->whereBetween('events.start_at', [$range['start'], $range['end']])
+                ->select('tags.name')
+                ->selectRaw('COUNT(*) as frequency')
+                ->groupBy('tags.name')
+                ->orderByDesc('frequency')
+                ->limit(3)
+                ->pluck('tags.name')
+                ->all();
+
+            return [
+                'events' => $counts ? (int) $counts->event_count : 0,
+                'venues' => $counts ? (int) $counts->venue_count : 0,
+                'tags' => $tags,
+            ];
+        });
+    }
+}

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -15,7 +15,7 @@
 	@yield('google.event.json')
 	<meta name="theme-color" content="#0f172a"/>
 	<meta name="csrf-token" content="{{ csrf_token() }}">
-	<title>@yield('title','Event Guide') • {{ config('app.app_name')}}</title>
+	<title>@yield('title','Event Guide') | {{ config('app.app_name')}}</title>
 
 	<!-- Theme initialization script - must run before page renders to prevent flash -->
 	<script>

--- a/resources/views/entities/show-tw.blade.php
+++ b/resources/views/entities/show-tw.blade.php
@@ -144,6 +144,59 @@
 		</div>
 		@endif
 
+		<!-- Related Events - Full Width -->
+		<div class="mt-6 rounded-lg border border-border bg-card shadow p-6">
+			<div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-4">
+				<h2 class="text-xl font-semibold flex items-center gap-2">
+					<i class="bi bi-calendar-event"></i>
+					Upcoming Events
+				</h2>
+				<!-- Date Filter -->
+				<form method="GET" action="{{ route('entities.show', $entity->slug) }}" class="flex items-center gap-2">
+					<label for="start_at" class="text-sm text-muted-foreground whitespace-nowrap">From date:</label>
+					<input type="date" id="start_at" name="start_at"
+						value="{{ $filterStartAt->format('Y-m-d') }}"
+						class="px-2 py-1 text-sm rounded-md border border-border bg-background text-foreground focus:outline-none focus:ring-1 focus:ring-primary">
+					<button type="submit" class="px-3 py-1 text-sm rounded-md bg-accent border border-border text-foreground hover:bg-accent/80 transition-colors">
+						Filter
+					</button>
+					@if (request()->filled('start_at'))
+					<a href="{{ route('entities.show', $entity->slug) }}" class="px-3 py-1 text-sm rounded-md border border-border text-muted-foreground hover:bg-accent transition-colors">
+						Reset
+					</a>
+					@endif
+				</form>
+			</div>
+
+			{{-- Fragment caching: the event-card partial has per-user content (attend/edit
+			     buttons), so it is only cached for guests — signed-in users (incl. editors)
+			     always render live and see edits immediately. The past-events grid has no
+			     per-user content, so it is cached for everyone. Keys fingerprint the event +
+			     its rendered relations (see Event::cardFingerprint) so any edit busts them. --}}
+			@if (isset($relatedEvents) && count($relatedEvents) > 0)
+				<!-- Events Grid -->
+				<div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-6 mb-6">
+					@foreach ($relatedEvents as $event)
+						@guest
+							{!! Cache::remember('event-card-tw:'.$event->cardFingerprint(), now()->addHours(6), fn () => view('events.card-tw', ['event' => $event])->render()) !!}
+						@else
+							@include('events.card-tw', ['event' => $event])
+						@endguest
+					@endforeach
+					@if (isset($pastEvents) && $pastEvents->count() > 0)
+						{!! Cache::remember('past-events-grid:'.$entity->id.':'.($entity->updated_at?->getTimestamp() ?? '0').':'.md5($pastEvents->map->cardFingerprint()->implode('|')), now()->addHours(6), fn () => view('events.past-events-grid-card-tw', ['pastEvents' => $pastEvents, 'entity' => $entity])->render()) !!}
+					@endif
+				</div>
+			@else
+				<p class="text-muted-foreground mb-4">No upcoming related events found.</p>
+				@if (isset($pastEvents) && $pastEvents->count() > 0)
+					<div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-6 mb-6">
+						{!! Cache::remember('past-events-grid:'.$entity->id.':'.($entity->updated_at?->getTimestamp() ?? '0').':'.md5($pastEvents->map->cardFingerprint()->implode('|')), now()->addHours(6), fn () => view('events.past-events-grid-card-tw', ['pastEvents' => $pastEvents, 'entity' => $entity])->render()) !!}
+					</div>
+				@endif
+			@endif
+		</div>
+
 		<!-- Description -->
 		@if ($entity->description)
 		<div class="rounded-lg border border-border bg-card shadow">
@@ -196,7 +249,12 @@
 
 	<!-- Sidebar -->
 	<div class="space-y-6">
-		
+
+		<!-- Venue Facts -->
+		@if ($entity->hasRole('Venue'))
+		@include('entities.venue-facts-tw', ['entity' => $entity])
+		@endif
+
 		<!-- Entity Details Card -->
 		<div class="rounded-lg border border-border bg-card shadow">
 			<div class="p-4 pt-2 space-y-4">
@@ -475,59 +533,6 @@
 		</div>
 		@endif
 	</div>
-</div>
-
-<!-- Related Events - Full Width -->
-<div class="mt-6 rounded-lg border border-border bg-card shadow p-6">
-	<div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-4">
-		<h2 class="text-xl font-semibold flex items-center gap-2">
-			<i class="bi bi-calendar-event"></i>
-			Upcoming Events
-		</h2>
-		<!-- Date Filter -->
-		<form method="GET" action="{{ route('entities.show', $entity->slug) }}" class="flex items-center gap-2">
-			<label for="start_at" class="text-sm text-muted-foreground whitespace-nowrap">From date:</label>
-			<input type="date" id="start_at" name="start_at"
-				value="{{ $filterStartAt->format('Y-m-d') }}"
-				class="px-2 py-1 text-sm rounded-md border border-border bg-background text-foreground focus:outline-none focus:ring-1 focus:ring-primary">
-			<button type="submit" class="px-3 py-1 text-sm rounded-md bg-accent border border-border text-foreground hover:bg-accent/80 transition-colors">
-				Filter
-			</button>
-			@if (request()->filled('start_at'))
-			<a href="{{ route('entities.show', $entity->slug) }}" class="px-3 py-1 text-sm rounded-md border border-border text-muted-foreground hover:bg-accent transition-colors">
-				Reset
-			</a>
-			@endif
-		</form>
-	</div>
-
-	{{-- Fragment caching: the event-card partial has per-user content (attend/edit
-	     buttons), so it is only cached for guests — signed-in users (incl. editors)
-	     always render live and see edits immediately. The past-events grid has no
-	     per-user content, so it is cached for everyone. Keys fingerprint the event +
-	     its rendered relations (see Event::cardFingerprint) so any edit busts them. --}}
-	@if (isset($relatedEvents) && count($relatedEvents) > 0)
-		<!-- Events Grid -->
-		<div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-6 mb-6">
-			@foreach ($relatedEvents as $event)
-				@guest
-					{!! Cache::remember('event-card-tw:'.$event->cardFingerprint(), now()->addHours(6), fn () => view('events.card-tw', ['event' => $event])->render()) !!}
-				@else
-					@include('events.card-tw', ['event' => $event])
-				@endguest
-			@endforeach
-			@if (isset($pastEvents) && $pastEvents->count() > 0)
-				{!! Cache::remember('past-events-grid:'.$entity->id.':'.($entity->updated_at?->getTimestamp() ?? '0').':'.md5($pastEvents->map->cardFingerprint()->implode('|')), now()->addHours(6), fn () => view('events.past-events-grid-card-tw', ['pastEvents' => $pastEvents, 'entity' => $entity])->render()) !!}
-			@endif
-		</div>
-	@else
-		<p class="text-muted-foreground mb-4">No upcoming related events found.</p>
-		@if (isset($pastEvents) && $pastEvents->count() > 0)
-			<div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-6 mb-6">
-				{!! Cache::remember('past-events-grid:'.$entity->id.':'.($entity->updated_at?->getTimestamp() ?? '0').':'.md5($pastEvents->map->cardFingerprint()->implode('|')), now()->addHours(6), fn () => view('events.past-events-grid-card-tw', ['pastEvents' => $pastEvents, 'entity' => $entity])->render()) !!}
-			</div>
-		@endif
-	@endif
 </div>
 
 @stop

--- a/resources/views/entities/show-tw.blade.php
+++ b/resources/views/entities/show-tw.blade.php
@@ -144,7 +144,7 @@
 		</div>
 		@endif
 
-		<!-- Related Events - Full Width -->
+		<!-- Upcoming Events - Full Width -->
 		<div class="mt-6 rounded-lg border border-border bg-card shadow p-6">
 			<div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-4">
 				<h2 class="text-xl font-semibold flex items-center gap-2">
@@ -170,8 +170,7 @@
 
 			{{-- Fragment caching: the event-card partial has per-user content (attend/edit
 			     buttons), so it is only cached for guests — signed-in users (incl. editors)
-			     always render live and see edits immediately. The past-events grid has no
-			     per-user content, so it is cached for everyone. Keys fingerprint the event +
+			     always render live and see edits immediately. Keys fingerprint the event +
 			     its rendered relations (see Event::cardFingerprint) so any edit busts them. --}}
 			@if (isset($relatedEvents) && count($relatedEvents) > 0)
 				<!-- Events Grid -->
@@ -183,17 +182,9 @@
 							@include('events.card-tw', ['event' => $event])
 						@endguest
 					@endforeach
-					@if (isset($pastEvents) && $pastEvents->count() > 0)
-						{!! Cache::remember('past-events-grid:'.$entity->id.':'.($entity->updated_at?->getTimestamp() ?? '0').':'.md5($pastEvents->map->cardFingerprint()->implode('|')), now()->addHours(6), fn () => view('events.past-events-grid-card-tw', ['pastEvents' => $pastEvents, 'entity' => $entity])->render()) !!}
-					@endif
 				</div>
 			@else
 				<p class="text-muted-foreground mb-4">No upcoming related events found.</p>
-				@if (isset($pastEvents) && $pastEvents->count() > 0)
-					<div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-6 mb-6">
-						{!! Cache::remember('past-events-grid:'.$entity->id.':'.($entity->updated_at?->getTimestamp() ?? '0').':'.md5($pastEvents->map->cardFingerprint()->implode('|')), now()->addHours(6), fn () => view('events.past-events-grid-card-tw', ['pastEvents' => $pastEvents, 'entity' => $entity])->render()) !!}
-					</div>
-				@endif
 			@endif
 		</div>
 
@@ -534,6 +525,22 @@
 		@endif
 	</div>
 </div>
+
+<!-- Past Events - Full Width -->
+@if (isset($pastEvents) && $pastEvents->count() > 0)
+<div class="mt-6 rounded-lg border border-border bg-card shadow p-6">
+	<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+		<i class="bi bi-calendar-event"></i>
+		Past Events
+	</h2>
+	{{-- Fragment caching: the past-events grid has no per-user content, so it is
+	     cached for everyone. Key fingerprints the event + its rendered relations
+	     (see Event::cardFingerprint) so any edit busts it. --}}
+	<div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-6 mb-6">
+		{!! Cache::remember('past-events-grid:'.$entity->id.':'.($entity->updated_at?->getTimestamp() ?? '0').':'.md5($pastEvents->map->cardFingerprint()->implode('|')), now()->addHours(6), fn () => view('events.past-events-grid-card-tw', ['pastEvents' => $pastEvents, 'entity' => $entity])->render()) !!}
+	</div>
+</div>
+@endif
 
 @stop
 

--- a/resources/views/entities/title-crumbs.blade.php
+++ b/resources/views/entities/title-crumbs.blade.php
@@ -1,12 +1,12 @@
 @if (isset($tag))
-• {{ ucfirst($tag->name)}}
+— {{ ucfirst($tag->name)}}
 @endif
 @if (isset($role))
-• {{ ucfirst($role) }}
+— {{ ucfirst($role) }}
 @endif
 @if (isset($type))
-• {{ ucfirst($type) }}
+— {{ ucfirst($type) }}
 @endif
 @if (isset($slug))
-• {{ strtoupper($name) }}
+— {{ strtoupper($name) }}
 @endif 

--- a/resources/views/entities/venue-facts-tw.blade.php
+++ b/resources/views/entities/venue-facts-tw.blade.php
@@ -2,6 +2,11 @@
      Included in the sidebar above the Entity Details card, venue entities only. --}}
 @php
 	$venueFactsLocation = $entity->getPrimaryLocation();
+	// Match the Locations card's Guarded gating (show-tw.blade.php's Locations card):
+	// a Guarded location's address/capacity are only shown to signed-in users.
+	$venueFactsLocationVisible = $venueFactsLocation
+		&& isset($venueFactsLocation->visibility)
+		&& ($venueFactsLocation->visibility->name != 'Guarded' || $signedIn);
 	$venueFactsAgePolicy = $entity->getAgePolicy();
 	$venueFactsWebsite = $entity->primaryLink();
 	$venueFactsPhotoCount = $entity->photos->count();
@@ -15,14 +20,14 @@
 	</h2>
 
 	<dl class="space-y-4 text-sm">
-		@if ($venueFactsLocation && !empty($venueFactsLocation->capacity))
+		@if ($venueFactsLocationVisible && !empty($venueFactsLocation->capacity))
 		<div>
 			<dt class="font-medium text-muted-foreground">Capacity</dt>
 			<dd class="text-foreground mt-0.5">{{ $venueFactsLocation->capacity }}</dd>
 		</div>
 		@endif
 
-		@if ($venueFactsLocation && !empty($venueFactsLocation->address_one))
+		@if ($venueFactsLocationVisible && !empty($venueFactsLocation->address_one))
 		<div>
 			<dt class="font-medium text-muted-foreground">Address</dt>
 			<dd class="text-foreground mt-0.5">

--- a/resources/views/entities/venue-facts-tw.blade.php
+++ b/resources/views/entities/venue-facts-tw.blade.php
@@ -1,0 +1,77 @@
+{{-- Venue facts card: quick-scan capacity/address/ages/links/photos for venue entity pages.
+     Included in the sidebar above the Entity Details card, venue entities only. --}}
+@php
+	$venueFactsLocation = $entity->getPrimaryLocation();
+	$venueFactsAgePolicy = $entity->getAgePolicy();
+	$venueFactsWebsite = $entity->primaryLink();
+	$venueFactsPhotoCount = $entity->photos->count();
+	$venueFactsHasSocial = $entity->facebook_username || $entity->twitter_username || $entity->instagram_username;
+@endphp
+
+<div class="rounded-lg border border-border bg-card shadow p-6">
+	<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+		<i class="bi bi-clipboard-data"></i>
+		Venue Facts
+	</h2>
+
+	<dl class="space-y-4 text-sm">
+		@if ($venueFactsLocation && !empty($venueFactsLocation->capacity))
+		<div>
+			<dt class="font-medium text-muted-foreground">Capacity</dt>
+			<dd class="text-foreground mt-0.5">{{ $venueFactsLocation->capacity }}</dd>
+		</div>
+		@endif
+
+		@if ($venueFactsLocation && !empty($venueFactsLocation->address_one))
+		<div>
+			<dt class="font-medium text-muted-foreground">Address</dt>
+			<dd class="text-foreground mt-0.5">
+				{{ $venueFactsLocation->address_one }}
+				@if ($venueFactsLocation->neighborhood)
+					&middot; {{ $venueFactsLocation->neighborhood }}
+				@endif
+				<br>
+				{{ $venueFactsLocation->city }}@if ($venueFactsLocation->state), {{ $venueFactsLocation->state }}@endif
+			</dd>
+		</div>
+		@endif
+
+		@if ($venueFactsAgePolicy)
+		<div>
+			<dt class="font-medium text-muted-foreground">Ages</dt>
+			<dd class="text-foreground mt-0.5">{{ $venueFactsAgePolicy }}</dd>
+		</div>
+		@endif
+
+		@if ($venueFactsWebsite || $venueFactsHasSocial)
+		<div>
+			<dt class="font-medium text-muted-foreground">Links</dt>
+			<dd class="text-foreground mt-1 flex flex-wrap gap-3">
+				@if ($venueFactsWebsite)
+				<a href="{{ $venueFactsWebsite->url }}" target="_blank" class="text-primary hover:text-primary/90">Website</a>
+				@endif
+				@if ($entity->facebook_username)
+				<a href="https://facebook.com/{{ $entity->facebook_username }}" target="_blank" class="text-primary hover:text-primary/90">Facebook</a>
+				@endif
+				@if ($entity->twitter_username)
+				<a href="https://twitter.com/{{ $entity->twitter_username }}" target="_blank" class="text-primary hover:text-primary/90">Twitter / X</a>
+				@endif
+				@if ($entity->instagram_username)
+				<a href="https://instagram.com/{{ $entity->instagram_username }}" target="_blank" class="text-primary hover:text-primary/90">Instagram</a>
+				@endif
+			</dd>
+		</div>
+		@endif
+
+		@if ($venueFactsPhotoCount > 0)
+		<div>
+			<dt class="font-medium text-muted-foreground">Photos</dt>
+			<dd class="text-foreground mt-0.5">
+				<a href="#photo-gallery" class="text-primary hover:text-primary/90">
+					{{ $venueFactsPhotoCount }} {{ Str::plural('photo', $venueFactsPhotoCount) }}
+				</a>
+			</dd>
+		</div>
+		@endif
+	</dl>
+</div>

--- a/resources/views/events/index-json-ld.blade.php
+++ b/resources/views/events/index-json-ld.blade.php
@@ -36,11 +36,11 @@
     }
 
     $isTagPage  = isset($tag);
-    $pageUrl    = $isTagPage ? route('events.tag', $tag->slug) : route('events.index');
-    $pageName   = $isTagPage ? (ucfirst($tag->name) . ' Events') : 'Events';
-    $pageDesc   = $isTagPage
+    $pageUrl    = $pageUrl ?? ($isTagPage ? route('events.tag', $tag->slug) : route('events.index'));
+    $pageName   = $pageName ?? ($isTagPage ? (ucfirst($tag->name) . ' Events') : 'Events');
+    $pageDesc   = $pageDesc ?? ($isTagPage
         ? ('Events tagged with ' . $tag->name . ' in Pittsburgh')
-        : 'Upcoming events, concerts and shows in Pittsburgh';
+        : 'Upcoming events, concerts and shows in Pittsburgh');
 
     $jsonLd = [
         '@context'    => 'https://schema.org',
@@ -62,6 +62,13 @@
             '@type'    => 'ListItem',
             'position' => 2,
             'name'     => ucfirst($tag->name),
+            'item'     => $pageUrl,
+        ];
+    } elseif ($pageUrl !== route('events.index')) {
+        $breadcrumbItems[] = [
+            '@type'    => 'ListItem',
+            'position' => 2,
+            'name'     => $pageName,
             'item'     => $pageUrl,
         ];
     }

--- a/resources/views/events/index-tw.blade.php
+++ b/resources/views/events/index-tw.blade.php
@@ -1,7 +1,11 @@
 @extends('layouts.app-tw')
 
 @section('title')
+@if (isset($tag) || isset($related) || isset($type) || isset($slug) || isset($cdate))
 Events @include('events.title-crumbs')
+@else
+Pittsburgh Events Calendar — Concerts, Shows & More
+@endif
 @endsection
 
 @if (isset($events) && count($events) > 0)

--- a/resources/views/events/time-window-tw.blade.php
+++ b/resources/views/events/time-window-tw.blade.php
@@ -1,0 +1,65 @@
+@extends('layouts.app-tw')
+
+@section('title', $window->title())
+
+@php
+    $desc = $window->metaDescription($stats);
+@endphp
+
+@section('description', $desc)
+@section('og-description', $desc)
+
+@if ($events->isNotEmpty())
+@section('page.json')
+@include('events.index-json-ld', [
+    'pageUrl' => url($window->path()),
+    'pageName' => $window->h1(),
+    'pageDesc' => $desc,
+])
+@endsection
+@endif
+
+@section('content')
+
+<!-- Page Header -->
+<div class="mb-6">
+	<h1 class="text-3xl font-bold text-primary mb-2">{{ $window->h1() }}</h1>
+	<p class="text-muted-foreground">{{ $desc }}</p>
+</div>
+
+<!-- Other windows -->
+<div class="mb-6 flex flex-wrap gap-2">
+	@foreach (\App\Enums\EventTimeWindow::cases() as $otherWindow)
+	<a href="{{ url($otherWindow->path()) }}"
+		class="inline-flex items-center px-3 py-1 rounded-full text-sm border transition-colors {{ $otherWindow === $window ? 'bg-primary text-primary-foreground border-primary' : 'border-border text-muted-foreground hover:bg-accent' }}">
+		{{ $otherWindow->label() }}
+	</a>
+	@endforeach
+</div>
+
+@if ($events->isNotEmpty())
+<div class="mb-4">
+	{!! $events->onEachSide(2)->links('vendor.pagination.tailwind') !!}
+</div>
+
+<div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-6">
+	@foreach ($events as $event)
+	@include('events.card-tw', ['event' => $event])
+	@endforeach
+</div>
+
+<div class="mt-4">
+	{!! $events->onEachSide(2)->links('vendor.pagination.tailwind') !!}
+</div>
+@else
+<div class="text-center py-12">
+	<i class="bi bi-calendar-x text-6xl text-muted-foreground/60 mb-4"></i>
+	<p class="text-muted-foreground">No events found for this window yet.</p>
+	<a href="{{ url('/events') }}" class="mt-4 inline-flex items-center text-primary hover:text-primary/90">
+		<i class="bi bi-arrow-left mr-2"></i>
+		View all events
+	</a>
+</div>
+@endif
+
+@endsection

--- a/resources/views/events/title-crumbs.blade.php
+++ b/resources/views/events/title-crumbs.blade.php
@@ -1,15 +1,15 @@
 @if (isset($tag))
-• {{ ucfirst($tag->name) }}
+— {{ ucfirst($tag->name) }}
 @endif
 @if (isset($related))
-• {{ ucfirst($related->name) }}
+— {{ ucfirst($related->name) }}
 @endif
 @if (isset($type))
-• {{ ucfirst($type) }}
+— {{ ucfirst($type) }}
 @endif
 @if (isset($slug))
-• {{ ucfirst($slug) }}
+— {{ ucfirst($slug) }}
 @endif
 @if (isset($cdate))
-• {{ $cdate->toDateString() }}
+— {{ $cdate->toDateString() }}
 @endif

--- a/resources/views/layouts/app-tw.blade.php
+++ b/resources/views/layouts/app-tw.blade.php
@@ -107,6 +107,8 @@
 			<!-- Main Content Area -->
 			<main class="flex-1 min-w-0 w-full mx-auto p-4 md:p-6 overflow-x-hidden overflow-y-auto bg-background max-w-[2400px]">
 				@yield('content')
+
+				@include('partials.footer-tw')
 			</main>
 		</div>
 	</div>

--- a/resources/views/layouts/app-tw.blade.php
+++ b/resources/views/layouts/app-tw.blade.php
@@ -27,7 +27,7 @@
 	@yield('page.json')
 	<meta name="theme-color" content="#0f172a"/>
 	<meta name="csrf-token" content="{{ csrf_token() }}">
-	<title>@yield('title','Event Guide') • {{ config('app.app_name')}}</title>
+	<title>@yield('title','Event Guide') | {{ config('app.app_name')}}</title>
 
 	<!-- Theme initialization script - must run before page renders to prevent flash -->
 	<script>

--- a/resources/views/minimal.blade.php
+++ b/resources/views/minimal.blade.php
@@ -10,7 +10,7 @@
 	<meta property="og:image" content="@yield('og-image', url('/').'/apple-icon-180x180.png')">
 	<meta property="og:description" content="@yield('og-description', 'A calender of events, concerts, club nights, weekly and monthly events series, promoters, artists, producers, djs, venues and other entities.')">
 	<meta name="description" content="A calender of events, concerts, club nights, weekly and monthly events series, promoters, artists, producers, djs, venues and other entities.">
-	<title>@yield('title','Event Guide') • {{ config('app.app_name')}}</title>
+	<title>@yield('title','Event Guide') | {{ config('app.app_name')}}</title>
 	
 	<link rel="manifest" href="/manifest.json">
     <link rel="apple-touch-icon" href="/apple-icon-180x180.png">

--- a/resources/views/pages/home-tw.blade.php
+++ b/resources/views/pages/home-tw.blade.php
@@ -132,13 +132,22 @@
 
 <!-- Upcoming Events Section -->
 <section id="upcoming-events" class="space-y-6">
-	<div class="flex items-center justify-between">
+	<div class="flex flex-wrap items-center justify-between gap-2">
 		<h2 class="text-2xl md:text-3xl font-bold text-foreground">Upcoming Events</h2>
 		<a href="{!! URL::route('events.index') !!}"
 			class="text-sm font-medium text-primary hover:text-primary/90 transition-colors inline-flex items-center gap-1">
 			View All
 			<i class="bi bi-arrow-right"></i>
 		</a>
+	</div>
+
+	<div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
+		@foreach (\App\Enums\EventTimeWindow::cases() as $window)
+		<a href="{{ url($window->path()) }}" class="hover:text-primary transition-colors">{{ $window->label() }}</a>
+		@if (!$loop->last)
+		<span aria-hidden="true">&middot;</span>
+		@endif
+		@endforeach
 	</div>
 
 	@include('events.4days-tw')

--- a/resources/views/partials/footer-tw.blade.php
+++ b/resources/views/partials/footer-tw.blade.php
@@ -1,0 +1,17 @@
+<footer class="mt-12 border-t border-border py-6 text-sm text-muted-foreground">
+	<div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+		<span class="font-semibold text-foreground">{{ config('app.app_name') }}</span>
+		@foreach (\App\Enums\EventTimeWindow::cases() as $window)
+		<span aria-hidden="true">&middot;</span>
+		<a href="{{ url($window->path()) }}" class="hover:text-primary transition-colors">{{ $window->label() }}</a>
+		@endforeach
+		<span aria-hidden="true">&middot;</span>
+		<a href="{{ url('/events') }}" class="hover:text-primary transition-colors">Events</a>
+		<span aria-hidden="true">&middot;</span>
+		<a href="{{ url('/entities') }}" class="hover:text-primary transition-colors">Entities</a>
+		<span aria-hidden="true">&middot;</span>
+		<a href="{{ url('/series') }}" class="hover:text-primary transition-colors">Series</a>
+		<span aria-hidden="true">&middot;</span>
+		<a href="{{ url('/tags') }}" class="hover:text-primary transition-colors">Tags</a>
+	</div>
+</footer>

--- a/resources/views/partials/photo-gallery-tw.blade.php
+++ b/resources/views/partials/photo-gallery-tw.blade.php
@@ -35,7 +35,7 @@
 @endphp
 
 @if ($galleryPhotos->count() > 0)
-<div class="rounded-lg border border-dark-border bg-card shadow p-8 p-4 pt-4 space-y-4">
+<div id="photo-gallery" class="rounded-lg border border-dark-border bg-card shadow p-8 p-4 pt-4 space-y-4">
 	<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
 		<i class="bi bi-images"></i>
 		Photos

--- a/resources/views/partials/sidebar-tw.blade.php
+++ b/resources/views/partials/sidebar-tw.blade.php
@@ -32,6 +32,18 @@
                 <span>Events</span>
             </a>
             <div class="ml-8 space-y-1 mt-1">
+                <a href="{{ url('/events/tonight') }}" class="nav-item-tw text-sm {{ Request::is('events/tonight') ? 'nav-item-active-tw' : '' }}">
+                    <i class="bi bi-moon-stars text-sm"></i>
+                    <span>Tonight</span>
+                </a>
+                <a href="{{ url('/events/this-weekend') }}" class="nav-item-tw text-sm {{ Request::is('events/this-weekend') ? 'nav-item-active-tw' : '' }}">
+                    <i class="bi bi-calendar-week text-sm"></i>
+                    <span>This Weekend</span>
+                </a>
+                <a href="{{ url('/events/this-week') }}" class="nav-item-tw text-sm {{ Request::is('events/this-week') ? 'nav-item-active-tw' : '' }}">
+                    <i class="bi bi-calendar-range text-sm"></i>
+                    <span>This Week</span>
+                </a>
                 <a href="{{ url('/events/grid') }}" class="nav-item-tw text-sm {{ Request::is('events/grid') ? 'nav-item-active-tw' : '' }}">
                     <i class="bi bi-grid text-sm"></i>
                     <span>Event Grid</span>
@@ -189,6 +201,18 @@
                 <span>Events</span>
             </a>
             <div class="ml-8 space-y-1 mt-1">
+                <a href="{{ url('/events/tonight') }}" class="nav-item-tw text-sm {{ Request::is('events/tonight') ? 'nav-item-active-tw' : '' }}">
+                    <i class="bi bi-moon-stars text-sm"></i>
+                    <span>Tonight</span>
+                </a>
+                <a href="{{ url('/events/this-weekend') }}" class="nav-item-tw text-sm {{ Request::is('events/this-weekend') ? 'nav-item-active-tw' : '' }}">
+                    <i class="bi bi-calendar-week text-sm"></i>
+                    <span>This Weekend</span>
+                </a>
+                <a href="{{ url('/events/this-week') }}" class="nav-item-tw text-sm {{ Request::is('events/this-week') ? 'nav-item-active-tw' : '' }}">
+                    <i class="bi bi-calendar-range text-sm"></i>
+                    <span>This Week</span>
+                </a>
                 <a href="{{ url('/events/grid') }}" class="nav-item-tw text-sm {{ Request::is('events/grid') ? 'nav-item-active-tw' : '' }}">
                     <i class="bi bi-grid text-sm"></i>
                     <span>Event Grid</span>

--- a/resources/views/series/show-tw.blade.php
+++ b/resources/views/series/show-tw.blade.php
@@ -5,7 +5,7 @@
 <link rel="canonical" href="{{ \App\Services\SeoMeta::canonicalFor('/series/'.$series->slug) }}">
 @endsection
 
-@section('title', $series->getTitleFormat())
+@section('title', $series->getSeoTitleFormat())
 @section('og-description', $series->short)
 
 @section('og-image')
@@ -330,11 +330,55 @@
 	</div>
 </div>
 
+<!-- Lineup - Full Width -->
+@if (isset($lineupEntities) && $lineupEntities->isNotEmpty())
+<div class="mt-6 rounded-lg border border-border bg-card shadow p-6">
+	<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+		<i class="bi bi-people"></i>
+		Lineup
+	</h2>
+	<div class="flex flex-wrap gap-2">
+		@foreach ($lineupEntities as $lineupEntity)
+			<x-entity-badge :entity="$lineupEntity" />
+		@endforeach
+	</div>
+</div>
+@endif
+
+<!-- Schedule - Full Width -->
+@if (isset($upcomingEvents) && $upcomingEvents->isNotEmpty())
+<div class="mt-6 rounded-lg border border-border bg-card shadow p-6">
+	<h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
+		<i class="bi bi-calendar-week"></i>
+		{{ $series->name }}{{ $festivalYear ? ' '.$festivalYear : '' }} Schedule
+	</h2>
+	<div class="space-y-4">
+		@foreach ($upcomingEvents->groupBy(fn ($event) => $event->start_at->format('l, F jS Y')) as $scheduleDate => $scheduleEvents)
+			<div>
+				<div class="text-sm font-semibold text-muted-foreground mb-2">{{ $scheduleDate }}</div>
+				<ul class="space-y-1">
+					@foreach ($scheduleEvents as $scheduleEvent)
+						<li class="flex flex-wrap items-center justify-between gap-2 text-sm">
+							<a href="{{ route('events.show', ['event' => $scheduleEvent->slug]) }}" class="text-primary hover:underline">
+								{{ $scheduleEvent->name }}
+							</a>
+							@if ($scheduleEvent->venue)
+								<span class="text-muted-foreground">{{ $scheduleEvent->venue->name }}</span>
+							@endif
+						</li>
+					@endforeach
+				</ul>
+			</div>
+		@endforeach
+	</div>
+</div>
+@endif
+
 <!-- Events - Full Width -->
 <div class="mt-6 rounded-lg border border-border bg-card shadow p-6">
 	<h3 class="text-xl font-semibold mb-4 flex items-center gap-2">
 		<i class="bi bi-calendar-event"></i>
-		Events
+		Past Events &amp; Archive
 		@if (isset($events))
 			<span class="text-sm font-normal text-muted-foreground ml-2">({{ $events->total() }})</span>
 		@endif

--- a/resources/views/tags/index.blade.php
+++ b/resources/views/tags/index.blade.php
@@ -2,7 +2,7 @@
 
 @section('title')
 @if (isset($tag))
-Keyword Tag • {{ $tag }}
+Keyword Tag — {{ $tag }}
 @else
 Keyword Tags
 @endif

--- a/resources/views/tags/show-tw.blade.php
+++ b/resources/views/tags/show-tw.blade.php
@@ -9,7 +9,7 @@
 
 @section('title')
 @if (isset($tag))
-{{ $tag }} Events, Artists & Series in Pittsburgh
+{{ Str::ucfirst($tag) }} Events, Artists & Series in Pittsburgh
 @else
 Tags
 @endif

--- a/resources/views/tags/show-tw.blade.php
+++ b/resources/views/tags/show-tw.blade.php
@@ -9,7 +9,7 @@
 
 @section('title')
 @if (isset($tag))
-{{ $tag }} • Tag
+{{ $tag }} Events, Artists & Series in Pittsburgh
 @else
 Tags
 @endif
@@ -41,8 +41,8 @@ Tags
 					@if ($tagObject->tagType)
 					<p class="text-xl text-muted-foreground mt-1">{{ $tagObject->tagType->name }}</p>
 					@endif
-					@if ($tagObject->tag_definition)
-					<p class="mt-2 text-muted-foreground">{{ $tagObject->tag_definition }}</p>
+					@if ($tagObject->description)
+					<p class="mt-2 text-muted-foreground">{{ $tagObject->description }}</p>
 					@endif
 				@endif
 			</div>

--- a/resources/views/users/title-crumbs.blade.php
+++ b/resources/views/users/title-crumbs.blade.php
@@ -1,6 +1,6 @@
 @if (isset($user))
-• {{ ucfirst($user->name) }}
+— {{ ucfirst($user->name) }}
 @endif
 @if (isset($slug))
-• {{ ucfirst($slug) }}
+— {{ ucfirst($slug) }}
 @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -243,7 +243,10 @@ Route::get('update', function () {
     EventUpdated::dispatch(new Event());
 });
 
-Route::get('events/today', [\App\Http\Controllers\EventsController::class, 'indexToday']);
+Route::get('events/tonight', [\App\Http\Controllers\EventTimeWindowController::class, 'show'])->defaults('window', 'tonight')->name('events.tonight');
+Route::get('events/today', [\App\Http\Controllers\EventTimeWindowController::class, 'show'])->defaults('window', 'today')->name('events.today');
+Route::get('events/this-weekend', [\App\Http\Controllers\EventTimeWindowController::class, 'show'])->defaults('window', 'this-weekend')->name('events.thisWeekend');
+Route::get('events/this-week', [\App\Http\Controllers\EventTimeWindowController::class, 'show'])->defaults('window', 'this-week')->name('events.thisWeek');
 Route::match(['get', 'post'], 'events/grid', [\App\Http\Controllers\EventsController::class, 'indexGrid'])->name('events.grid');
 Route::get('events/grid/tag/{slug}', [\App\Http\Controllers\EventsController::class, 'indexGridTags'])->name('events.grid.tag');
 Route::get('events/grid/by-date/{year}/{month?}/{day?}', [\App\Http\Controllers\EventsController::class, 'indexGridByDate'])->name('events.grid.byDate')

--- a/tests/Feature/Console/GenerateSitemapCommandTest.php
+++ b/tests/Feature/Console/GenerateSitemapCommandTest.php
@@ -67,6 +67,17 @@ class GenerateSitemapCommandTest extends TestCase
         }
     }
 
+    public function test_includes_the_time_window_landing_pages(): void
+    {
+        $content = $this->generate();
+
+        $base = rtrim(config('app.url'), '/');
+        $this->assertStringContainsString($base.'/events/tonight', $content);
+        $this->assertStringContainsString($base.'/events/today', $content);
+        $this->assertStringContainsString($base.'/events/this-weekend', $content);
+        $this->assertStringContainsString($base.'/events/this-week', $content);
+    }
+
     public function test_includes_public_content_and_excludes_non_public(): void
     {
         $public = Event::factory()->create([

--- a/tests/Feature/SeoTitlePatternTest.php
+++ b/tests/Feature/SeoTitlePatternTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\Tag;
+use App\Models\Visibility;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SeoTitlePatternTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    protected function appName(): string
+    {
+        return config('app.app_name');
+    }
+
+    public function test_home_page_title_is_query_forward(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertOk();
+        $response->assertSee('| '.$this->appName().'</title>', false);
+        $response->assertDontSee("\u{2022} ".$this->appName().'</title>', false);
+    }
+
+    public function test_events_index_title_is_query_forward_and_generic(): void
+    {
+        $response = $this->get('/events');
+
+        $response->assertOk();
+        $response->assertSee('| '.$this->appName().'</title>', false);
+        $response->assertDontSee("\u{2022} ".$this->appName().'</title>', false);
+        $response->assertSee('Pittsburgh Events Calendar', false);
+    }
+
+    public function test_event_show_title_is_query_forward(): void
+    {
+        $event = Event::factory()->create(['visibility_id' => Visibility::VISIBILITY_PUBLIC]);
+
+        $response = $this->get('/events/'.$event->id);
+
+        $response->assertOk();
+        $response->assertSee('| '.$this->appName().'</title>', false);
+        $response->assertDontSee("\u{2022} ".$this->appName().'</title>', false);
+    }
+
+    public function test_tag_show_page_renders_tag_description(): void
+    {
+        $tag = Tag::factory()->create([
+            'name' => 'Description Probe',
+            'slug' => 'description-probe',
+            'description' => 'A tag used only to verify the description renders.',
+        ]);
+
+        $response = $this->get('/tags/'.$tag->slug);
+
+        $response->assertOk();
+        $response->assertSee('A tag used only to verify the description renders.', false);
+    }
+}

--- a/tests/Feature/SeoTitlePatternTest.php
+++ b/tests/Feature/SeoTitlePatternTest.php
@@ -68,4 +68,18 @@ class SeoTitlePatternTest extends TestCase
         $response->assertOk();
         $response->assertSee('A tag used only to verify the description renders.', false);
     }
+
+    public function test_tag_show_page_title_capitalizes_lowercase_tag_name(): void
+    {
+        $tag = Tag::factory()->create([
+            'name' => 'lowercase tag',
+            'slug' => 'lowercase-tag',
+        ]);
+
+        $response = $this->get('/tags/'.$tag->slug);
+
+        $response->assertOk();
+        $response->assertSee('<title>Lowercase Tag Events, Artists & Series in Pittsburgh', false);
+        $response->assertDontSee('<title>lowercase Tag Events', false);
+    }
 }

--- a/tests/Feature/SeriesSeoTest.php
+++ b/tests/Feature/SeriesSeoTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Entity;
+use App\Models\Event;
+use App\Models\EventType;
+use App\Models\OccurrenceDay;
+use App\Models\OccurrenceType;
+use App\Models\Series;
+use App\Models\Visibility;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SeriesSeoTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    private function occurrenceType(string $name): int
+    {
+        return OccurrenceType::where('name', $name)->value('id');
+    }
+
+    private function nonFestivalEventType(): int
+    {
+        return EventType::where('slug', '!=', 'festival')->inRandomOrder()->value('id');
+    }
+
+    /**
+     * A Yearly-occurrence series (no Festival event type needed — Yearly
+     * alone should trip the festival title) with a future-dated event: the
+     * title should include the event's year and the brand suffix.
+     */
+    public function test_yearly_series_title_includes_upcoming_year_and_brand(): void
+    {
+        $series = Series::factory()->create([
+            'name' => 'Skull Fest',
+            'event_type_id' => $this->nonFestivalEventType(),
+            'occurrence_type_id' => $this->occurrenceType('Yearly'),
+        ]);
+
+        $upcoming = Carbon::now()->addMonths(4);
+        Event::factory()->create([
+            'series_id' => $series->id,
+            'start_at' => $upcoming,
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+
+        $this->assertSame($upcoming->year, $series->fresh(['occurrenceType', 'eventType'])->getFestivalYear());
+
+        $response = $this->get('/series/'.$series->slug);
+
+        $response->assertOk();
+        $expectedTitle = e('Skull Fest '.$upcoming->year.' — Lineup, Schedule & Tickets in Pittsburgh').' | '.config('app.app_name');
+        $response->assertSee('<title>'.$expectedTitle.'</title>', false);
+    }
+
+    /**
+     * A Festival-eventType series (Weekly occurrence, so it's the event type
+     * — not the occurrence type — driving festival detection) with only
+     * past events: the title should fall back to the most recent past year.
+     */
+    public function test_festival_event_type_series_with_only_past_events_uses_past_year(): void
+    {
+        $festivalTypeId = EventType::where('slug', 'festival')->value('id');
+
+        $series = Series::factory()->create([
+            'name' => 'Millvale Music Festival',
+            'event_type_id' => $festivalTypeId,
+            'occurrence_type_id' => $this->occurrenceType('Weekly'),
+        ]);
+
+        $past = Carbon::now()->subYear();
+        Event::factory()->create([
+            'series_id' => $series->id,
+            'start_at' => $past,
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+
+        $response = $this->get('/series/'.$series->slug);
+
+        $response->assertOk();
+        $expectedTitle = e('Millvale Music Festival '.$past->year.' — Lineup, Schedule & Tickets in Pittsburgh').' | '.config('app.app_name');
+        $response->assertSee('<title>'.$expectedTitle.'</title>', false);
+    }
+
+    /**
+     * A Weekly, non-festival series with no venue: no year in the title,
+     * clean " — " format, and no dangling separators from the missing venue.
+     */
+    public function test_weekly_series_title_has_no_year_and_no_dangling_separators(): void
+    {
+        $series = Series::factory()->create([
+            'name' => 'Weekly Jazz Night',
+            'event_type_id' => $this->nonFestivalEventType(),
+            'occurrence_type_id' => $this->occurrenceType('Weekly'),
+            'occurrence_day_id' => OccurrenceDay::where('name', 'Friday')->value('id'),
+            'venue_id' => null,
+        ]);
+
+        $title = $series->fresh(['occurrenceType', 'occurrenceDay', 'eventType', 'venue'])->getSeoTitleFormat();
+
+        $this->assertStringContainsString('Weekly Jazz Night — Weekly Fridays', $title);
+        $this->assertStringNotContainsString(' at ', $title);
+        $this->assertStringNotContainsString('  ', $title);
+        $this->assertNotEquals(' ', substr($title, -1));
+        $this->assertNotEquals('—', substr(trim($title), -1));
+
+        $response = $this->get('/series/'.$series->slug);
+
+        $response->assertOk();
+        $expectedTitle = e($title).' | '.config('app.app_name');
+        $response->assertSee('<title>'.$expectedTitle.'</title>', false);
+    }
+
+    /**
+     * With an upcoming event that has an attached entity, both the Lineup and
+     * Schedule sections should render, and the schedule should list the
+     * upcoming events in ascending date order.
+     */
+    public function test_page_shows_lineup_and_schedule_with_events_in_ascending_order(): void
+    {
+        $series = Series::factory()->create([
+            'name' => 'Skull Fest',
+            'event_type_id' => $this->nonFestivalEventType(),
+            'occurrence_type_id' => $this->occurrenceType('Yearly'),
+        ]);
+
+        $performer = Entity::factory()->create(['name' => 'ZZ Lineup Performer '.uniqid()]);
+
+        $laterEvent = Event::factory()->create([
+            'name' => 'ZZ Later Night '.uniqid(),
+            'series_id' => $series->id,
+            'start_at' => Carbon::now()->addMonths(5),
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+        $earlierEvent = Event::factory()->create([
+            'name' => 'ZZ Earlier Night '.uniqid(),
+            'series_id' => $series->id,
+            'start_at' => Carbon::now()->addMonths(2),
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+        $earlierEvent->entities()->attach($performer->id);
+
+        $response = $this->get('/series/'.$series->slug);
+
+        $response->assertOk();
+        $response->assertSee('Lineup');
+        // The Schedule heading is the series name + its nearest upcoming
+        // year (the earlier event) + the literal word "Schedule" — distinct
+        // from the sidebar's unrelated "Schedule Information" label.
+        $response->assertSee($series->name.' '.$earlierEvent->start_at->year.' Schedule');
+        $response->assertSee($performer->name);
+        $response->assertSeeInOrder([$earlierEvent->name, $laterEvent->name]);
+    }
+
+    /**
+     * Unit coverage of the year-fallback chain: upcoming -> past -> none.
+     */
+    public function test_get_festival_year_falls_back_from_upcoming_to_past_to_none(): void
+    {
+        $series = Series::factory()->create([
+            'event_type_id' => EventType::where('slug', 'festival')->value('id'),
+            'occurrence_type_id' => $this->occurrenceType('Weekly'),
+        ]);
+
+        // No events at all -> null.
+        $this->assertNull($series->fresh()->getFestivalYear());
+
+        // Only a past event -> that event's year.
+        $past = Carbon::now()->subYears(2);
+        Event::factory()->create([
+            'series_id' => $series->id,
+            'start_at' => $past,
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+        $this->assertSame($past->year, $series->fresh()->getFestivalYear());
+
+        // A later upcoming event takes priority over the past one.
+        $upcoming = Carbon::now()->addMonths(3);
+        Event::factory()->create([
+            'series_id' => $series->id,
+            'start_at' => $upcoming,
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+        $this->assertSame($upcoming->year, $series->fresh()->getFestivalYear());
+    }
+}

--- a/tests/Feature/SeriesSeoTest.php
+++ b/tests/Feature/SeriesSeoTest.php
@@ -164,6 +164,39 @@ class SeriesSeoTest extends TestCase
     }
 
     /**
+     * A non-festival series (Weekly occurrence, non-festival event type)
+     * with an upcoming event should still get a Schedule section, but its
+     * heading must NOT carry a fabricated "edition year" — that's a
+     * festival-only concept. Regression test for a review finding: the
+     * controller previously passed $festivalYear unconditionally, so an
+     * ordinary weekly club night rendered "{name} {year} Schedule".
+     */
+    public function test_non_festival_series_schedule_heading_has_no_year(): void
+    {
+        $series = Series::factory()->create([
+            'name' => 'Weekly Jazz Night',
+            'event_type_id' => $this->nonFestivalEventType(),
+            'occurrence_type_id' => $this->occurrenceType('Weekly'),
+            'occurrence_day_id' => OccurrenceDay::where('name', 'Friday')->value('id'),
+        ]);
+
+        $this->assertFalse($series->fresh(['occurrenceType', 'eventType'])->isFestival());
+
+        $upcoming = Carbon::now()->addWeeks(2);
+        Event::factory()->create([
+            'series_id' => $series->id,
+            'start_at' => $upcoming,
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+
+        $response = $this->get('/series/'.$series->slug);
+
+        $response->assertOk();
+        $response->assertSee($series->name.' Schedule');
+        $response->assertDontSee($series->name.' '.$upcoming->year.' Schedule');
+    }
+
+    /**
      * Unit coverage of the year-fallback chain: upcoming -> past -> none.
      */
     public function test_get_festival_year_falls_back_from_upcoming_to_past_to_none(): void

--- a/tests/Feature/Services/EventTimeWindowStatsTest.php
+++ b/tests/Feature/Services/EventTimeWindowStatsTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Feature\Services;
+
+use App\Enums\EventTimeWindow;
+use App\Models\Entity;
+use App\Models\Event;
+use App\Models\Tag;
+use App\Models\User;
+use App\Models\Visibility;
+use App\Services\EventTimeWindowStats;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class EventTimeWindowStatsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+    }
+
+    protected function insideStart(EventTimeWindow $window): string
+    {
+        $range = $window->range();
+
+        return Carbon::parse($range['start'])->addMinutes(10)->format('Y-m-d H:i:s');
+    }
+
+    public function test_stats_count_public_events_only(): void
+    {
+        $window = EventTimeWindow::Today;
+        $start = $this->insideStart($window);
+
+        Event::factory()->create([
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => $start,
+            'created_by' => User::factory()->create()->id,
+        ]);
+        Event::factory()->create([
+            'visibility_id' => Visibility::VISIBILITY_PRIVATE,
+            'start_at' => $start,
+            'created_by' => User::factory()->create()->id,
+        ]);
+        Event::factory()->create([
+            'visibility_id' => Visibility::VISIBILITY_PROPOSAL,
+            'start_at' => $start,
+            'created_by' => User::factory()->create()->id,
+        ]);
+
+        $stats = app(EventTimeWindowStats::class)->stats($window);
+
+        $this->assertSame(1, $stats['events']);
+    }
+
+    public function test_stats_counts_distinct_venues_and_top_tags(): void
+    {
+        $window = EventTimeWindow::Today;
+        $start = $this->insideStart($window);
+
+        $venue = Entity::factory()->create();
+        $tagA = Tag::factory()->create(['name' => 'Techno']);
+        $tagB = Tag::factory()->create(['name' => 'Punk']);
+
+        $eventOne = Event::factory()->create([
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => $start,
+            'venue_id' => $venue->id,
+            'created_by' => User::factory()->create()->id,
+        ]);
+        $eventTwo = Event::factory()->create([
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => $start,
+            'venue_id' => $venue->id,
+            'created_by' => User::factory()->create()->id,
+        ]);
+
+        $eventOne->tags()->attach([$tagA->id, $tagB->id]);
+        $eventTwo->tags()->attach([$tagA->id]);
+
+        $stats = app(EventTimeWindowStats::class)->stats($window);
+
+        $this->assertSame(2, $stats['events']);
+        $this->assertSame(1, $stats['venues']); // same venue for both events
+        $this->assertSame('Techno', $stats['tags'][0]); // most frequent first
+        $this->assertContains('Punk', $stats['tags']);
+    }
+
+    public function test_cache_key_varies_by_window_start_date(): void
+    {
+        $stats = app(EventTimeWindowStats::class);
+
+        $today = $stats->stats(EventTimeWindow::Today);
+
+        $todayRange = EventTimeWindow::Today->range();
+        $cacheKey = 'event-window-stats:today:'.substr($todayRange['start'], 0, 10);
+
+        $this->assertTrue(Cache::has($cacheKey));
+
+        // A different window (this-week) starts on the same date but is a
+        // distinct cache entry keyed by window value + start date.
+        $weekRange = EventTimeWindow::ThisWeek->range();
+        $weekCacheKey = 'event-window-stats:this-week:'.substr($weekRange['start'], 0, 10);
+
+        $this->assertNotSame($cacheKey, $weekCacheKey);
+    }
+}

--- a/tests/Feature/VenueEntityPageTest.php
+++ b/tests/Feature/VenueEntityPageTest.php
@@ -108,21 +108,19 @@ class VenueEntityPageTest extends TestCase
 
         // Guest (not signed in): the Guarded location's street address and
         // capacity must not leak into the facts panel, matching the
-        // existing Locations card's Guarded gating.
+        // existing Locations card's Guarded gating. This also covers
+        // Entity::getJsonLd(), which gates its streetAddress and
+        // maximumAttendeeCapacity fields on the same Guarded check -- so the
+        // assertions below run against the full response body, JSON-LD
+        // included, rather than stripping the <script type="application/ld+json">
+        // blocks first.
         $response = $this->get('/entities/' . $venue->slug);
 
         $response->assertOk();
 
-        // Strip the JSON-LD <script> blocks before asserting: Entity::getJsonLd()'s
-        // address/capacity fields are a separate, pre-existing code path that isn't
-        // gated by location visibility today (see task-4-report.md concerns) and is
-        // out of scope for this fix -- this test targets only the human-visible
-        // facts panel / Locations card markup.
-        $visibleHtml = preg_replace('#<script type="application/ld\+json">.*?</script>#s', '', $response->getContent());
-
-        $this->assertStringNotContainsString('999 Secret Alley', $visibleHtml);
-        $this->assertStringNotContainsString('4321', $visibleHtml);
-        $this->assertStringNotContainsString('Undisclosed Neighborhood', $visibleHtml);
+        $response->assertDontSee('999 Secret Alley', false);
+        $response->assertDontSee('4321', false);
+        $response->assertDontSee('Undisclosed Neighborhood', false);
     }
 
     public function test_seo_description_omits_neighborhood_for_guarded_location(): void
@@ -206,6 +204,28 @@ class VenueEntityPageTest extends TestCase
 
         $response->assertOk();
         $response->assertSee($event->name);
+    }
+
+    public function test_private_event_linked_only_by_venue_id_is_hidden_from_guests(): void
+    {
+        $venue = $this->makeVenue(['name' => 'Preserving Underground Private']);
+
+        $privateEvent = Event::factory()->create([
+            'name' => 'ZZPRIVATEVENUEONLY-' . uniqid(),
+            'venue_id' => $venue->id,
+            'start_at' => Carbon::now()->addDays(2),
+            'visibility_id' => Visibility::VISIBILITY_PRIVATE,
+        ]);
+
+        // Deliberately not attached via the entity_event pivot -- this is the
+        // "venue_id only" case the union query surfaces, and it must still
+        // respect visibility for guests.
+        $this->assertFalse($privateEvent->entities()->where('entities.id', $venue->id)->exists());
+
+        $response = $this->get('/entities/' . $venue->slug);
+
+        $response->assertOk();
+        $response->assertDontSee($privateEvent->name);
     }
 
     public function test_age_policy_is_21_plus_when_all_recent_events_require_21(): void

--- a/tests/Feature/VenueEntityPageTest.php
+++ b/tests/Feature/VenueEntityPageTest.php
@@ -88,9 +88,57 @@ class VenueEntityPageTest extends TestCase
         $response = $this->get('/entities/' . $venue->slug);
 
         $response->assertOk();
-        $response->assertSee('Venue Facts');
-        $response->assertSee('650');
-        $response->assertSee('Millvale Business District');
+        // Scoped with assertSeeInOrder so this can't be satisfied by the
+        // (visibility-gated) Locations card lower in the sidebar instead of
+        // the Venue Facts card.
+        $response->assertSeeInOrder(['Venue Facts', '650', 'Millvale Business District']);
+    }
+
+    public function test_guarded_venue_location_hides_address_and_capacity_from_guests(): void
+    {
+        $venue = $this->makeVenue(['name' => 'The Secret Speakeasy']);
+        Location::factory()->create([
+            'entity_id' => $venue->id,
+            'address_one' => '999 Secret Alley',
+            'city' => 'Pittsburgh',
+            'capacity' => 4321,
+            'neighborhood' => 'Undisclosed Neighborhood',
+            'visibility_id' => Visibility::VISIBILITY_GUARDED,
+        ]);
+
+        // Guest (not signed in): the Guarded location's street address and
+        // capacity must not leak into the facts panel, matching the
+        // existing Locations card's Guarded gating.
+        $response = $this->get('/entities/' . $venue->slug);
+
+        $response->assertOk();
+
+        // Strip the JSON-LD <script> blocks before asserting: Entity::getJsonLd()'s
+        // address/capacity fields are a separate, pre-existing code path that isn't
+        // gated by location visibility today (see task-4-report.md concerns) and is
+        // out of scope for this fix -- this test targets only the human-visible
+        // facts panel / Locations card markup.
+        $visibleHtml = preg_replace('#<script type="application/ld\+json">.*?</script>#s', '', $response->getContent());
+
+        $this->assertStringNotContainsString('999 Secret Alley', $visibleHtml);
+        $this->assertStringNotContainsString('4321', $visibleHtml);
+        $this->assertStringNotContainsString('Undisclosed Neighborhood', $visibleHtml);
+    }
+
+    public function test_seo_description_omits_neighborhood_for_guarded_location(): void
+    {
+        $venue = $this->makeVenue(['name' => 'The Guarded Room']);
+        Location::factory()->create([
+            'entity_id' => $venue->id,
+            'city' => 'Pittsburgh',
+            'neighborhood' => 'Undisclosed Neighborhood',
+            'visibility_id' => Visibility::VISIBILITY_GUARDED,
+        ]);
+        $venue = $venue->fresh(['roles', 'locations.visibility']);
+
+        $description = $venue->getSeoDescriptionFormat();
+
+        $this->assertStringNotContainsString('Undisclosed Neighborhood', $description);
     }
 
     public function test_upcoming_events_render_before_description(): void
@@ -114,6 +162,29 @@ class VenueEntityPageTest extends TestCase
 
         $response->assertOk();
         $response->assertSeeInOrder([$event->name, $descriptionMarker], false);
+    }
+
+    public function test_past_events_render_after_description_at_the_bottom(): void
+    {
+        $descriptionMarker = 'ZZDESC-' . uniqid() . ' history of the room.';
+        $venue = $this->makeVenue([
+            'name' => 'The Bottom Room',
+            'description' => $descriptionMarker,
+        ]);
+
+        $pastEvent = Event::factory()->create([
+            'name' => 'ZZPASTEVENT-' . uniqid(),
+            'venue_id' => $venue->id,
+            'start_at' => Carbon::now()->subDays(3),
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+
+        $response = $this->get('/entities/' . $venue->slug);
+
+        $response->assertOk();
+        // The Upcoming Events grid moved to the top, but the past-events grid
+        // must stay at the bottom of the page, after the description.
+        $response->assertSeeInOrder([$descriptionMarker, 'Past Events', $pastEvent->name], false);
     }
 
     public function test_event_linked_only_by_venue_id_appears_on_venue_page(): void

--- a/tests/Feature/VenueEntityPageTest.php
+++ b/tests/Feature/VenueEntityPageTest.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Entity;
+use App\Models\EntityStatus;
+use App\Models\Event;
+use App\Models\Location;
+use App\Models\Role;
+use App\Models\Visibility;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class VenueEntityPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    private function venueRole(): Role
+    {
+        return Role::where('name', 'Venue')->firstOrFail();
+    }
+
+    private function makeVenue(array $attrs = []): Entity
+    {
+        $venue = Entity::factory()->create(array_merge([
+            'entity_status_id' => EntityStatus::ACTIVE,
+            'short' => '',
+        ], $attrs));
+        $venue->roles()->attach($this->venueRole());
+
+        return $venue->fresh(['roles']);
+    }
+
+    public function test_venue_title_includes_upcoming_events_and_city(): void
+    {
+        $venue = $this->makeVenue(['name' => 'The Rex Theater']);
+        Location::factory()->create([
+            'entity_id' => $venue->id,
+            'city' => 'Pittsburgh',
+            'capacity' => 700,
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+
+        $response = $this->get('/entities/' . $venue->slug);
+
+        $response->assertOk();
+        $expectedTitle = e('The Rex Theater — Upcoming Events & Concerts in Pittsburgh') . ' | ' . config('app.app_name');
+        $response->assertSee('<title>' . $expectedTitle . '</title>', false);
+    }
+
+    public function test_non_venue_entity_title_is_unchanged(): void
+    {
+        $entity = Entity::factory()->create([
+            'entity_status_id' => EntityStatus::ACTIVE,
+            'name' => 'Some Touring DJ',
+            'short' => '',
+        ]);
+
+        $response = $this->get('/entities/' . $entity->slug);
+
+        $response->assertOk();
+        $rawTitle = $entity->getSeoTitleFormat();
+        $this->assertStringNotContainsString('Upcoming Events & Concerts in', $rawTitle);
+        $response->assertSee('<title>' . e($rawTitle) . ' | ' . config('app.app_name') . '</title>', false);
+    }
+
+    public function test_venue_facts_panel_renders_capacity_and_neighborhood(): void
+    {
+        $venue = $this->makeVenue(['name' => 'Mr Smalls Theatre']);
+        Location::factory()->create([
+            'entity_id' => $venue->id,
+            'city' => 'Millvale',
+            'state' => 'PA',
+            'capacity' => 650,
+            'neighborhood' => 'Millvale Business District',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+
+        $response = $this->get('/entities/' . $venue->slug);
+
+        $response->assertOk();
+        $response->assertSee('Venue Facts');
+        $response->assertSee('650');
+        $response->assertSee('Millvale Business District');
+    }
+
+    public function test_upcoming_events_render_before_description(): void
+    {
+        $descriptionMarker = 'ZZDESC-' . uniqid() . ' full history of the room.';
+        $venue = $this->makeVenue([
+            'name' => 'Spirit Hall',
+            'description' => $descriptionMarker,
+        ]);
+
+        $event = Event::factory()->create([
+            'name' => 'ZZEVENT-' . uniqid(),
+            'venue_id' => $venue->id,
+            'start_at' => Carbon::now()->addDays(3),
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'min_age' => 21,
+        ]);
+        $event->entities()->attach($venue->id);
+
+        $response = $this->get('/entities/' . $venue->slug);
+
+        $response->assertOk();
+        $response->assertSeeInOrder([$event->name, $descriptionMarker], false);
+    }
+
+    public function test_event_linked_only_by_venue_id_appears_on_venue_page(): void
+    {
+        $venue = $this->makeVenue(['name' => 'Preserving Underground']);
+
+        $event = Event::factory()->create([
+            'name' => 'ZZVENUEONLY-' . uniqid(),
+            'venue_id' => $venue->id,
+            'start_at' => Carbon::now()->addDays(2),
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+
+        // Deliberately not attached via the entity_event pivot -- this is the
+        // "venue_id only" case the union query needs to surface.
+        $this->assertFalse($event->entities()->where('entities.id', $venue->id)->exists());
+
+        $response = $this->get('/entities/' . $venue->slug);
+
+        $response->assertOk();
+        $response->assertSee($event->name);
+    }
+
+    public function test_age_policy_is_21_plus_when_all_recent_events_require_21(): void
+    {
+        $venue = $this->makeVenue(['name' => 'ZZ Club TwentyOne']);
+
+        for ($i = 0; $i < 3; $i++) {
+            Event::factory()->create([
+                'venue_id' => $venue->id,
+                'min_age' => 21,
+                'start_at' => Carbon::now()->addDays($i + 1),
+                'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            ]);
+        }
+
+        $this->assertSame('21+', $venue->getAgePolicy());
+
+        $response = $this->get('/entities/' . $venue->slug);
+        $response->assertOk();
+        $response->assertSee('21+');
+    }
+
+    public function test_age_policy_is_varies_by_event_when_mixed(): void
+    {
+        $venue = $this->makeVenue(['name' => 'ZZ Club Mixed']);
+
+        Event::factory()->create([
+            'venue_id' => $venue->id,
+            'min_age' => null,
+            'start_at' => Carbon::now()->addDay(),
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+        Event::factory()->create([
+            'venue_id' => $venue->id,
+            'min_age' => 21,
+            'start_at' => Carbon::now()->addDays(2),
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+
+        $this->assertSame('Varies by event', $venue->getAgePolicy());
+
+        $response = $this->get('/entities/' . $venue->slug);
+        $response->assertOk();
+        $response->assertSee('Varies by event');
+    }
+
+    public function test_json_ld_includes_music_venue_type_and_max_capacity(): void
+    {
+        $venue = $this->makeVenue(['name' => 'ZZ JSON Venue']);
+        Location::factory()->create([
+            'entity_id' => $venue->id,
+            'city' => 'Pittsburgh',
+            'address_one' => '123 Main St',
+            'capacity' => 500,
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+
+        Event::factory()->create([
+            'venue_id' => $venue->id,
+            'start_at' => Carbon::now()->addDays(5),
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+
+        $response = $this->get('/entities/' . $venue->slug);
+
+        $response->assertOk();
+        $response->assertSee('"@type": "MusicVenue"', false);
+        $response->assertSee('"maximumAttendeeCapacity": 500', false);
+        $response->assertSee('"@type": "Event"', false);
+    }
+}

--- a/tests/Feature/Web/EventTimeWindowPagesTest.php
+++ b/tests/Feature/Web/EventTimeWindowPagesTest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Tests\Feature\Web;
+
+use App\Enums\EventTimeWindow;
+use App\Models\Event;
+use App\Models\User;
+use App\Models\Visibility;
+use App\Services\EventTimeWindowStats;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class EventTimeWindowPagesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+        Cache::flush();
+    }
+
+    protected function appName(): string
+    {
+        return config('app.app_name');
+    }
+
+    public static function windowProvider(): array
+    {
+        return [
+            'tonight' => ['tonight', '/events/tonight', 'Tonight'],
+            'today' => ['today', '/events/today', 'Today'],
+            'this-weekend' => ['this-weekend', '/events/this-weekend', 'This Weekend'],
+            'this-week' => ['this-week', '/events/this-week', 'This Week'],
+        ];
+    }
+
+    protected function eventInside(EventTimeWindow $window, array $overrides = []): Event
+    {
+        $range = $window->range();
+        $start = Carbon::parse($range['start'])->addMinutes(10)->format('Y-m-d H:i:s');
+
+        return Event::factory()->create(array_merge([
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => $start,
+            'created_by' => User::factory()->create()->id,
+        ], $overrides));
+    }
+
+    protected function eventOutside(EventTimeWindow $window, array $overrides = []): Event
+    {
+        $range = $window->range();
+        $start = Carbon::parse($range['start'])->subDays(3)->format('Y-m-d H:i:s');
+
+        return Event::factory()->create(array_merge([
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => $start,
+            'created_by' => User::factory()->create()->id,
+        ], $overrides));
+    }
+
+    /**
+     * @dataProvider windowProvider
+     */
+    public function test_page_returns_200_with_expected_title(string $windowValue, string $path, string $phrase): void
+    {
+        $window = EventTimeWindow::from($windowValue);
+
+        $response = $this->get($path);
+
+        $response->assertOk();
+        // The layout's inline @section('title', ...) form runs content through
+        // e(), so '&' in the copy renders as '&amp;' in the compiled <title>.
+        $response->assertSee('<title>'.e($window->title()).' | '.$this->appName().'</title>', false);
+        $response->assertSee($phrase, false);
+    }
+
+    /**
+     * @dataProvider windowProvider
+     */
+    public function test_canonical_is_the_clean_window_path(string $windowValue, string $path, string $phrase): void
+    {
+        $response = $this->get($path);
+
+        $response->assertOk();
+        $base = rtrim(config('app.url'), '/');
+        $response->assertSee('<link rel="canonical" href="'.$base.$path.'">', false);
+    }
+
+    /**
+     * @dataProvider windowProvider
+     */
+    public function test_sort_param_variant_is_noindexed(string $windowValue, string $path, string $phrase): void
+    {
+        $response = $this->get($path.'?sort=name');
+
+        $response->assertOk();
+        $response->assertSee('<meta name="robots" content="noindex, follow">', false);
+    }
+
+    /**
+     * @dataProvider windowProvider
+     */
+    public function test_event_inside_window_is_shown_and_outside_window_is_absent(string $windowValue, string $path, string $phrase): void
+    {
+        $window = EventTimeWindow::from($windowValue);
+
+        $inside = $this->eventInside($window, ['name' => 'Inside Window Test Event']);
+        $outside = $this->eventOutside($window, ['name' => 'Outside Window Test Event']);
+
+        $response = $this->get($path);
+
+        $response->assertOk();
+        $response->assertSee($inside->name);
+        $response->assertDontSee($outside->name);
+    }
+
+    /**
+     * @dataProvider windowProvider
+     */
+    public function test_private_event_inside_window_is_absent_for_guests(string $windowValue, string $path, string $phrase): void
+    {
+        $window = EventTimeWindow::from($windowValue);
+
+        $private = $this->eventInside($window, [
+            'name' => 'Private Window Test Event',
+            'visibility_id' => Visibility::VISIBILITY_PRIVATE,
+        ]);
+
+        $response = $this->get($path);
+
+        $response->assertOk();
+        $response->assertDontSee($private->name);
+    }
+
+    /**
+     * @dataProvider windowProvider
+     */
+    public function test_meta_description_contains_the_computed_event_count(string $windowValue, string $path, string $phrase): void
+    {
+        $window = EventTimeWindow::from($windowValue);
+
+        $this->eventInside($window, ['name' => 'Count Test Event']);
+
+        $response = $this->get($path);
+        $response->assertOk();
+
+        $stats = app(EventTimeWindowStats::class)->stats($window);
+        $desc = $window->metaDescription($stats);
+
+        // Inline @section(..., $desc) runs content through e(), so '&' renders as '&amp;'.
+        $response->assertSee('<meta name="description" content="'.e($desc).'">', false);
+        $response->assertSee((string) $stats['events'], false);
+    }
+
+    /**
+     * @dataProvider windowProvider
+     */
+    public function test_response_contains_item_list_json_ld_when_events_present(string $windowValue, string $path, string $phrase): void
+    {
+        $window = EventTimeWindow::from($windowValue);
+
+        $this->eventInside($window, ['name' => 'JSON LD Test Event']);
+
+        $response = $this->get($path);
+
+        $response->assertOk();
+        $response->assertSee('"@type": "ItemList"', false);
+    }
+
+    /**
+     * @dataProvider windowProvider
+     */
+    public function test_empty_state_has_no_json_ld(string $windowValue, string $path, string $phrase): void
+    {
+        // No events created inside the window: only whatever the seeder
+        // happens to leave inside this real-time window, if anything.
+        $window = EventTimeWindow::from($windowValue);
+        $stats = app(EventTimeWindowStats::class)->stats($window);
+
+        $response = $this->get($path);
+        $response->assertOk();
+
+        if ($stats['events'] === 0) {
+            $response->assertDontSee('"@type": "ItemList"', false);
+            $response->assertSee('No events found for this window yet.', false);
+        } else {
+            $this->assertTrue(true); // seeded data already populates this window; nothing to assert
+        }
+    }
+
+    public function test_other_window_pill_links_are_present(): void
+    {
+        $response = $this->get('/events/tonight');
+
+        $response->assertOk();
+        $response->assertSee('href="'.url('/events/today').'"', false);
+        $response->assertSee('href="'.url('/events/this-weekend').'"', false);
+        $response->assertSee('href="'.url('/events/this-week').'"', false);
+    }
+}

--- a/tests/Feature/Web/EventsControllerTest.php
+++ b/tests/Feature/Web/EventsControllerTest.php
@@ -2,8 +2,10 @@
 
 namespace Tests\Feature\Web;
 
+use App\Models\Entity;
 use App\Models\Event;
 use App\Models\Photo;
+use App\Models\Series;
 use App\Models\Tag;
 use App\Models\User;
 use App\Models\UserStatus;
@@ -137,6 +139,101 @@ class EventsControllerTest extends TestCase
         $response->assertOk();
         $response->assertSee('Public Tag Probe Event');
         $response->assertDontSee('Secret Private Tag Probe Event');
+    }
+
+    /**
+     * The future listing compacted its paginated result under the wrong
+     * variable name ($future_events), so the view (which only reads $events)
+     * always rendered "No matching events found." A public future event must
+     * actually appear on the page.
+     */
+    public function test_index_future_shows_created_event(): void
+    {
+        $event = Event::factory()->create([
+            'name' => 'Future Listing Probe Event',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => now()->addWeek(),
+        ]);
+
+        $response = $this->get('/events/future');
+
+        $response->assertOk();
+        $response->assertSee('Future Listing Probe Event');
+    }
+
+    /**
+     * Same bug as indexFuture, but for $past_events.
+     */
+    public function test_index_past_shows_created_event(): void
+    {
+        $event = Event::factory()->create([
+            'name' => 'Past Listing Probe Event',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => now()->subWeek(),
+        ]);
+
+        $response = $this->get('/events/past');
+
+        $response->assertOk();
+        $response->assertSee('Past Listing Probe Event');
+    }
+
+    /**
+     * Same bug as indexFuture, but for the "starting on this day" listing.
+     */
+    public function test_index_starting_shows_created_event(): void
+    {
+        $event = Event::factory()->create([
+            'name' => 'Starting Listing Probe Event',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => now()->startOfDay()->addHours(12),
+        ]);
+
+        $response = $this->get('/events/starting/'.now()->format('Ymd'));
+
+        $response->assertOk();
+        $response->assertSee('Starting Listing Probe Event');
+    }
+
+    /**
+     * Same bug as indexFuture, but for the by-venue listing.
+     */
+    public function test_index_venue_shows_created_event(): void
+    {
+        $venue = Entity::factory()->venue()->create(['slug' => 'listing-probe-venue']);
+        $event = Event::factory()->create([
+            'name' => 'Venue Listing Probe Event',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => now()->addWeek(),
+            'venue_id' => $venue->id,
+        ]);
+
+        $response = $this->get('/events/venue/listing-probe-venue');
+
+        $response->assertOk();
+        $response->assertSee('Venue Listing Probe Event');
+    }
+
+    /**
+     * Same bug as indexFuture, but for the by-series listing.
+     */
+    public function test_index_series_shows_created_event(): void
+    {
+        $series = Series::factory()->create([
+            'name' => 'Listing Probe Series',
+            'slug' => 'listing-probe-series',
+        ]);
+        $event = Event::factory()->create([
+            'name' => 'Series Listing Probe Event',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => now()->addWeek(),
+            'series_id' => $series->id,
+        ]);
+
+        $response = $this->get('/events/series/listing-probe-series');
+
+        $response->assertOk();
+        $response->assertSee('Series Listing Probe Event');
     }
 
     /**

--- a/tests/Unit/EventTimeWindowTest.php
+++ b/tests/Unit/EventTimeWindowTest.php
@@ -237,4 +237,13 @@ class EventTimeWindowTest extends TestCase
 
         $this->assertSame('Live music, club nights and DIY shows in Pittsburgh — updated daily.', $desc);
     }
+
+    public function test_meta_description_omits_venue_clause_when_no_venues(): void
+    {
+        $desc = EventTimeWindow::Tonight->metaDescription(['events' => 5, 'venues' => 0, 'tags' => []]);
+
+        $this->assertSame('5 shows tonight.', $desc);
+        $this->assertStringNotContainsString('Pittsburgh venues', $desc);
+        $this->assertStringNotContainsString('across 0', $desc);
+    }
 }

--- a/tests/Unit/EventTimeWindowTest.php
+++ b/tests/Unit/EventTimeWindowTest.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Enums\EventTimeWindow;
+use Carbon\CarbonImmutable;
+use Tests\TestCase;
+
+/**
+ * Boundary matrix for the /events/tonight, /today, /this-weekend, /this-week
+ * landing pages. All times are America/New_York wall-clock, expressed as
+ * naive 'Y-m-d H:i:s' strings compared against events.start_at.
+ */
+class EventTimeWindowTest extends TestCase
+{
+    protected function now(string $dateTime): CarbonImmutable
+    {
+        return CarbonImmutable::parse($dateTime, 'America/New_York');
+    }
+
+    public function test_today_window_is_the_calendar_day(): void
+    {
+        $range = EventTimeWindow::Today->range($this->now('2026-08-04 12:00:00')); // Tuesday
+
+        $this->assertSame('2026-08-04 00:00:00', $range['start']);
+        $this->assertSame('2026-08-04 23:59:59', $range['end']);
+    }
+
+    public function test_this_week_window_rolls_six_days_forward(): void
+    {
+        $range = EventTimeWindow::ThisWeek->range($this->now('2026-08-04 12:00:00')); // Tuesday
+
+        $this->assertSame('2026-08-04 00:00:00', $range['start']);
+        $this->assertSame('2026-08-10 23:59:59', $range['end']);
+    }
+
+    public function test_this_week_window_crosses_a_month_boundary(): void
+    {
+        $range = EventTimeWindow::ThisWeek->range($this->now('2026-08-28 09:00:00')); // Friday
+
+        $this->assertSame('2026-08-28 00:00:00', $range['start']);
+        $this->assertSame('2026-09-03 23:59:59', $range['end']);
+    }
+
+    // --- Tuesday noon: plain day, weekend is the upcoming Friday ---
+
+    public function test_tuesday_noon_tonight_is_tuesday_evening(): void
+    {
+        $range = EventTimeWindow::Tonight->range($this->now('2026-08-04 12:00:00')); // Tuesday
+
+        $this->assertSame('2026-08-04 17:00:00', $range['start']);
+        $this->assertSame('2026-08-05 03:00:00', $range['end']);
+    }
+
+    public function test_tuesday_noon_weekend_is_upcoming_friday(): void
+    {
+        $range = EventTimeWindow::ThisWeekend->range($this->now('2026-08-04 12:00:00')); // Tuesday
+
+        $this->assertSame('2026-08-07 17:00:00', $range['start']); // Friday
+        $this->assertSame('2026-08-10 03:00:00', $range['end']); // Monday
+    }
+
+    // --- Friday 18:00: tonight and weekend both anchor to this Friday ---
+
+    public function test_friday_evening_tonight_is_friday_night(): void
+    {
+        $range = EventTimeWindow::Tonight->range($this->now('2026-08-07 18:00:00')); // Friday
+
+        $this->assertSame('2026-08-07 17:00:00', $range['start']);
+        $this->assertSame('2026-08-08 03:00:00', $range['end']);
+    }
+
+    public function test_friday_evening_weekend_is_current_weekend(): void
+    {
+        $range = EventTimeWindow::ThisWeekend->range($this->now('2026-08-07 18:00:00')); // Friday
+
+        $this->assertSame('2026-08-07 17:00:00', $range['start']);
+        $this->assertSame('2026-08-10 03:00:00', $range['end']);
+    }
+
+    // --- Saturday 01:00: still "Friday night" per the <3am hangover rule ---
+
+    public function test_saturday_1am_tonight_is_still_fridays_window(): void
+    {
+        $range = EventTimeWindow::Tonight->range($this->now('2026-08-08 01:00:00')); // Saturday
+
+        $this->assertSame('2026-08-07 17:00:00', $range['start']);
+        $this->assertSame('2026-08-08 03:00:00', $range['end']);
+    }
+
+    public function test_saturday_1am_weekend_is_still_current(): void
+    {
+        $range = EventTimeWindow::ThisWeekend->range($this->now('2026-08-08 01:00:00')); // Saturday
+
+        $this->assertSame('2026-08-07 17:00:00', $range['start']);
+        $this->assertSame('2026-08-10 03:00:00', $range['end']);
+    }
+
+    // --- Sunday 20:00: still within the Fri->Mon weekend window ---
+
+    public function test_sunday_evening_weekend_is_still_current(): void
+    {
+        $range = EventTimeWindow::ThisWeekend->range($this->now('2026-08-09 20:00:00')); // Sunday
+
+        $this->assertSame('2026-08-07 17:00:00', $range['start']);
+        $this->assertSame('2026-08-10 03:00:00', $range['end']);
+    }
+
+    public function test_sunday_evening_tonight_is_sunday_night(): void
+    {
+        $range = EventTimeWindow::Tonight->range($this->now('2026-08-09 20:00:00')); // Sunday
+
+        $this->assertSame('2026-08-09 17:00:00', $range['start']);
+        $this->assertSame('2026-08-10 03:00:00', $range['end']);
+    }
+
+    // --- Monday 02:00: hangover from Sunday night; weekend is the one that just ended ---
+
+    public function test_monday_2am_tonight_is_sundays_window(): void
+    {
+        $range = EventTimeWindow::Tonight->range($this->now('2026-08-10 02:00:00')); // Monday
+
+        $this->assertSame('2026-08-09 17:00:00', $range['start']);
+        $this->assertSame('2026-08-10 03:00:00', $range['end']);
+    }
+
+    public function test_monday_2am_weekend_is_the_just_ended_one(): void
+    {
+        $range = EventTimeWindow::ThisWeekend->range($this->now('2026-08-10 02:00:00')); // Monday
+
+        $this->assertSame('2026-08-07 17:00:00', $range['start']);
+        $this->assertSame('2026-08-10 03:00:00', $range['end']);
+    }
+
+    // --- Monday 12:00: fully into the new week; weekend is next Friday ---
+
+    public function test_monday_noon_tonight_is_monday_night(): void
+    {
+        $range = EventTimeWindow::Tonight->range($this->now('2026-08-10 12:00:00')); // Monday
+
+        $this->assertSame('2026-08-10 17:00:00', $range['start']);
+        $this->assertSame('2026-08-11 03:00:00', $range['end']);
+    }
+
+    public function test_monday_noon_weekend_is_next_friday(): void
+    {
+        $range = EventTimeWindow::ThisWeekend->range($this->now('2026-08-10 12:00:00')); // Monday
+
+        $this->assertSame('2026-08-14 17:00:00', $range['start']); // Friday
+        $this->assertSame('2026-08-17 03:00:00', $range['end']); // Monday
+    }
+
+    // --- default $now (no argument) resolves without throwing ---
+
+    public function test_range_defaults_to_current_time_when_now_is_not_injected(): void
+    {
+        $range = EventTimeWindow::Today->range();
+
+        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2} 00:00:00$/', $range['start']);
+        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2} 23:59:59$/', $range['end']);
+    }
+
+    // --- copy / label / path / title / h1 ---
+
+    public function test_paths_and_labels(): void
+    {
+        $this->assertSame('/events/tonight', EventTimeWindow::Tonight->path());
+        $this->assertSame('Tonight', EventTimeWindow::Tonight->label());
+        $this->assertSame('/events/today', EventTimeWindow::Today->path());
+        $this->assertSame('Today', EventTimeWindow::Today->label());
+        $this->assertSame('/events/this-weekend', EventTimeWindow::ThisWeekend->path());
+        $this->assertSame('This Weekend', EventTimeWindow::ThisWeekend->label());
+        $this->assertSame('/events/this-week', EventTimeWindow::ThisWeek->path());
+        $this->assertSame('This Week', EventTimeWindow::ThisWeek->label());
+    }
+
+    public function test_title_has_no_brand_suffix(): void
+    {
+        $this->assertSame('Events in Pittsburgh Tonight — Live Music, Shows & More', EventTimeWindow::Tonight->title());
+        $this->assertSame('Events in Pittsburgh Today — Live Music, Shows & More', EventTimeWindow::Today->title());
+        $this->assertSame('Events in Pittsburgh This Weekend — Live Music, Shows & More', EventTimeWindow::ThisWeekend->title());
+        $this->assertSame('Events in Pittsburgh This Week — Live Music, Shows & More', EventTimeWindow::ThisWeek->title());
+
+        foreach (EventTimeWindow::cases() as $window) {
+            $this->assertStringNotContainsString('Arcane City', $window->title());
+        }
+    }
+
+    public function test_h1(): void
+    {
+        $this->assertSame('Events in Pittsburgh Tonight', EventTimeWindow::Tonight->h1());
+        $this->assertSame('Events in Pittsburgh Today', EventTimeWindow::Today->h1());
+        $this->assertSame('Events in Pittsburgh This Weekend', EventTimeWindow::ThisWeekend->h1());
+        $this->assertSame('Events in Pittsburgh This Week', EventTimeWindow::ThisWeek->h1());
+    }
+
+    // --- meta description grammar ---
+
+    public function test_meta_description_plural_counts(): void
+    {
+        $desc = EventTimeWindow::Tonight->metaDescription([
+            'events' => 5,
+            'venues' => 3,
+            'tags' => ['Techno', 'Punk', 'DIY'],
+        ]);
+
+        $this->assertSame('5 shows tonight across 3 Pittsburgh venues — Techno, Punk, DIY & more.', $desc);
+    }
+
+    public function test_meta_description_singular_counts(): void
+    {
+        $desc = EventTimeWindow::Today->metaDescription([
+            'events' => 1,
+            'venues' => 1,
+            'tags' => ['Jazz'],
+        ]);
+
+        $this->assertSame('1 show today across 1 Pittsburgh venue — Jazz & more.', $desc);
+    }
+
+    public function test_meta_description_weekend_and_week_phrases(): void
+    {
+        $this->assertSame(
+            '2 shows this weekend across 2 Pittsburgh venues — Rock & more.',
+            EventTimeWindow::ThisWeekend->metaDescription(['events' => 2, 'venues' => 2, 'tags' => ['Rock']])
+        );
+
+        $this->assertSame(
+            '10 shows this week across 6 Pittsburgh venues — Rock & more.',
+            EventTimeWindow::ThisWeek->metaDescription(['events' => 10, 'venues' => 6, 'tags' => ['Rock']])
+        );
+    }
+
+    public function test_meta_description_falls_back_when_no_events(): void
+    {
+        $desc = EventTimeWindow::Tonight->metaDescription(['events' => 0, 'venues' => 0, 'tags' => []]);
+
+        $this->assertSame('Live music, club nights and DIY shows in Pittsburgh — updated daily.', $desc);
+    }
+}


### PR DESCRIPTION
## Summary

Part 5 of 6 of the issue #2002 SEO series (base: `2002-seo-venue-pages`). Festival queries ("skull fest 2026", "millvale music festival 2026 schedule/lineup") want the year, a lineup, and a schedule — series pages had none of these.

## Changes

- **`Series::getSeoTitleFormat()`** (new; `getTitleFormat()` untouched) — festivals (eventType `festival` OR Yearly occurrence): `{Name} {year} — Lineup, Schedule & Tickets in Pittsburgh`, year from the next upcoming event, falling back to the latest past edition, else omitted. Non-festivals: clean `{Name} — {OccurrenceType} {repeat} at {venue}` with no dangling separators for any missing part. View switched to the new method.
- **`getOccurrenceRepeatAttribute()`** — missing `Yearly` case handled without dangling spaces.
- **Lineup + Schedule sections** — `SeriesController::show()` now also passes `$upcomingEvents` (visible, ASC) and `$lineupEntities` (distinct entities across upcoming — or latest-edition — events, by frequency, single grouped join). The page renders an entity-chip **Lineup** section and a date-grouped **"{Name} {Year} Schedule"** section (year shown for festivals only) above the existing archive, which is retitled "Past Events & Archive". The existing DESC-paginated archive behavior is unchanged.

## Test plan

- New `tests/Feature/SeriesSeoTest.php` (6 tests): festival year from upcoming/past events, weekly series without year, no-dangling-separator permutations, Lineup/Schedule render + ascending order, non-festival schedule heading has no year.
- Series + API series test files and `SeoMetaLayoutTest` green; `composer phpstan` clean.

## Follow-ups (tracked in issue)

- `getFestivalYear()` uses the unfiltered `nextEvent()` (matches the existing "Next:" sidebar convention); a private event could in principle drive the title year.

Part of #2002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
