### PR TITLE
SEO: scene hub pages /scenes/{slug} [#2002 series 6/6]

### DIFF
--- a/app/Console/Commands/GenerateSitemap.php
+++ b/app/Console/Commands/GenerateSitemap.php
@@ -144,6 +144,14 @@ class GenerateSitemap extends Command
         foreach (self::PAGES as $page) {
             yield Url::create($this->baseUrl.$page);
         }
+
+        // Scene hub pages are config-driven (config/scenes.php) rather than
+        // a database table, so loop the config keys instead of hardcoding
+        // slugs here — keeps this in sync with ScenesController/routes.
+        yield Url::create($this->baseUrl.'/scenes');
+        foreach (array_keys(config('scenes', [])) as $sceneSlug) {
+            yield Url::create($this->baseUrl.'/scenes/'.$sceneSlug);
+        }
     }
 
     /**

--- a/app/Http/Controllers/ScenesController.php
+++ b/app/Http/Controllers/ScenesController.php
@@ -30,7 +30,6 @@ class ScenesController extends Controller
         $scenes = collect(config('scenes', []))->map(function (array $scene, string $slug) {
             $scene['slug'] = $slug;
             $scene['stats'] = $this->stats($slug, $scene['tags']);
-            $scene['heroImageUrl'] = $this->heroImageUrl($slug, $scene['tags']);
 
             return $scene;
         })->values();
@@ -110,7 +109,6 @@ class ScenesController extends Controller
             'entities' => $entities,
             'series' => $series,
             'stats' => $stats,
-            'heroImageUrl' => $this->heroImageUrl($slug, $tags),
         ]);
     }
 
@@ -142,34 +140,4 @@ class ScenesController extends Controller
         });
     }
 
-    /**
-     * Full-size primary-photo URL of the soonest upcoming public event in the
-     * scene, for the scene hero image; null when no such event has a photo
-     * (views fall back to the scene's configured icon). Public-only and
-     * cached so the same URL is safe to serve to every visitor. An empty
-     * string is cached in place of null so misses don't re-run the query.
-     *
-     * @param array<int, string> $tags
-     */
-    protected function heroImageUrl(string $slug, array $tags): ?string
-    {
-        $url = Cache::remember('scene-hero:'.$slug, self::STATS_CACHE_TTL, function () use ($tags) {
-            $event = Event::query()
-                ->where('visibility_id', Visibility::VISIBILITY_PUBLIC)
-                ->future()
-                ->whereHas('tags', function ($query) use ($tags) {
-                    $query->whereIn('tags.slug', $tags);
-                })
-                ->whereHas('photos', function ($query) {
-                    $query->where('photos.is_primary', 1);
-                })
-                ->with('photos')
-                ->orderBy('start_at')
-                ->first();
-
-            return $event ? ($event->getPrimaryPhotoPath() ?? '') : '';
-        });
-
-        return $url !== '' ? $url : null;
-    }
 }

--- a/app/Http/Controllers/ScenesController.php
+++ b/app/Http/Controllers/ScenesController.php
@@ -6,6 +6,7 @@ use App\Models\Entity;
 use App\Models\Event;
 use App\Models\Series;
 use App\Models\Visibility;
+use Carbon\Carbon;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Cache;
 
@@ -29,6 +30,7 @@ class ScenesController extends Controller
         $scenes = collect(config('scenes', []))->map(function (array $scene, string $slug) {
             $scene['slug'] = $slug;
             $scene['stats'] = $this->stats($slug, $scene['tags']);
+            $scene['heroImageUrl'] = $this->heroImageUrl($slug, $scene['tags']);
 
             return $scene;
         })->values();
@@ -57,15 +59,36 @@ class ScenesController extends Controller
             ->limit(48)
             ->get();
 
+        // "Key" = tagged for the scene AND actually active: ranked by public
+        // event count over the trailing year plus anything upcoming, counting
+        // both lineup (pivot) events and events hosted as the venue. Tagged
+        // entities with no events in that window are dropped entirely.
+        $since = Carbon::now('America/New_York')->subYear();
+
         $entities = Entity::query()
             ->active()
             ->whereHas('tags', function ($query) use ($tags) {
                 $query->whereIn('tags.slug', $tags);
             })
+            ->withCount([
+                'events as recent_events_count' => function ($query) use ($since) {
+                    $query->where('events.visibility_id', Visibility::VISIBILITY_PUBLIC)
+                        ->where('events.start_at', '>=', $since);
+                },
+                'venueEvents as recent_venue_events_count' => function ($query) use ($since) {
+                    $query->where('events.visibility_id', Visibility::VISIBILITY_PUBLIC)
+                        ->where('events.start_at', '>=', $since);
+                },
+            ])
             ->with(['roles', 'photos'])
+            ->orderByRaw('(recent_events_count + recent_venue_events_count) DESC')
             ->orderBy('name')
             ->limit(12)
-            ->get();
+            ->get()
+            ->filter(function (Entity $entity) {
+                return ((int) $entity->getAttribute('recent_events_count') + (int) $entity->getAttribute('recent_venue_events_count')) > 0;
+            })
+            ->values();
 
         $series = Series::query()
             ->visible($this->user)
@@ -87,6 +110,7 @@ class ScenesController extends Controller
             'entities' => $entities,
             'series' => $series,
             'stats' => $stats,
+            'heroImageUrl' => $this->heroImageUrl($slug, $tags),
         ]);
     }
 
@@ -116,5 +140,36 @@ class ScenesController extends Controller
                 'venues' => $counts ? (int) $counts->venue_count : 0,
             ];
         });
+    }
+
+    /**
+     * Full-size primary-photo URL of the soonest upcoming public event in the
+     * scene, for the scene hero image; null when no such event has a photo
+     * (views fall back to the scene's configured icon). Public-only and
+     * cached so the same URL is safe to serve to every visitor. An empty
+     * string is cached in place of null so misses don't re-run the query.
+     *
+     * @param array<int, string> $tags
+     */
+    protected function heroImageUrl(string $slug, array $tags): ?string
+    {
+        $url = Cache::remember('scene-hero:'.$slug, self::STATS_CACHE_TTL, function () use ($tags) {
+            $event = Event::query()
+                ->where('visibility_id', Visibility::VISIBILITY_PUBLIC)
+                ->future()
+                ->whereHas('tags', function ($query) use ($tags) {
+                    $query->whereIn('tags.slug', $tags);
+                })
+                ->whereHas('photos', function ($query) {
+                    $query->where('photos.is_primary', 1);
+                })
+                ->with('photos')
+                ->orderBy('start_at')
+                ->first();
+
+            return $event ? ($event->getPrimaryPhotoPath() ?? '') : '';
+        });
+
+        return $url !== '' ? $url : null;
     }
 }

