### PR TITLE
Fix: Column 'is_benefit' cannot be null on API event update [EVENTREPO-XH]

### DIFF
--- a/app/Http/Controllers/Api/EventsController.php
+++ b/app/Http/Controllers/Api/EventsController.php
@@ -1076,9 +1076,13 @@ class EventsController extends Controller
         $input = $request->all();
         $input['updated_by'] = $this->user->id;
 
+        $nonNullableBooleans = $this->nonNullableBooleanEventFields();
         foreach ($this->optionalEventFields() as $field) {
             if (!array_key_exists($field, $input)) {
-                $input[$field] = null;
+                // Boolean fields are backed by NOT NULL columns, so an omitted
+                // field resets to false (0) rather than null to avoid an
+                // integrity constraint violation.
+                $input[$field] = in_array($field, $nonNullableBooleans, true) ? false : null;
             }
         }
 
@@ -1151,6 +1155,21 @@ class EventsController extends Controller
             'cancelled_at',
             'do_not_repost',
             'min_age',
+        ];
+    }
+
+    /**
+     * Subset of optional fields backed by NOT NULL boolean columns. When these
+     * are omitted from a PUT they must reset to false, not null, otherwise the
+     * update fails with an integrity constraint violation.
+     *
+     * @return array<int, string>
+     */
+    private function nonNullableBooleanEventFields(): array
+    {
+        return [
+            'is_benefit',
+            'do_not_repost',
         ];
     }
 

--- a/tests/Feature/ApiEventsCrudTest.php
+++ b/tests/Feature/ApiEventsCrudTest.php
@@ -91,6 +91,29 @@ class ApiEventsCrudTest extends TestCase
         $this->assertSame('ZZ-Updated-Event', $event->fresh()->name);
     }
 
+    public function test_update_resets_omitted_boolean_fields_to_false(): void
+    {
+        $event = Event::factory()->create([
+            'created_by' => $this->user->id,
+            'slug' => 'zz-benefit-target-'.uniqid(),
+            'is_benefit' => 1,
+            'do_not_repost' => 1,
+        ]);
+
+        // PUT payload deliberately omits is_benefit and do_not_repost. Those
+        // columns are NOT NULL, so the update must reset them to false rather
+        // than null (which previously triggered an integrity constraint error).
+        $payload = $this->validPayload(['slug' => $event->slug]);
+        unset($payload['is_benefit'], $payload['do_not_repost']);
+
+        $response = $this->putJson('/api/events/'.$event->slug, $payload);
+
+        $response->assertOk();
+        $fresh = $event->fresh();
+        $this->assertSame(0, (int) $fresh->is_benefit);
+        $this->assertFalse((bool) $fresh->do_not_repost);
+    }
+
     public function test_update_refuses_when_not_creator(): void
     {
         $other = User::factory()->create();


### PR DESCRIPTION
## Sentry issue

- **Issue:** [EVENTREPO-XH](https://geoff-maddock.sentry.io/issues/7648438008/)
- **Error:** `Illuminate\Database\QueryException: SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'is_benefit' cannot be null`
- **Endpoint:** `PUT /api/events/{event}` (`App\Http\Controllers\Api\EventsController::update`)
- **Occurrences:** 6 events, unresolved
- **User feedback:** none attached

## Error summary

A `PUT` to `/api/events/{slug}` fails with a database integrity-constraint violation when the request body omits `is_benefit`. The captured event's payload contained only `end_at, event_type_id, name, slug, start_at, venue_id, visibility_id` — no `is_benefit` — and the update aborted trying to write `NULL` into a `NOT NULL` column.

## Root cause

`EventsController::update()` implements full-replace (PUT) semantics: every field listed in `optionalEventFields()` that is absent from the request body is reset to `null`.

```php
foreach ($this->optionalEventFields() as $field) {
    if (!array_key_exists($field, $input)) {
        $input[$field] = null;
    }
}
```

Two of those optional fields — `is_benefit` and `do_not_repost` — are backed by `NOT NULL` boolean columns (`tinyint(1) NOT NULL DEFAULT '0'`, per `database/schema/mysql-schema.dump`). All the other optional fields are nullable, so only these two booleans break when omitted. Setting them to `null` violates the constraint and throws.

## What changed

- `app/Http/Controllers/Api/EventsController.php`: when an optional field is omitted from a PUT, reset non-nullable boolean fields (`is_benefit`, `do_not_repost`) to `false` (0) instead of `null`. Nullable fields are unchanged. Introduced a small `nonNullableBooleanEventFields()` helper listing the two columns.
- `tests/Feature/ApiEventsCrudTest.php`: added `test_update_resets_omitted_boolean_fields_to_false`, which PUTs a payload omitting both boolean fields against an event that has them set to `1` and asserts they reset to `false` and the request succeeds.

The diff is minimal and scoped to the PUT update path; PATCH semantics are untouched.

## Verification note

Automated tests could **not** be run in the triage sandbox: `composer install` is blocked by proxy timeouts here, and the suite requires a live MySQL database that this environment does not provide. Changes pass `php -l` (syntax) and the added regression test will run under CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5WkMwDu1Qnt6AaQchGzYa)_