### PR TITLE
Tag show: add section jump links, split events into Upcoming/Past

### DIFF
--- a/app/Http/Controllers/TagsController.php
+++ b/app/Http/Controllers/TagsController.php
@@ -273,14 +273,22 @@ class TagsController extends Controller
             ->limit(8)
             ->get();
 
-        // get limited events linked to the tag (8 for preview)
-        $events = Event::getByTag($slug)
+        // get limited events linked to the tag (8 each for preview)
+        $eventsBase = fn () => Event::getByTag($slug)
             ->with('visibility', 'venue','tags', 'entities','series','eventType','threads')
             ->where(function ($query) {
                 /* @phpstan-ignore-next-line */
                 $query->visible($this->user);
-            })
-            ->orderBy('start_at', 'DESC')
+            });
+
+        $upcomingEvents = $eventsBase()
+            ->future()
+            ->orderBy('name', 'ASC')
+            ->limit(8)
+            ->get();
+
+        $pastEvents = $eventsBase()
+            ->past()
             ->orderBy('name', 'ASC')
             ->limit(8)
             ->get();
@@ -297,12 +305,10 @@ class TagsController extends Controller
             ->limit(8)
             ->get();
 
-        $tags = Tag::orderBy('name', 'ASC')->get();
-
         // Get related tags based on co-occurrence with events
         $relatedTags = $tagObject ? $tagObject->relatedTags() : [];
 
-        return view('tags.show-tw', compact('series', 'entities', 'events', 'slug', 'tag', 'tagObject', 'tags', 'relatedTags'));
+        return view('tags.show-tw', compact('series', 'entities', 'upcomingEvents', 'pastEvents', 'slug', 'tag', 'tagObject', 'relatedTags'));
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "dev-events",
             "dependencies": {
                 "alpinejs": "^3.13.5",
                 "bootstrap-icons": "^1.5.0",
@@ -2430,10 +2431,9 @@
             ]
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
-            "license": "MIT",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },

--- a/resources/views/tags/show-tw.blade.php
+++ b/resources/views/tags/show-tw.blade.php
@@ -96,6 +96,36 @@ Tags
 			@endif
 		</div>
 
+		<!-- Section Jump Links -->
+		@if(count($upcomingEvents) > 0 || count($pastEvents) > 0 || count($entities) > 0 || count($series) > 0)
+		<div class="flex flex-wrap gap-2">
+			@if(count($upcomingEvents) > 0)
+			<a href="#upcoming-events" class="inline-flex items-center px-4 py-2 bg-card border-2 border-primary text-foreground rounded-lg hover:bg-accent transition-colors text-sm font-medium">
+				<i class="bi bi-calendar-event mr-2"></i>
+				Upcoming Events
+			</a>
+			@endif
+			@if(count($pastEvents) > 0)
+			<a href="#past-events" class="inline-flex items-center px-4 py-2 bg-card border-2 border-primary text-foreground rounded-lg hover:bg-accent transition-colors text-sm font-medium">
+				<i class="bi bi-clock-history mr-2"></i>
+				Past Events
+			</a>
+			@endif
+			@if(count($entities) > 0)
+			<a href="#entities" class="inline-flex items-center px-4 py-2 bg-card border-2 border-primary text-foreground rounded-lg hover:bg-accent transition-colors text-sm font-medium">
+				<i class="bi bi-people mr-2"></i>
+				Entities
+			</a>
+			@endif
+			@if(count($series) > 0)
+			<a href="#series" class="inline-flex items-center px-4 py-2 bg-card border-2 border-primary text-foreground rounded-lg hover:bg-accent transition-colors text-sm font-medium">
+				<i class="bi bi-collection mr-2"></i>
+				Series
+			</a>
+			@endif
+		</div>
+		@endif
+
 		<!-- Related Tags Section -->
 		@if(isset($tagObject) && isset($relatedTags) && count($relatedTags) > 0)
 		<div>
@@ -124,17 +154,34 @@ Tags
 
 		<!-- Content Sections -->
 		<div class="space-y-8">
-			<!-- Events Section -->
-			@if(isset($events) && count($events) > 0)
-			<div>
+			<!-- Upcoming Events Section -->
+			@if(count($upcomingEvents) > 0)
+			<div id="upcoming-events" class="scroll-mt-6">
 				<div class="flex items-baseline gap-3 mb-4">