--- a/app/Http/Controllers/ScenesController.php
+++ b/app/Http/Controllers/ScenesController.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Entity;
+use App\Models\Event;
+use App\Models\Series;
+use App\Models\Visibility;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Curated genre "scene" hub pages: /scenes/{slug}. Config-driven v1 for
+ * issue #2002 §4 — no database model, no migration. Each scene groups a
+ * handful of real tag slugs (config/scenes.php) into one editorial landing
+ * page combining upcoming events, key entities, and active series, so it
+ * can rank for genre-demand searches ("raves pittsburgh", "goth events")
+ * that a bare tag listing doesn't.
+ */
+class ScenesController extends Controller
+{
+    /**
+     * Cached stats TTL in seconds (matches EventTimeWindowStats).
+     */
+    protected const STATS_CACHE_TTL = 900;
+
+    public function index(): View
+    {
+        $scenes = collect(config('scenes', []))->map(function (array $scene, string $slug) {
+            $scene['slug'] = $slug;
+            $scene['stats'] = $this->stats($slug, $scene['tags']);
+
+            return $scene;
+        })->values();
+
+        return view('scenes.index-tw', [
+            'scenes' => $scenes,
+        ]);
+    }
+
+    public function show(string $slug): View
+    {
+        $scene = config("scenes.$slug");
+
+        abort_unless($scene, 404);
+
+        $tags = $scene['tags'];
+
+        $events = Event::query()
+            ->visible($this->user)
+            ->future()
+            ->whereHas('tags', function ($query) use ($tags) {
+                $query->whereIn('tags.slug', $tags);
+            })
+            ->with(EventsController::cardEventEagerLoad($this->user))
+            ->orderBy('start_at')
+            ->limit(48)
+            ->get();
+
+        $entities = Entity::query()
+            ->active()
+            ->whereHas('tags', function ($query) use ($tags) {
+                $query->whereIn('tags.slug', $tags);
+            })
+            ->with(['roles', 'photos'])
+            ->orderBy('name')
+            ->limit(12)
+            ->get();
+
+        $series = Series::query()
+            ->visible($this->user)
+            ->whereNull('cancelled_at')
+            ->whereHas('tags', function ($query) use ($tags) {
+                $query->whereIn('tags.slug', $tags);
+            })
+            ->with(['visibility', 'venue.locations', 'tags', 'entities', 'occurrenceType', 'photos'])
+            ->orderBy('name')
+            ->limit(8)
+            ->get();
+
+        $stats = $this->stats($slug, $tags);
+
+        return view('scenes.show-tw', [
+            'slug' => $slug,
+            'scene' => $scene,
+            'events' => $events,
+            'entities' => $entities,
+            'series' => $series,
+            'stats' => $stats,
+        ]);
+    }
+
+    /**
+     * Public-only upcoming event count + distinct venue count for a scene,
+     * cached for 15 minutes so the value is safe to share across every
+     * visitor regardless of who's signed in (mirrors EventTimeWindowStats).
+     *
+     * @param array<int, string> $tags
+     * @return array{events: int, venues: int}
+     */
+    protected function stats(string $slug, array $tags): array
+    {
+        return Cache::remember('scene-stats:'.$slug, self::STATS_CACHE_TTL, function () use ($tags) {
+            $counts = Event::query()
+                ->where('visibility_id', Visibility::VISIBILITY_PUBLIC)
+                ->future()
+                ->whereHas('tags', function ($query) use ($tags) {
+                    $query->whereIn('tags.slug', $tags);
+                })
+                ->selectRaw('COUNT(*) as event_count, COUNT(DISTINCT venue_id) as venue_count')
+                ->toBase()
+                ->first();
+
+            return [
+                'events' => $counts ? (int) $counts->event_count : 0,
+                'venues' => $counts ? (int) $counts->venue_count : 0,
+            ];
+        });
+    }
+}

--- a/app/Models/Entity.php
+++ b/app/Models/Entity.php
@@ -491,6 +491,16 @@ class Entity extends Eloquent
     }
 
     /**
+     * Events linked to this entity as the venue (events.venue_id), as a real
+     * relation so it can be used with withCount/whereHas — unlike
+     * eventsAtVenue(), which executes immediately.
+     */
+    public function venueEvents(): HasMany
+    {
+        return $this->hasMany(Event::class, 'venue_id');
+    }
+
+    /**
      * Get a ranked list of entities that frequently perform with this entity
      * (other entities related to the same events).
      */

