### PR TITLE
Fix: guard Instagram post against events with no primary photo [EVENTREPO-VA]

### DIFF
--- a/app/Http/Controllers/Api/EventInstagramController.php
+++ b/app/Http/Controllers/Api/EventInstagramController.php
@@ -155,6 +155,12 @@ class EventInstagramController extends Controller
             return back();
         }
 
+        if ($error = $this->eventPhotoError($event)) {
+            flash()->error('Error', $error);
+
+            return back();
+        }
+
         PostEventToInstagram::dispatch($event, false, $this->user?->id);
 
         flash()->success('Queued', 'This event is being posted to Instagram in the background. You will be notified when it finishes.');
@@ -172,6 +178,10 @@ class EventInstagramController extends Controller
         }
 
         if ($error = $this->instagramCredentialError($instagram)) {
+            return $this->instagramActionResponse(false, 'Error', $error);
+        }
+
+        if ($error = $this->eventPhotoError($event)) {
             return $this->instagramActionResponse(false, 'Error', $error);
         }
 
@@ -210,6 +220,10 @@ class EventInstagramController extends Controller
             return response()->json(['success' => false, 'message' => $error], 400);
         }
 
+        if ($error = $this->eventPhotoError($event)) {
+            return response()->json(['success' => false, 'message' => $error], 422);
+        }
+
         // Build the job so we can hand its tracking id back to the caller, then dispatch.
         $job = new PostEventToInstagram($event, true, $user->id);
         dispatch($job);
@@ -233,6 +247,21 @@ class EventInstagramController extends Controller
 
         if (!$instagram->getPageAccessToken()) {
             return 'You must have an Instagram page linked to post to Instagram.';
+        }
+
+        return null;
+    }
+
+    /**
+     * Instagram posts are built from the event's primary photo. Fail fast at
+     * dispatch time when it is missing so the caller gets an immediate,
+     * actionable message, instead of queuing a job that throws "You must have
+     * a photo…" and burns all three retries before giving up (EVENTREPO-VA).
+     */
+    private function eventPhotoError(Event $event): ?string
+    {
+        if (!$event->getPrimaryPhoto()) {
+            return 'This event must have a primary photo before it can be posted to Instagram.';
         }
 
         return null;

--- a/tests/Feature/ApiEventInstagramTest.php
+++ b/tests/Feature/ApiEventInstagramTest.php
@@ -69,6 +69,32 @@ class ApiEventInstagramTest extends TestCase
                  ]);
     }
 
+    public function test_cannot_post_event_without_primary_photo_to_instagram()
+    {
+        $user = User::factory()->create(['user_status_id' => 1]);
+        $this->actingAs($user, 'sanctum');
+
+        // Public event owned by the user, but with no primary photo attached.
+        $event = Event::factory()->create([
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'created_by' => $user->id,
+        ]);
+
+        // Credentials are present, so the request reaches the primary-photo guard.
+        $instagram = Mockery::mock(Instagram::class);
+        $instagram->shouldReceive('getIgUserId')->andReturn(123);
+        $instagram->shouldReceive('getPageAccessToken')->andReturn('token');
+        $this->app->instance(Instagram::class, $instagram);
+
+        $response = $this->postJson('/api/events/'.$event->id.'/instagram-post');
+
+        $response->assertStatus(422)
+                 ->assertJson([
+                     'success' => false,
+                     'message' => 'This event must have a primary photo before it can be posted to Instagram.',
+                 ]);
+    }
+
     public function test_cannot_post_private_event_to_instagram()
     {
         $user = User::factory()->create(['user_status_id' => 1]);


### PR DESCRIPTION
## Sentry issue

[EVENTREPO-VA](https://sentry.io/organizations/geoff-maddock/issues/7500374813/) — `RuntimeException: You must have a photo to extract the image to post to Instagram.`

- First seen 2026-05-22, **last seen 2026-08-01 (still recurring)**, 42 total events on the group, no user feedback attached.
- Culprit: `App\Services\Integrations\InstagramEventPoster::primaryImageUrl` (called from `postCarousel` / `postSingle`), thrown inside the queued `PostEventToInstagram` job.

## Root cause

`InstagramEventPoster` builds the post media from the event's **primary photo**. When an event has none, `primaryImageUrl()` throws `RuntimeException('You must have a photo…')` from *inside* the queued job. The job is configured with `tries = 3` and a backoff, so a single photoless post attempt fails three times before giving up — each failure re-reporting the same exception to Sentry.

The three dispatch sites in `EventInstagramController` already pre-flight Instagram **credentials** (`instagramCredentialError()`) before queuing, but nothing checks that the event actually has a photo — so a user posting a photoless event queues a job that is guaranteed to fail.

## What changed

- Added a small `eventPhotoError(Event $event): ?string` helper mirroring the existing `instagramCredentialError()` pattern: returns a user-facing message when `getPrimaryPhoto()` is null, otherwise null.
- Called it at all three dispatch sites — `postToInstagram` (single, flash + redirect), `postCarouselToInstagram` (carousel web, JSON/redirect), and `postCarouselToInstagramApi` (carousel API, `422`) — right after the existing credential check.

A photoless event now fails fast with an actionable message ("This event must have a primary photo before it can be posted to Instagram.") instead of queuing a doomed job that burns three retries and floods Sentry.

## Tests

- Added `test_cannot_post_event_without_primary_photo_to_instagram` to `tests/Feature/ApiEventInstagramTest.php`: owner posts a public event with credentials present but **no** primary photo → asserts `422` and the guard message. Mirrors the existing owned-public-event success test, which already attaches a primary photo (comment: "so getPrimaryPhoto() succeeds"), so the new guard is consistent with existing expectations.
- Both changed files pass `php -l`. PHPStan and PHPUnit could not be run in this environment (Composer dependencies are not installed and the test suite requires a live MySQL database) — the diff is minimal and follows the surrounding, already-tested credential-check pattern.

Scope: minimal, targeted fix for this one Sentry issue. Does not merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4v1gttCHu6fZzasUQPTin)_