-					<h2 class="text-2xl font-semibold text-foreground">Events</h2>
+					<h2 class="text-2xl font-semibold text-foreground">Upcoming Events</h2>
 					<a href="{{ url('/events?filters[tag]=' . $slug) }}" class="text-sm text-muted-foreground hover:text-foreground transition-colors">
 						View all
 					</a>
 				</div>
 				<div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-3 3xl:grid-cols-4">
-					@foreach ($events->take(8) as $event)
+					@foreach ($upcomingEvents->take(8) as $event)
+					@include('events.card-tw', ['event' => $event, 'series' => null, 'entity' => null])
+					@endforeach
+				</div>
+			</div>
+			@endif
+
+			<!-- Past Events Section -->
+			@if(count($pastEvents) > 0)
+			<div id="past-events" class="scroll-mt-6">
+				<div class="flex items-baseline gap-3 mb-4">
+					<h2 class="text-2xl font-semibold text-foreground">Past Events</h2>
+					<a href="{{ url('/events?filters[tag]=' . $slug) }}" class="text-sm text-muted-foreground hover:text-foreground transition-colors">
+						View all
+					</a>
+				</div>
+				<div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-3 3xl:grid-cols-4">
+					@foreach ($pastEvents->take(8) as $event)
 					@include('events.card-tw', ['event' => $event, 'series' => null, 'entity' => null])
 					@endforeach
 				</div>
@@ -143,7 +190,7 @@ Tags
 
 			<!-- Entities Section -->
 			@if(isset($entities) && count($entities) > 0)
-			<div>
+			<div id="entities" class="scroll-mt-6">
 				<div class="flex items-baseline gap-3 mb-4">
 					<h2 class="text-2xl font-semibold text-foreground">Entities</h2>
 					<a href="{{ url('/entities?filters[tag]=' . $slug) }}" class="text-sm text-muted-foreground hover:text-foreground transition-colors">
@@ -160,7 +207,7 @@ Tags
 
 			<!-- Series Section -->
 			@if(isset($series) && count($series) > 0)
-			<div>
+			<div id="series" class="scroll-mt-6">
 				<div class="flex items-baseline gap-3 mb-4">
 					<h2 class="text-2xl font-semibold text-foreground">Series</h2>
 					<a href="{{ url('/series?filters[tag]=' . $slug) }}" class="text-sm text-muted-foreground hover:text-foreground transition-colors">
@@ -176,7 +223,7 @@ Tags
 			@endif
 
 			<!-- No Content Message -->
-			@if((!isset($series) || count($series) == 0) && (!isset($events) || count($events) == 0) && (!isset($entities) || count($entities) == 0))
+			@if(count($series) == 0 && count($upcomingEvents) == 0 && count($pastEvents) == 0 && count($entities) == 0)
 			<div class="text-center py-12 bg-card rounded-lg border border-border">
 				<i class="bi bi-tag text-4xl text-muted-foreground/50 mb-3 block"></i>
 				<p class="text-muted-foreground">No content found for this tag.</p>

