### PR TITLE
Fix: single-digit month/day 500 on API events by-date [EVENTREPO-WG]

### DIFF
--- a/app/Http/Controllers/Api/EventsController.php
+++ b/app/Http/Controllers/Api/EventsController.php
@@ -371,17 +371,19 @@ class EventsController extends Controller
         ?string $day = null
     ): JsonResponse {
         // set the start_at from and to dates based on the passed params
+        // Cast the route params to integers so single-digit months/days (e.g. /api/events/by-date/2026/8)
+        // produce a valid date instead of an unparseable string like "2026801" (EVENTREPO-WG).
         if ($year && !$month && !$day) {
-            $start_at_from = $year.'0101';
-            $start_at_to = $year.'1231';
+            $start_at_from = Carbon::create((int) $year, 1, 1)->startOfDay();
+            $start_at_to = Carbon::create((int) $year, 12, 31)->startOfDay();
             $slug = $year;
         } elseif (!$day) {
-            $start_at_from = Carbon::parse($year.$month.'01');
-            $start_at_to = Carbon::parse($start_at_from)->endOfMonth();
+            $start_at_from = Carbon::create((int) $year, (int) $month, 1)->startOfDay();
+            $start_at_to = $start_at_from->copy()->endOfMonth();
             $slug = $year.' - '.$month;
         } else {
-            $start_at_from = Carbon::parse($year.$month.$day);
-            $start_at_to = Carbon::parse($start_at_from)->addDay();
+            $start_at_from = Carbon::create((int) $year, (int) $month, (int) $day)->startOfDay();
+            $start_at_to = $start_at_from->copy()->addDay();
             $slug = $year.' - '.$month.' - '.$day;
         }
 

--- a/tests/Feature/ApiEventsHappyPathTest.php
+++ b/tests/Feature/ApiEventsHappyPathTest.php
@@ -79,6 +79,22 @@ class ApiEventsHappyPathTest extends TestCase
         $response->assertStatus(200);
     }
 
+    public function test_index_by_date_handles_single_digit_month(): void
+    {
+        // Regression: /api/events/by-date/2026/8 previously concatenated the raw
+        // params into the unparseable string "2026801" and threw a 500 (EVENTREPO-WG).
+        $response = $this->getJson('/api/events/by-date/2026/8');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_index_by_date_handles_single_digit_month_and_day(): void
+    {
+        $response = $this->getJson('/api/events/by-date/2026/8/4');
+
+        $response->assertStatus(200);
+    }
+
     public function test_index_attending_returns_list(): void
     {
         $response = $this->getJson('/api/events/attending');


### PR DESCRIPTION
## Sentry issue

[EVENTREPO-WG](https://sentry.io/organizations/geoff-maddock/issues/7617395307/) — `Carbon\Exceptions\InvalidFormatException: Could not parse '2026801': Failed to parse time string (2026801) at position 4 (8): Unexpected character`

- **Route:** `GET /api/events/by-date/{year}/{month?}/{day?}` → `App\Http\Controllers\Api\EventsController::indexByDate`
- **Reproducing URL from Sentry:** `GET https://arcane.city/api/events/by-date/2026/8`
- **Still firing:** latest event `2026-08-04`; count ~2, user feedback: none attached.

## Why this isn't already fixed by #1974

PR #1974 fixed this exact bug — but only in the **web** controller (`app/Http/Controllers/EventsController.php`). The **API** controller has its own `indexByDate` with the same string-concatenation logic, which #1974 did not touch. The Sentry stacktrace points squarely at `app/Http/Controllers/Api/EventsController.php:379`, so the issue kept firing after #1974 merged.

## Root cause

`Api\EventsController::indexByDate` built the `start_at` range by string-concatenating the raw route params:

```php
$start_at_from = Carbon::parse($year.$month.'01');   // "2026" . "8" . "01" = "2026801"
```

A single-digit month (or day) isn't zero-padded, so `2026` + `8` + `01` yields `"2026801"`, which Carbon can't parse — throwing `InvalidFormatException` and surfacing as a 500. Two-digit months (`/api/events/by-date/2026/08`) happened to work, which is why it fired intermittently.

## Change

`app/Http/Controllers/Api/EventsController.php` — build the range with `Carbon::create()` and integer-cast params, mirroring the fix already merged for the sibling web controller in #1974:

```php
$start_at_from = Carbon::create((int) $year, (int) $month, 1)->startOfDay();
$start_at_to   = $start_at_from->copy()->endOfMonth();
```

Downstream `where('start_at', '>', …)->where('start_at', '<', …)` semantics are preserved (year → whole year, month → whole month, day → that day through the next). The route already permits single-digit month/day (`routes/api.php` constraints `(0?[1-9]|1[012])` / `(0?[1-9]|[12][0-9]|3[01])`), so the params reach the controller.

## Tests

Added two regression tests in `tests/Feature/ApiEventsHappyPathTest.php`, alongside the existing year-only test:

- `test_index_by_date_handles_single_digit_month` — `GET /api/events/by-date/2026/8` returns 200 (previously 500).
- `test_index_by_date_handles_single_digit_month_and_day` — `GET /api/events/by-date/2026/8/4` returns 200.

> Note: the full `composer tests` pipeline (MySQL migrate + seed + phpunit) wasn't runnable in the triage sandbox (no MySQL; composer install stalled on a large VCS dependency). `php -l` passes on both changed files and the change is a line-for-line mirror of the already-merged, CI-passed pattern from #1974. CI will exercise the new tests.

## Scope

Single controller method + tests. No migrations, seeders, or frontend changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lc3mWL4xAZk2i3vVuaCkxg)_