--- a/config/scenes.php
+++ b/config/scenes.php
@@ -34,7 +34,7 @@ return [
         'name' => 'Raves & EDM',
         'title' => 'Raves, EDM & Club Nights in Pittsburgh — Upcoming Events & Parties',
         'description' => 'Upcoming raves, techno and house parties, and EDM club nights in Pittsburgh.',
-        'tags' => ['rave', 'techno', 'house', 'edm', 'electronic'],
+        'tags' => ['rave', 'techno', 'house', 'edm', 'electronic', 'dubstep'],
     ],
 
     'punk-hardcore' => [
@@ -55,10 +55,10 @@ return [
 
     'drum-and-bass' => [
         'icon' => 'bi-vinyl-fill',
-        'name' => 'Drum & Bass',
-        'title' => 'Drum & Bass & Jungle Nights in Pittsburgh — Upcoming Events',
-        'description' => 'Upcoming drum and bass and jungle nights in Pittsburgh.',
-        'tags' => ['drum-and-bass', 'jungle'],
+        'name' => 'Drum & Bass, Jungle & UK Bass',
+        'title' => 'Drum & Bass, Jungle & UK Bass Nights in Pittsburgh — Upcoming Events',
+        'description' => 'Upcoming drum and bass, jungle and UK bass nights in Pittsburgh.',
+        'tags' => ['drum-and-bass', 'jungle', 'bass'],
     ],
 
     'experimental-noise' => [

--- a/config/scenes.php
+++ b/config/scenes.php
@@ -11,8 +11,8 @@
 | genre-demand searches that a bare tag listing doesn't.
 |
 | Keys:
-|   icon        Bootstrap Icons class used as the scene's visual fallback
-|               when no upcoming event photo is available for the hero image.
+|   icon        Bootstrap Icons class used as the scene's visual on the hub
+|               page header and index cards (until curated images exist).
 |   name        Display name (nav/footer/cards), e.g. "Raves & EDM"
 |   title       SEO <title> (layout appends " | " . config('app.app_name'))
 |   description Meta description base sentence; the controller appends

--- a/config/scenes.php
+++ b/config/scenes.php
@@ -61,6 +61,22 @@ return [
         'tags' => ['drum-and-bass', 'jungle', 'bass'],
     ],
 
+    'hip-hop-beats' => [
+        'icon' => 'bi-mic-fill',
+        'name' => 'Hip Hop & Beats',
+        'title' => 'Hip Hop, Rap & Beats in Pittsburgh — Upcoming Shows & Events',
+        'description' => 'Upcoming hip hop, rap, trap and beat-scene shows in Pittsburgh.',
+        'tags' => ['hip-hop', 'rap', 'beats', 'trap'],
+    ],
+
+    'alternative-indie' => [
+        'icon' => 'bi-cassette-fill',
+        'name' => 'Alternative & Indie',
+        'title' => 'Alternative & Indie Shows in Pittsburgh — Upcoming Events',
+        'description' => 'Upcoming alternative, indie, shoegaze and dream pop shows in Pittsburgh.',
+        'tags' => ['alternative', 'indie', 'indierock', 'indiepop', 'shoegaze', 'dream-pop'],
+    ],
+
     'experimental-noise' => [
         'icon' => 'bi-soundwave',
         'name' => 'Experimental & Noise',

--- a/config/scenes.php
+++ b/config/scenes.php
@@ -11,6 +11,8 @@
 | genre-demand searches that a bare tag listing doesn't.
 |
 | Keys:
+|   icon        Bootstrap Icons class used as the scene's visual fallback
+|               when no upcoming event photo is available for the hero image.
 |   name        Display name (nav/footer/cards), e.g. "Raves & EDM"
 |   title       SEO <title> (layout appends " | " . config('app.app_name'))
 |   description Meta description base sentence; the controller appends
@@ -28,6 +30,7 @@
 return [
 
     'rave-edm' => [
+        'icon' => 'bi-music-note-beamed',
         'name' => 'Raves & EDM',
         'title' => 'Raves, EDM & Club Nights in Pittsburgh — Upcoming Events & Parties',
         'description' => 'Upcoming raves, techno and house parties, and EDM club nights in Pittsburgh.',
@@ -35,6 +38,7 @@ return [
     ],
 
     'punk-hardcore' => [
+        'icon' => 'bi-lightning-fill',
         'name' => 'Punk & Hardcore',
         'title' => 'Punk & Hardcore Shows in Pittsburgh — Upcoming Events',
         'description' => 'Upcoming punk and hardcore shows in Pittsburgh, from DIY basement gigs to club bills.',
@@ -42,6 +46,7 @@ return [
     ],
 
     'goth-industrial' => [
+        'icon' => 'bi-moon-stars-fill',
         'name' => 'Goth & Industrial',
         'title' => 'Goth & Industrial Nights in Pittsburgh — Upcoming Events',
         'description' => 'Upcoming goth, industrial and darkwave nights in Pittsburgh.',
@@ -49,6 +54,7 @@ return [
     ],
 
     'drum-and-bass' => [
+        'icon' => 'bi-vinyl-fill',
         'name' => 'Drum & Bass',
         'title' => 'Drum & Bass & Jungle Nights in Pittsburgh — Upcoming Events',
         'description' => 'Upcoming drum and bass and jungle nights in Pittsburgh.',
@@ -56,6 +62,7 @@ return [
     ],
 
     'experimental-noise' => [
+        'icon' => 'bi-soundwave',
         'name' => 'Experimental & Noise',
         'title' => 'Experimental & Noise Shows in Pittsburgh — Upcoming Events',
         'description' => 'Upcoming experimental, noise and ambient shows in Pittsburgh.',

--- a/config/scenes.php
+++ b/config/scenes.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Scene hub pages (/scenes/{slug})
+|--------------------------------------------------------------------------
+|
+| Config-driven v1 for issue #2002 §4 — no database model, no migration.
+| Each entry powers one curated hub page combining upcoming events, key
+| entities, and active series for a genre "scene" so it can rank for
+| genre-demand searches that a bare tag listing doesn't.
+|
+| Keys:
+|   name        Display name (nav/footer/cards), e.g. "Raves & EDM"
+|   title       SEO <title> (layout appends " | " . config('app.app_name'))
+|   description Meta description base sentence; the controller appends
+|               live public event/venue counts.
+|   tags        Real tag slugs (App\Models\Tag.slug) that define the scene.
+|               Verified against database/initialize/*.sql — the dev/test
+|               DB's TagsTableSeeder only carries 3 rows, so these were
+|               checked against the production tag export, not tinker.
+|
+| ScenesController::show() 404s for any slug not present here. The sitemap
+| generator loops these keys — never hardcode a scene slug outside this file.
+|
+*/
+
+return [
+
+    'rave-edm' => [
+        'name' => 'Raves & EDM',
+        'title' => 'Raves, EDM & Club Nights in Pittsburgh — Upcoming Events & Parties',
+        'description' => 'Upcoming raves, techno and house parties, and EDM club nights in Pittsburgh.',
+        'tags' => ['rave', 'techno', 'house', 'edm', 'electronic'],
+    ],
+
+    'punk-hardcore' => [
+        'name' => 'Punk & Hardcore',
+        'title' => 'Punk & Hardcore Shows in Pittsburgh — Upcoming Events',
+        'description' => 'Upcoming punk and hardcore shows in Pittsburgh, from DIY basement gigs to club bills.',
+        'tags' => ['punk', 'hardcore'],
+    ],
+
+    'goth-industrial' => [
+        'name' => 'Goth & Industrial',
+        'title' => 'Goth & Industrial Nights in Pittsburgh — Upcoming Events',
+        'description' => 'Upcoming goth, industrial and darkwave nights in Pittsburgh.',
+        'tags' => ['goth', 'industrial', 'darkwave'],
+    ],
+
+    'drum-and-bass' => [
+        'name' => 'Drum & Bass',
+        'title' => 'Drum & Bass & Jungle Nights in Pittsburgh — Upcoming Events',
+        'description' => 'Upcoming drum and bass and jungle nights in Pittsburgh.',
+        'tags' => ['drum-and-bass', 'jungle'],
+    ],
+
+    'experimental-noise' => [
+        'name' => 'Experimental & Noise',
+        'title' => 'Experimental & Noise Shows in Pittsburgh — Upcoming Events',
+        'description' => 'Upcoming experimental, noise and ambient shows in Pittsburgh.',
+        'tags' => ['experimental', 'noise', 'ambient'],
+    ],
+
+];

--- a/resources/views/partials/footer-tw.blade.php
+++ b/resources/views/partials/footer-tw.blade.php
@@ -14,4 +14,11 @@
 		<span aria-hidden="true">&middot;</span>
 		<a href="{{ url('/tags') }}" class="hover:text-primary transition-colors">Tags</a>
 	</div>
+	<div class="flex flex-wrap items-center gap-x-2 gap-y-1 mt-1">
+		<span class="font-semibold text-foreground">Scenes</span>
+		@foreach (config('scenes', []) as $sceneSlug => $scene)
+		<span aria-hidden="true">&middot;</span>
+		<a href="{{ url('/scenes/'.$sceneSlug) }}" class="hover:text-primary transition-colors">{{ $scene['name'] }}</a>
+		@endforeach
+	</div>
 </footer>

--- a/resources/views/partials/sidebar-tw.blade.php
+++ b/resources/views/partials/sidebar-tw.blade.php
@@ -80,6 +80,12 @@
             <span>Tags</span>
         </a>
 
+        <!-- Scenes -->
+        <a href="{{ url('/scenes') }}" class="nav-item-tw {{ Request::is('scenes') || Request::is('scenes/*') ? 'nav-item-active-tw' : '' }}">
+            <i class="bi bi-vinyl text-lg"></i>
+            <span>Scenes</span>
+        </a>
+
 
         <!-- Forum -->
         <a href="{{ url('/threads/all') }}" class="nav-item-tw {{ Request::is('threads*') ? 'nav-item-active-tw' : '' }}">
@@ -246,6 +252,12 @@
         <a href="{{ url('/tags') }}" class="nav-item-tw {{ Request::is('tags') ? 'nav-item-active-tw' : '' }}">
             <i class="bi bi-tags text-lg"></i>
             <span>Tags</span>
+        </a>
+
+        <!-- Scenes -->
+        <a href="{{ url('/scenes') }}" class="nav-item-tw {{ Request::is('scenes') || Request::is('scenes/*') ? 'nav-item-active-tw' : '' }}">
+            <i class="bi bi-vinyl text-lg"></i>
+            <span>Scenes</span>
         </a>
 
         <!-- Forum -->

--- a/resources/views/scenes/copy/alternative-indie.blade.php
+++ b/resources/views/scenes/copy/alternative-indie.blade.php
@@ -1,0 +1,9 @@
+<p class="text-muted-foreground leading-relaxed mb-4">
+	Alternative and indie shows in Pittsburgh span everything from jangly indie pop and guitar-driven indie rock to
+	the hazier end of the spectrum — shoegaze and dream pop bills that lean on texture and volume. Touring bands
+	route through the city's mid-size rooms while local acts fill out club and DIY bills week to week.
+</p>
+<p class="text-muted-foreground leading-relaxed mb-4">
+	It's a porous scene: the same crowds and venues overlap with punk, experimental, and electronic nights, so a
+	good indie bill is often the easiest entry point into everything else happening in the city.
+</p>

--- a/resources/views/scenes/copy/drum-and-bass.blade.php
+++ b/resources/views/scenes/copy/drum-and-bass.blade.php
@@ -1,0 +1,9 @@
+<p class="text-muted-foreground leading-relaxed mb-4">
+	Drum and bass and jungle nights in Pittsburgh are smaller and more specialized than the broader EDM scene,
+	usually organized around a dedicated crew or a recurring party rather than a fixed venue. Expect fast breaks,
+	heavy bass, and a crowd that knows the genre well.
+</p>
+<p class="text-muted-foreground leading-relaxed mb-4">
+	These nights don't always run on a predictable schedule, so the events and series listed below are the best way
+	to catch the next one — check individual listings for lineup details and set times.
+</p>

--- a/resources/views/scenes/copy/experimental-noise.blade.php
+++ b/resources/views/scenes/copy/experimental-noise.blade.php
@@ -1,0 +1,10 @@
+<p class="text-muted-foreground leading-relaxed mb-4">
+	Experimental, noise, and ambient shows in Pittsburgh happen mostly in DIY spaces, art galleries, and the
+	occasional unconventional venue — basements, storefronts, and pop-up spaces as much as traditional clubs. The
+	scene overlaps with the city's broader underground music and art communities.
+</p>
+<p class="text-muted-foreground leading-relaxed mb-4">
+	Sets can range from harsh noise to long-form ambient drone, often on bills that mix genres more freely than a
+	typical club night. If you're exploring for the first time, a quieter ambient set is usually a more approachable
+	entry point than a full noise show.
+</p>

--- a/resources/views/scenes/copy/goth-industrial.blade.php
+++ b/resources/views/scenes/copy/goth-industrial.blade.php
@@ -1,0 +1,10 @@
+<p class="text-muted-foreground leading-relaxed mb-4">
+	Pittsburgh's goth and industrial scene centers on a handful of recurring club nights and DJ sets spinning
+	darkwave, EBM, and industrial alongside classic goth staples. You'll find it as dedicated genre nights and as
+	backroom sets tucked into bigger club calendars around the city.
+</p>
+<p class="text-muted-foreground leading-relaxed mb-4">
+	The look and the music go together — expect fog, black lights, and a crowd that takes the aesthetic seriously.
+	Goth nights in this city tend to rotate venues over time, so the events and series listed below are the most
+	reliable way to track which ones are currently running.
+</p>

--- a/resources/views/scenes/copy/hip-hop-beats.blade.php
+++ b/resources/views/scenes/copy/hip-hop-beats.blade.php
@@ -1,0 +1,10 @@
+<p class="text-muted-foreground leading-relaxed mb-4">
+	Pittsburgh's hip hop scene runs from headline rap shows at the city's bigger rooms to beat showcases, open
+	cyphers, and producer nights in smaller clubs and DIY spaces. Local MCs and beatmakers share bills with touring
+	acts, and the beat-scene side of things — instrumental sets, trap and experimental production — keeps its own
+	steady circuit of nights.
+</p>
+<p class="text-muted-foreground leading-relaxed mb-4">
+	If you're looking for a way in, producer showcases and local openers are usually the best introduction — lineups
+	turn over fast and the same names show up across venues all over the city.
+</p>

--- a/resources/views/scenes/copy/punk-hardcore.blade.php
+++ b/resources/views/scenes/copy/punk-hardcore.blade.php
@@ -1,0 +1,10 @@
+<p class="text-muted-foreground leading-relaxed mb-4">
+	Punk and hardcore shows in Pittsburgh happen in basements, VFW halls, and small DIY venues as much as in
+	traditional clubs — a scene built on all-ages matinees, touring bands routing through on weeknights, and local
+	bills that mix genres freely. Expect word-of-mouth and hand-made flyers over big marketing pushes.
+</p>
+<p class="text-muted-foreground leading-relaxed mb-4">
+	The bands range from straightforward hardcore and pop-punk to noisier, more experimental corners of the genre.
+	If you're new to the scene, a local show is usually the friendliest way in — most spaces are welcoming and door
+	prices stay low.
+</p>

--- a/resources/views/scenes/copy/rave-edm.blade.php
+++ b/resources/views/scenes/copy/rave-edm.blade.php
@@ -1,0 +1,11 @@
+<p class="text-muted-foreground leading-relaxed mb-4">
+	Pittsburgh's rave and EDM scene runs through warehouses, DIY spaces, and clubs across the city, with promoters
+	booking everything from house and techno to bass-heavy EDM lineups. Look for late-night sets in repurposed
+	industrial spaces alongside more polished club nights downtown and in neighborhoods like Lawrenceville and the
+	Strip District.
+</p>
+<p class="text-muted-foreground leading-relaxed mb-4">
+	Local and touring DJs keep the calendar full most weekends, and the crowd ranges from all-ages day parties to
+	21+ after-hours events. Check individual event listings below for age restrictions, door times, and venue
+	details before you head out.
+</p>

--- a/resources/views/scenes/index-tw.blade.php
+++ b/resources/views/scenes/index-tw.blade.php
@@ -24,13 +24,9 @@
 			@foreach ($scenes as $scene)
 			<a href="{{ url('/scenes/'.$scene['slug']) }}"
 				class="block rounded-lg border border-border bg-card overflow-hidden hover:border-primary hover:shadow-md transition-all">
-				@if (!empty($scene['heroImageUrl']))
-				<img src="{{ $scene['heroImageUrl'] }}" alt="{{ $scene['name'] }}" class="w-full h-36 object-cover">
-				@else
 				<div class="w-full h-36 bg-muted flex items-center justify-center">
 					<i class="bi {{ $scene['icon'] ?? 'bi-music-note-beamed' }} text-4xl text-muted-foreground/60"></i>
 				</div>
-				@endif
 				<div class="p-6">
 					<h2 class="text-xl font-semibold text-foreground mb-2">{{ $scene['name'] }}</h2>
 					<p class="text-sm text-muted-foreground mb-4 line-clamp-2">{{ $scene['description'] }}</p>

--- a/resources/views/scenes/index-tw.blade.php
+++ b/resources/views/scenes/index-tw.blade.php
@@ -23,18 +23,27 @@
 		<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
 			@foreach ($scenes as $scene)
 			<a href="{{ url('/scenes/'.$scene['slug']) }}"
-				class="block rounded-lg border border-border bg-card p-6 hover:border-primary hover:shadow-md transition-all">
-				<h2 class="text-xl font-semibold text-foreground mb-2">{{ $scene['name'] }}</h2>
-				<p class="text-sm text-muted-foreground mb-4 line-clamp-2">{{ $scene['description'] }}</p>
-				<div class="flex items-center gap-4 text-sm text-muted-foreground">
-					<span class="inline-flex items-center gap-1">
-						<i class="bi bi-calendar-event"></i>
-						{{ $scene['stats']['events'] }} {{ Str::plural('event', $scene['stats']['events']) }}
-					</span>
-					<span class="inline-flex items-center gap-1">
-						<i class="bi bi-geo-alt"></i>
-						{{ $scene['stats']['venues'] }} {{ Str::plural('venue', $scene['stats']['venues']) }}
-					</span>
+				class="block rounded-lg border border-border bg-card overflow-hidden hover:border-primary hover:shadow-md transition-all">
+				@if (!empty($scene['heroImageUrl']))
+				<img src="{{ $scene['heroImageUrl'] }}" alt="{{ $scene['name'] }}" class="w-full h-36 object-cover">
+				@else
+				<div class="w-full h-36 bg-muted flex items-center justify-center">
+					<i class="bi {{ $scene['icon'] ?? 'bi-music-note-beamed' }} text-4xl text-muted-foreground/60"></i>
+				</div>
+				@endif
+				<div class="p-6">
+					<h2 class="text-xl font-semibold text-foreground mb-2">{{ $scene['name'] }}</h2>
+					<p class="text-sm text-muted-foreground mb-4 line-clamp-2">{{ $scene['description'] }}</p>
+					<div class="flex items-center gap-4 text-sm text-muted-foreground">
+						<span class="inline-flex items-center gap-1">
+							<i class="bi bi-calendar-event"></i>
+							{{ $scene['stats']['events'] }} {{ Str::plural('event', $scene['stats']['events']) }}
+						</span>
+						<span class="inline-flex items-center gap-1">
+							<i class="bi bi-geo-alt"></i>
+							{{ $scene['stats']['venues'] }} {{ Str::plural('venue', $scene['stats']['venues']) }}
+						</span>
+					</div>
 				</div>
 			</a>
 			@endforeach

--- a/resources/views/scenes/index-tw.blade.php
+++ b/resources/views/scenes/index-tw.blade.php
@@ -3,7 +3,7 @@
 @section('title', 'Pittsburgh Music Scenes')
 
 @php
-    $desc = 'Curated genre hubs for Pittsburgh — raves & EDM, punk & hardcore, goth & industrial, drum and bass, and experimental & noise, with upcoming events, key venues and artists, and active series.';
+    $desc = 'Curated genre hubs for Pittsburgh — '.collect(config('scenes'))->pluck('name')->map(fn ($name) => Str::lower($name))->join(', ', ' and ').' — with upcoming events, key venues and artists, and active series.';
 @endphp
 
 @section('description', $desc)

--- a/resources/views/scenes/index-tw.blade.php
+++ b/resources/views/scenes/index-tw.blade.php
@@ -1,0 +1,45 @@
+@extends('layouts.app-tw')
+
+@section('title', 'Pittsburgh Music Scenes')
+
+@php
+    $desc = 'Curated genre hubs for Pittsburgh — raves & EDM, punk & hardcore, goth & industrial, drum and bass, and experimental & noise, with upcoming events, key venues and artists, and active series.';
+@endphp
+
+@section('description', $desc)
+@section('og-description', $desc)
+
+@section('content')
+
+<div class="mx-auto px-6 py-8 max-w-[2400px]">
+	<div class="space-y-6">
+		<!-- Page Header -->
+		<div class="mb-2">
+			<h1 class="text-4xl font-bold text-foreground">Scenes</h1>
+			<p class="mt-2 text-muted-foreground max-w-3xl">{{ $desc }}</p>
+		</div>
+
+		<!-- Scene Cards -->
+		<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+			@foreach ($scenes as $scene)
+			<a href="{{ url('/scenes/'.$scene['slug']) }}"
+				class="block rounded-lg border border-border bg-card p-6 hover:border-primary hover:shadow-md transition-all">
+				<h2 class="text-xl font-semibold text-foreground mb-2">{{ $scene['name'] }}</h2>
+				<p class="text-sm text-muted-foreground mb-4 line-clamp-2">{{ $scene['description'] }}</p>
+				<div class="flex items-center gap-4 text-sm text-muted-foreground">
+					<span class="inline-flex items-center gap-1">
+						<i class="bi bi-calendar-event"></i>
+						{{ $scene['stats']['events'] }} {{ Str::plural('event', $scene['stats']['events']) }}
+					</span>
+					<span class="inline-flex items-center gap-1">
+						<i class="bi bi-geo-alt"></i>
+						{{ $scene['stats']['venues'] }} {{ Str::plural('venue', $scene['stats']['venues']) }}
+					</span>
+				</div>
+			</a>
+			@endforeach
+		</div>
+	</div>
+</div>
+
+@stop

--- a/resources/views/scenes/show-tw.blade.php
+++ b/resources/views/scenes/show-tw.blade.php
@@ -41,13 +41,9 @@
 					{{ $stats['venues'] }} {{ Str::plural('venue', $stats['venues']) }}
 				</p>
 			</div>
-			@if (!empty($heroImageUrl))
-			<img src="{{ $heroImageUrl }}" alt="{{ $scene['name'] }}" class="hidden sm:block h-28 md:h-36 aspect-video object-cover rounded-lg border border-border shrink-0">
-			@else
 			<div class="hidden sm:flex h-28 md:h-36 aspect-video rounded-lg border border-border bg-muted items-center justify-center shrink-0">
 				<i class="bi {{ $scene['icon'] ?? 'bi-music-note-beamed' }} text-5xl text-muted-foreground/60"></i>
 			</div>
-			@endif
 		</div>
 
 		<!-- Sibling Scenes -->
@@ -96,21 +92,21 @@
 					View all
 				</a>
 			</div>
-			<div class="flex flex-wrap gap-2">
+			<div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-6 gap-2">
 				@foreach ($entities as $entity)
 				<a href="{{ route('entities.show', $entity->slug) }}"
-					class="inline-flex items-center gap-2 pl-1 pr-3 py-1 rounded-full border border-border bg-card hover:border-primary hover:bg-accent transition-colors"
+					class="flex items-center gap-2 px-3 py-2 min-w-0 rounded-lg border border-border bg-card hover:border-primary hover:bg-accent transition-colors"
 					title="{{ $entity->name }}">
 					@if ($primary = $entity->getPrimaryPhoto())
-					<img src="{{ Storage::disk('external')->url($primary->getStorageThumbnail()) }}" alt="" class="w-6 h-6 rounded-full object-cover">
+					<img src="{{ Storage::disk('external')->url($primary->getStorageThumbnail()) }}" alt="" class="w-6 h-6 rounded-full object-cover shrink-0">
 					@else
-					<span class="w-6 h-6 rounded-full bg-muted flex items-center justify-center">
+					<span class="w-6 h-6 rounded-full bg-muted flex items-center justify-center shrink-0">
 						<i class="bi bi-building text-xs text-muted-foreground"></i>
 					</span>
 					@endif
-					<span class="text-sm font-medium text-foreground">{{ $entity->name }}</span>
+					<span class="text-sm font-medium text-foreground truncate">{{ $entity->name }}</span>
 					@if ($role = $entity->roles->first())
-					<span class="text-xs text-muted-foreground">{{ $role->name }}</span>
+					<span class="text-xs text-muted-foreground shrink-0 ml-auto">{{ $role->name }}</span>
 					@endif
 				</a>
 				@endforeach

--- a/resources/views/scenes/show-tw.blade.php
+++ b/resources/views/scenes/show-tw.blade.php
@@ -33,12 +33,21 @@
 		</div>
 
 		<!-- Page Header -->
-		<div>
-			<h1 class="text-4xl font-bold text-foreground mb-2">{{ $scene['name'] }}</h1>
-			<p class="text-muted-foreground">
-				{{ $stats['events'] }} upcoming {{ Str::plural('event', $stats['events']) }} &middot;
-				{{ $stats['venues'] }} {{ Str::plural('venue', $stats['venues']) }}
-			</p>
+		<div class="flex items-start justify-between gap-6">
+			<div>
+				<h1 class="text-4xl font-bold text-foreground mb-2">{{ $scene['name'] }}</h1>
+				<p class="text-muted-foreground">
+					{{ $stats['events'] }} upcoming {{ Str::plural('event', $stats['events']) }} &middot;
+					{{ $stats['venues'] }} {{ Str::plural('venue', $stats['venues']) }}
+				</p>
+			</div>
+			@if (!empty($heroImageUrl))
+			<img src="{{ $heroImageUrl }}" alt="{{ $scene['name'] }}" class="hidden sm:block h-28 md:h-36 aspect-video object-cover rounded-lg border border-border shrink-0">
+			@else
+			<div class="hidden sm:flex h-28 md:h-36 aspect-video rounded-lg border border-border bg-muted items-center justify-center shrink-0">
+				<i class="bi {{ $scene['icon'] ?? 'bi-music-note-beamed' }} text-5xl text-muted-foreground/60"></i>
+			</div>
+			@endif
 		</div>
 
 		<!-- Sibling Scenes -->

--- a/resources/views/scenes/show-tw.blade.php
+++ b/resources/views/scenes/show-tw.blade.php
@@ -1,0 +1,131 @@
+@extends('layouts.app-tw')
+
+@section('title', $scene['title'])
+
+@php
+    $primaryTag = $scene['tags'][0];
+    $desc = rtrim($scene['description'], '.') . '. ' . $stats['events'] . ' upcoming ' . Str::plural('event', $stats['events']) . ' across ' . $stats['venues'] . ' ' . Str::plural('venue', $stats['venues']) . '.';
+@endphp
+
+@section('description', $desc)
+@section('og-description', $desc)
+
+@if ($events->isNotEmpty())
+@section('page.json')
+@include('events.index-json-ld', [
+    'pageUrl' => url('/scenes/'.$slug),
+    'pageName' => $scene['name'],
+    'pageDesc' => $desc,
+])
+@endsection
+@endif
+
+@section('content')
+
+<div class="mx-auto px-6 py-8 max-w-[2400px]">
+	<div class="space-y-8">
+		<!-- Back Button -->
+		<div class="flex items-center gap-4">
+			<a href="{{ url('/scenes') }}" class="inline-flex items-center gap-2 px-3 py-2 text-sm border border-border rounded-lg hover:bg-accent transition-colors">
+				<i class="bi bi-arrow-left"></i>
+				Back to Scenes
+			</a>
+		</div>
+
+		<!-- Page Header -->
+		<div>
+			<h1 class="text-4xl font-bold text-foreground mb-2">{{ $scene['name'] }}</h1>
+			<p class="text-muted-foreground">
+				{{ $stats['events'] }} upcoming {{ Str::plural('event', $stats['events']) }} &middot;
+				{{ $stats['venues'] }} {{ Str::plural('venue', $stats['venues']) }}
+			</p>
+		</div>
+
+		<!-- Sibling Scenes -->
+		<div class="flex flex-wrap gap-2">
+			@foreach (config('scenes') as $siblingSlug => $sibling)
+			<a href="{{ url('/scenes/'.$siblingSlug) }}"
+				class="inline-flex items-center px-3 py-1 rounded-full text-sm border transition-colors {{ $siblingSlug === $slug ? 'bg-primary text-primary-foreground border-primary' : 'border-border text-muted-foreground hover:bg-accent' }}">
+				{{ $sibling['name'] }}
+			</a>
+			@endforeach
+		</div>
+
+		<!-- Editorial Copy -->
+		<div class="max-w-3xl">
+			@include('scenes.copy.'.$slug)
+		</div>
+
+		<!-- Upcoming Events -->
+		<div>
+			<div class="flex items-baseline gap-3 mb-4">
+				<h2 class="text-2xl font-semibold text-foreground">Upcoming Events</h2>
+				<a href="{{ url('/events?filters[tag]='.$primaryTag) }}" class="text-sm text-muted-foreground hover:text-foreground transition-colors">
+					View all
+				</a>
+			</div>
+			@if ($events->isNotEmpty())
+			<div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-6">
+				@foreach ($events as $event)
+				@include('events.card-tw', ['event' => $event, 'series' => null, 'entity' => null])
+				@endforeach
+			</div>
+			@else
+			<div class="text-center py-12 bg-card rounded-lg border border-border">
+				<i class="bi bi-calendar-x text-4xl text-muted-foreground/50 mb-3 block"></i>
+				<p class="text-muted-foreground">No upcoming {{ $scene['name'] }} events posted yet.</p>
+			</div>
+			@endif
+		</div>
+
+		<!-- Key Venues & Artists -->
+		@if ($entities->isNotEmpty())
+		<div>
+			<div class="flex items-baseline gap-3 mb-4">
+				<h2 class="text-2xl font-semibold text-foreground">Key Venues &amp; Artists</h2>
+				<a href="{{ url('/entities?filters[tag]='.$primaryTag) }}" class="text-sm text-muted-foreground hover:text-foreground transition-colors">
+					View all
+				</a>
+			</div>
+			<div class="flex flex-wrap gap-2">
+				@foreach ($entities as $entity)
+				<a href="{{ route('entities.show', $entity->slug) }}"
+					class="inline-flex items-center gap-2 pl-1 pr-3 py-1 rounded-full border border-border bg-card hover:border-primary hover:bg-accent transition-colors"
+					title="{{ $entity->name }}">
+					@if ($primary = $entity->getPrimaryPhoto())
+					<img src="{{ Storage::disk('external')->url($primary->getStorageThumbnail()) }}" alt="" class="w-6 h-6 rounded-full object-cover">
+					@else
+					<span class="w-6 h-6 rounded-full bg-muted flex items-center justify-center">
+						<i class="bi bi-building text-xs text-muted-foreground"></i>
+					</span>
+					@endif
+					<span class="text-sm font-medium text-foreground">{{ $entity->name }}</span>
+					@if ($role = $entity->roles->first())
+					<span class="text-xs text-muted-foreground">{{ $role->name }}</span>
+					@endif
+				</a>
+				@endforeach
+			</div>
+		</div>
+		@endif
+
+		<!-- Active Series -->
+		@if ($series->isNotEmpty())
+		<div>
+			<div class="flex items-baseline gap-3 mb-4">
+				<h2 class="text-2xl font-semibold text-foreground">Active Series</h2>
+				<a href="{{ url('/series?filters[tag]='.$primaryTag) }}" class="text-sm text-muted-foreground hover:text-foreground transition-colors">
+					View all
+				</a>
+			</div>
+			<div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-6">
+				@foreach ($series as $s)
+				@include('series.card-tw', ['series' => $s, 'event' => null, 'entity' => null])
+				@endforeach
+			</div>
+		</div>
+		@endif
+	</div>
+</div>
+
+@stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -243,6 +243,9 @@ Route::get('update', function () {
     EventUpdated::dispatch(new Event());
 });
 
+Route::get('scenes', [\App\Http\Controllers\ScenesController::class, 'index'])->name('scenes.index');
+Route::get('scenes/{slug}', [\App\Http\Controllers\ScenesController::class, 'show'])->name('scenes.show');
+
 Route::get('events/tonight', [\App\Http\Controllers\EventTimeWindowController::class, 'show'])->defaults('window', 'tonight')->name('events.tonight');
 Route::get('events/today', [\App\Http\Controllers\EventTimeWindowController::class, 'show'])->defaults('window', 'today')->name('events.today');
 Route::get('events/this-weekend', [\App\Http\Controllers\EventTimeWindowController::class, 'show'])->defaults('window', 'this-weekend')->name('events.thisWeekend');

--- a/tests/Feature/Console/GenerateSitemapCommandTest.php
+++ b/tests/Feature/Console/GenerateSitemapCommandTest.php
@@ -78,6 +78,17 @@ class GenerateSitemapCommandTest extends TestCase
         $this->assertStringContainsString($base.'/events/this-week', $content);
     }
 
+    public function test_includes_the_scene_hub_pages(): void
+    {
+        $content = $this->generate();
+
+        $base = rtrim(config('app.url'), '/');
+        $this->assertStringContainsString($base.'/scenes', $content);
+        foreach (array_keys(config('scenes')) as $slug) {
+            $this->assertStringContainsString($base.'/scenes/'.$slug, $content);
+        }
+    }
+
     public function test_includes_public_content_and_excludes_non_public(): void
     {
         $public = Event::factory()->create([

--- a/tests/Feature/ScenesTest.php
+++ b/tests/Feature/ScenesTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\Tag;
+use App\Models\Visibility;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\View;
+use Tests\TestCase;
+
+class ScenesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    protected function firstSceneSlug(): string
+    {
+        return array_key_first(config('scenes'));
+    }
+
+    public function test_scene_show_is_ok_and_shows_only_matching_upcoming_public_events(): void
+    {
+        $slug = $this->firstSceneSlug();
+        $scene = config("scenes.$slug");
+        $sceneTag = Tag::factory()->create(['slug' => $scene['tags'][0]]);
+        $otherTag = Tag::factory()->create(['slug' => 'scenes-test-unrelated-tag']);
+
+        $matchingFutureEvent = Event::factory()->create([
+            'name' => 'Scene Matching Future Event',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => Carbon::now()->addDays(5),
+        ]);
+        $matchingFutureEvent->tags()->attach($sceneTag->id);
+
+        $untaggedFutureEvent = Event::factory()->create([
+            'name' => 'Scene Untagged Future Event',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => Carbon::now()->addDays(5),
+        ]);
+        $untaggedFutureEvent->tags()->attach($otherTag->id);
+
+        $matchingPastEvent = Event::factory()->create([
+            'name' => 'Scene Matching Past Event',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => Carbon::now()->subDays(5),
+        ]);
+        $matchingPastEvent->tags()->attach($sceneTag->id);
+
+        $response = $this->get('/scenes/'.$slug);
+
+        $response->assertOk();
+        $response->assertSee('Scene Matching Future Event');
+        $response->assertDontSee('Scene Untagged Future Event');
+        $response->assertDontSee('Scene Matching Past Event');
+    }
+
+    public function test_unknown_scene_slug_is_404(): void
+    {
+        $response = $this->get('/scenes/not-a-real-scene');
+
+        $response->assertNotFound();
+    }
+
+    public function test_scene_show_title_uses_config_and_brand_suffix_and_has_meta_description(): void
+    {
+        $slug = $this->firstSceneSlug();
+        $scene = config("scenes.$slug");
+
+        $response = $this->get('/scenes/'.$slug);
+
+        $response->assertOk();
+        $expectedTitle = e($scene['title']).' | '.config('app.app_name');
+        $response->assertSee('<title>'.$expectedTitle.'</title>', false);
+        $response->assertSee('<meta name="description" content="', false);
+    }
+
+    public function test_scene_show_includes_item_list_json_ld_when_events_exist(): void
+    {
+        $slug = $this->firstSceneSlug();
+        $scene = config("scenes.$slug");
+        $sceneTag = Tag::factory()->create(['slug' => $scene['tags'][0]]);
+
+        $event = Event::factory()->create([
+            'name' => 'Scene Json Ld Event',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => Carbon::now()->addDays(3),
+        ]);
+        $event->tags()->attach($sceneTag->id);
+
+        $response = $this->get('/scenes/'.$slug);
+
+        $response->assertOk();
+        $response->assertSee('"@type": "ItemList"', false);
+        $response->assertSee('Scene Json Ld Event', false);
+    }
+
+    public function test_scenes_index_lists_all_five_scene_names(): void
+    {
+        $response = $this->get('/scenes');
+
+        $response->assertOk();
+        foreach (config('scenes') as $scene) {
+            $response->assertSee($scene['name']);
+        }
+    }
+
+    public function test_every_configured_scene_has_a_copy_partial(): void
+    {
+        foreach (array_keys(config('scenes')) as $slug) {
+            $this->assertTrue(
+                View::exists('scenes.copy.'.$slug),
+                "Missing copy partial for scene [$slug]: scenes.copy.$slug"
+            );
+        }
+    }
+}

--- a/tests/Feature/ScenesTest.php
+++ b/tests/Feature/ScenesTest.php
@@ -113,7 +113,7 @@ class ScenesTest extends TestCase
         $response->assertDontSee('Scene Dormant Artist');
     }
 
-    public function test_scene_hero_falls_back_to_configured_icon_when_no_event_photo(): void
+    public function test_scene_page_shows_configured_icon(): void
     {
         $slug = $this->firstSceneSlug();
         $scene = config("scenes.$slug");

--- a/tests/Feature/ScenesTest.php
+++ b/tests/Feature/ScenesTest.php
@@ -164,7 +164,7 @@ class ScenesTest extends TestCase
         $response->assertSee('Scene Json Ld Event', false);
     }
 
-    public function test_scenes_index_lists_all_five_scene_names(): void
+    public function test_scenes_index_lists_all_configured_scene_names(): void
     {
         $response = $this->get('/scenes');
 

--- a/tests/Feature/ScenesTest.php
+++ b/tests/Feature/ScenesTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature;
 
+use App\Models\Entity;
+use App\Models\EntityStatus;
 use App\Models\Event;
 use App\Models\Tag;
 use App\Models\Visibility;
@@ -61,6 +63,65 @@ class ScenesTest extends TestCase
         $response->assertSee('Scene Matching Future Event');
         $response->assertDontSee('Scene Untagged Future Event');
         $response->assertDontSee('Scene Matching Past Event');
+    }
+
+    public function test_key_entities_require_recent_events_and_rank_by_activity(): void
+    {
+        $slug = $this->firstSceneSlug();
+        $scene = config("scenes.$slug");
+        $sceneTag = Tag::factory()->create(['slug' => $scene['tags'][0]]);
+
+        $makeEntity = function (string $name) use ($sceneTag): Entity {
+            $entity = Entity::factory()->create([
+                'name' => $name,
+                'slug' => str_replace(' ', '-', strtolower($name)),
+                'entity_status_id' => EntityStatus::ACTIVE,
+            ]);
+            $entity->tags()->attach($sceneTag->id);
+
+            return $entity;
+        };
+
+        $busyArtist = $makeEntity('Scene Busy Artist');
+        foreach ([3, 10] as $days) {
+            $event = Event::factory()->create([
+                'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+                'start_at' => Carbon::now()->addDays($days),
+            ]);
+            $event->entities()->attach($busyArtist->id);
+        }
+
+        $hostVenue = $makeEntity('Scene Host Venue');
+        Event::factory()->create([
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => Carbon::now()->addDays(7),
+            'venue_id' => $hostVenue->id,
+        ]);
+
+        $dormantArtist = $makeEntity('Scene Dormant Artist');
+        $oldEvent = Event::factory()->create([
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'start_at' => Carbon::now()->subYears(2),
+        ]);
+        $oldEvent->entities()->attach($dormantArtist->id);
+
+        $response = $this->get('/scenes/'.$slug);
+
+        $response->assertOk();
+        // Two recent events beat one; only-old-events entities are dropped.
+        $response->assertSeeInOrder(['Scene Busy Artist', 'Scene Host Venue']);
+        $response->assertDontSee('Scene Dormant Artist');
+    }
+
+    public function test_scene_hero_falls_back_to_configured_icon_when_no_event_photo(): void
+    {
+        $slug = $this->firstSceneSlug();
+        $scene = config("scenes.$slug");
+
+        $response = $this->get('/scenes/'.$slug);
+
+        $response->assertOk();
+        $response->assertSee('bi '.$scene['icon'], false);
     }
 
     public function test_unknown_scene_slug_is_404(): void


### PR DESCRIPTION
## Summary

Part 6 of 6 of the issue #2002 SEO series (base: `2002-seo-festival-series`). Genre demand (raves/edm pittsburgh, punk shows pittsburgh, goth events, dnb, experimental) validated scene hubs — pages a bare tag listing can't rank for without editorial copy.

Adds config-driven scene hub pages: `/scenes` and `/scenes/{slug}` for five scenes.

## Changes

- **`config/scenes.php`** — single source of scene data (name, SEO title, description, tag slugs). Slugs verified against real tags: rave-edm → rave/techno/house/edm/electronic; punk-hardcore → punk/hardcore; goth-industrial → goth/industrial/darkwave; drum-and-bass → drum-and-bass/jungle (`dnb` doesn't exist as a slug); experimental-noise → experimental/noise/ambient.
- **`ScenesController`** — `index` (scene cards with cached counts) and `show` (404 on unknown slug): upcoming visible events (limit 48, shared card eager loads), key entities (12), active series (8), public-only cached stats for the meta description.
- **Views** — scene page with **human-written editorial copy at the top** (one Blade partial per scene under `scenes/copy/` — ⚠️ *please review/polish these five paragraphs; they were kept deliberately generic*), events grid, venue/artist chips, active series, sibling-scene cross-links, ItemList JSON-LD via the shared partial.
- **Wiring** — sitemap (loops the config), footer Scenes group, sidebar nav item (desktop + mobile).
- Fixed a Blade scope-leak (page `$series`/`$entities` colliding with card-partial variables) using the same guard pattern as `tags/show-tw`.

## Test plan

- New `tests/Feature/ScenesTest.php`: tagged-event visible / untagged & past absent, unknown slug 404, config-driven titles/meta, JSON-LD, index lists all scenes, copy partial exists for every config key; sitemap test covers scene URLs.
- `composer phpstan` clean; full suite green at branch tip.

## Deploy notes

- `php artisan route:clear`; regenerate the sitemap.

Part of #2002. With this merged, all five work items of #2002 are implemented (measurement remains a GSC ops task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