--- a/tests/Feature/TagShowPageTest.php
+++ b/tests/Feature/TagShowPageTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\Tag;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TagShowPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    protected function makePublicEventWithTag(Tag $tag, array $attributes = []): Event
+    {
+        $event = Event::factory()->create(array_merge(['visibility_id' => 3], $attributes));
+        $event->tags()->attach($tag->id);
+
+        return $event;
+    }
+
+    /** @test */
+    public function upcoming_events_show_before_past_events()
+    {
+        $tag = Tag::factory()->create();
+        $future = $this->makePublicEventWithTag($tag, [
+            'name' => 'Zeta Future Gathering',
+            'start_at' => now()->addDays(3),
+        ]);
+        $past = $this->makePublicEventWithTag($tag, [
+            'name' => 'Alpha Past Gathering',
+            'start_at' => now()->subDays(3),
+        ]);
+
+        $response = $this->get("/tags/{$tag->slug}");
+
+        $response->assertOk();
+        $response->assertSeeInOrder(['Upcoming Events', $future->name, 'Past Events', $past->name]);
+    }
+
+    /** @test */
+    public function upcoming_events_are_sorted_ascending_by_start_date()
+    {
+        $tag = Tag::factory()->create();
+        $later = $this->makePublicEventWithTag($tag, [
+            'name' => 'Distant Future Event',
+            'start_at' => now()->addDays(10),
+        ]);
+        $sooner = $this->makePublicEventWithTag($tag, [
+            'name' => 'Near Future Event',
+            'start_at' => now()->addDays(2),
+        ]);
+
+        $response = $this->get("/tags/{$tag->slug}");
+
+        $response->assertOk();
+        $response->assertSeeInOrder([$sooner->name, $later->name]);
+    }
+
+    /** @test */
+    public function past_events_are_sorted_descending_by_start_date()
+    {
+        $tag = Tag::factory()->create();
+        $older = $this->makePublicEventWithTag($tag, [
+            'name' => 'Long Ago Event',
+            'start_at' => now()->subDays(10),
+        ]);
+        $recent = $this->makePublicEventWithTag($tag, [
+            'name' => 'Recent Past Event',
+            'start_at' => now()->subDays(2),
+        ]);
+
+        $response = $this->get("/tags/{$tag->slug}");
+
+        $response->assertOk();
+        $response->assertSeeInOrder([$recent->name, $older->name]);
+    }
+
+    /** @test */
+    public function jump_links_and_section_anchors_render_for_populated_sections()
+    {
+        $tag = Tag::factory()->create();
+        $this->makePublicEventWithTag($tag, ['start_at' => now()->addDays(3)]);
+        $this->makePublicEventWithTag($tag, ['start_at' => now()->subDays(3)]);
+
+        $response = $this->get("/tags/{$tag->slug}");
+
+        $response->assertOk();
+        $response->assertSee('href="#upcoming-events"', false);
+        $response->assertSee('href="#past-events"', false);
+        $response->assertSee('id="upcoming-events"', false);
+        $response->assertSee('id="past-events"', false);
+    }
+
+    /** @test */
+    public function empty_tag_shows_no_content_message_and_no_jump_links()
+    {
+        $tag = Tag::factory()->create();
+
+        $response = $this->get("/tags/{$tag->slug}");
+
+        $response->assertOk();
+        $response->assertSee('No content found for this tag.');
+        $response->assertDontSee('href="#upcoming-events"', false);
+        $response->assertDontSee('href="#past-events"', false);
+    }
+}


### PR DESCRIPTION
## Summary

Improves the tag show page (`/tags/{tag}`):

- **Section jump links** — a pill row below the page header (same style as the search page), with one pill per non-empty section: Upcoming Events, Past Events, Entities, Series. Each section has an anchor id with `scroll-mt-6` so clicking a pill scrolls to it with a small offset.
- **Events split into Upcoming/Past** — previously a single Events section sorted `start_at DESC`, which buried upcoming events under recent history on active tags. Now an **Upcoming Events** section renders first (ascending, via the existing `Event::future()` scope), followed by **Past Events** (descending, via `past()`). Both keep the 8-item preview limit and the existing "View all" link to `/events?filters[tag]={slug}`.
- Removed an unused `$tags = Tag::orderBy('name')->get()` query from `TagsController::show()` that loaded every tag on each request but was never referenced by the view.
- Entities, Series, and Related Tags sections are unchanged (other than gaining anchor ids).

Note: the upcoming/past boundary is start-of-today (consistent with the entity show page), so an event from earlier today still counts as upcoming.

## Manual testing

1. Visit a tag that has both future and past events (e.g. an active genre tag):
   - Jump-link pills render below the header for each populated section.
   - Clicking each pill scrolls to the matching section with a small top offset.
   - **Upcoming Events** appears first, sorted soonest-first; **Past Events** below it, sorted most-recent-first.
   - Both event sections show at most 8 cards and their "View all" links go to the filtered events index.
2. Visit a tag with only past events: no Upcoming Events section or pill; Past Events renders normally.
3. Visit a tag with no content at all: the "No content found for this tag." card shows and no pills render.
4. As a signed-in user with private/proposal events, confirm visibility rules still apply (only your own non-public events appear).

## Automated tests

- New `tests/Feature/TagShowPageTest.php` (5 tests): upcoming-before-past ordering, ascending upcoming sort, descending past sort, jump links/anchors render, empty-tag state.
- `composer phpstan` clean on the controller; existing SEO tests hitting `/tags/{slug}` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)