### PR TITLE
Add Event Graph admin module at events/graph

### DIFF
--- a/app/Http/Controllers/ActivityController.php
+++ b/app/Http/Controllers/ActivityController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Filters\ActivityFilters;
+use App\Http\Controllers\Concerns\BucketsGraphData;
 use App\Http\ResultBuilder\ListEntityResultBuilder;
 use App\Models\Action;
 use App\Models\Activity;
@@ -17,9 +18,9 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ActivityController extends Controller
 {
-    private const UNKNOWN_LABEL = 'Unknown';
+    use BucketsGraphData;
 
-    private const ALLOWED_GROUP_BY = ['day', 'week', 'month', 'year'];
+    private const UNKNOWN_LABEL = 'Unknown';
 
     protected string $prefix;
 
@@ -324,50 +325,6 @@ class ActivityController extends Controller
         }
 
         return $datasets;
-    }
-
-    protected function buildBucketLabels(Carbon $startDate, Carbon $endDate, string $groupBy): array
-    {
-        $labels = [];
-        $cursor = $this->getBucketStart($startDate, $groupBy);
-        $endBucket = $this->getBucketStart($endDate, $groupBy);
-
-        while ($cursor->lte($endBucket)) {
-            $labels[] = $this->getBucketLabel($cursor, $groupBy);
-            $this->advanceBucketCursor($cursor, $groupBy);
-        }
-
-        return $labels;
-    }
-
-    protected function getBucketLabel(Carbon $date, string $groupBy): string
-    {
-        return match ($groupBy) {
-            'week' => $date->copy()->startOfWeek(Carbon::MONDAY)->format('Y-m-d'),
-            'month' => $date->copy()->startOfMonth()->format('Y-m'),
-            'year' => $date->copy()->startOfYear()->format('Y'),
-            default => $date->copy()->startOfDay()->format('Y-m-d'),
-        };
-    }
-
-    protected function getBucketStart(Carbon $date, string $groupBy): Carbon
-    {
-        return match ($groupBy) {
-            'week' => $date->copy()->startOfWeek(Carbon::MONDAY),
-            'month' => $date->copy()->startOfMonth(),
-            'year' => $date->copy()->startOfYear(),
-            default => $date->copy()->startOfDay(),
-        };
-    }
-
-    protected function advanceBucketCursor(Carbon $cursor, string $groupBy): void
-    {
-        match ($groupBy) {
-            'week' => $cursor->addWeek(),
-            'month' => $cursor->addMonth(),
-            'year' => $cursor->addYear(),
-            default => $cursor->addDay(),
-        };
     }
 
     protected function getActivityTypeExpression(): string

--- a/app/Http/Controllers/Concerns/BucketsGraphData.php
+++ b/app/Http/Controllers/Concerns/BucketsGraphData.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers\Concerns;
+
+use Carbon\Carbon;
+
+/**
+ * Shared time-bucketing helpers for graph endpoints (activity graph, event graph).
+ */
+trait BucketsGraphData
+{
+    protected const ALLOWED_GROUP_BY = ['day', 'week', 'month', 'year'];
+
+    protected function buildBucketLabels(Carbon $startDate, Carbon $endDate, string $groupBy): array
+    {
+        $labels = [];
+        $cursor = $this->getBucketStart($startDate, $groupBy);
+        $endBucket = $this->getBucketStart($endDate, $groupBy);
+
+        while ($cursor->lte($endBucket)) {
+            $labels[] = $this->getBucketLabel($cursor, $groupBy);
+            $this->advanceBucketCursor($cursor, $groupBy);
+        }
+
+        return $labels;
+    }
+
+    protected function getBucketLabel(Carbon $date, string $groupBy): string
+    {
+        return match ($groupBy) {
+            'week' => $date->copy()->startOfWeek(Carbon::MONDAY)->format('Y-m-d'),
+            'month' => $date->copy()->startOfMonth()->format('Y-m'),
+            'year' => $date->copy()->startOfYear()->format('Y'),
+            default => $date->copy()->startOfDay()->format('Y-m-d'),
+        };
+    }
+
+    protected function getBucketStart(Carbon $date, string $groupBy): Carbon
+    {
+        return match ($groupBy) {
+            'week' => $date->copy()->startOfWeek(Carbon::MONDAY),
+            'month' => $date->copy()->startOfMonth(),
+            'year' => $date->copy()->startOfYear(),
+            default => $date->copy()->startOfDay(),
+        };
+    }
+
+    protected function advanceBucketCursor(Carbon $cursor, string $groupBy): void
+    {
+        match ($groupBy) {
+            'week' => $cursor->addWeek(),
+            'month' => $cursor->addMonth(),
+            'year' => $cursor->addYear(),
+            default => $cursor->addDay(),
+        };
+    }
+}

--- a/app/Http/Controllers/EventGraphController.php
+++ b/app/Http/Controllers/EventGraphController.php
@@ -1,0 +1,328 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Concerns\BucketsGraphData;
+use App\Models\EntityType;
+use App\Models\Event;
+use App\Models\EventType;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class EventGraphController extends Controller
+{
+    use BucketsGraphData;
+
+    protected const ALLOWED_SERIES_BY = ['total', 'event_type', 'venue', 'promoter', 'series', 'tag', 'entity'];
+
+    protected const ALLOWED_DATE_FIELDS = ['start_at', 'created_at'];
+
+    public function __construct()
+    {
+        $this->middleware(['auth', 'can:admin']);
+        parent::__construct();
+    }
+
+    public function graph(Request $request): string
+    {
+        $filters = $this->getGraphFilters($request);
+        $graphData = $this->buildGraphData($filters);
+
+        return view('events.graph-tw')
+            ->with(array_merge($graphData, ['filters' => $filters], $this->getGraphOptions()))
+            ->render();
+    }
+
+    public function exportGraph(Request $request): StreamedResponse
+    {
+        $filters = $this->getGraphFilters($request);
+        $graphData = $this->buildGraphData($filters);
+        $rows = $graphData['rows'];
+        $filename = 'event-graph-'.Carbon::now()->format('Ymd-His').'.csv';
+
+        return response()->streamDownload(function () use ($rows, $graphData, $filters): void {
+            $output = fopen('php://output', 'w');
+            if ($output === false) {
+                Log::error('Failed to open output stream for event graph export', [
+                    'filters' => $filters,
+                ]);
+                return;
+            }
+
+            fputcsv($output, ['Period', 'Series', 'Count']);
+            foreach ($rows as $row) {
+                fputcsv($output, [$row->period, $row->series_label, $row->event_count]);
+            }
+
+            fputcsv($output, []);
+            fputcsv($output, ['Breakdown', $filters['series_by']]);
+            fputcsv($output, ['Date basis', $filters['date_field']]);
+            fputcsv($output, ['Grouping', $filters['group_by']]);
+            fputcsv($output, ['Included dates', $graphData['startDate']->toDateString().' to '.$graphData['endDate']->toDateString()]);
+            fclose($output);
+        }, $filename, [
+            'Content-Type' => 'text/csv',
+        ]);
+    }
+
+    protected function getGraphFilters(Request $request): array
+    {
+        $input = $request->only([
+            'days', 'start_date', 'end_date', 'group_by', 'series_by', 'date_field',
+            'event_type_id', 'entity_type_id', 'tag', 'line_limit',
+        ]);
+
+        $validator = validator($input, [
+            'days' => ['nullable', 'integer', 'min:1', 'max:1095'],
+            'start_date' => ['nullable', 'date'],
+            'end_date' => ['nullable', 'date'],
+            'group_by' => ['nullable', 'in:'.implode(',', self::ALLOWED_GROUP_BY)],
+            'series_by' => ['nullable', 'in:'.implode(',', self::ALLOWED_SERIES_BY)],
+            'date_field' => ['nullable', 'in:'.implode(',', self::ALLOWED_DATE_FIELDS)],
+            'event_type_id' => ['nullable', 'integer', 'min:1'],
+            'entity_type_id' => ['nullable', 'integer', 'min:1'],
+            'tag' => ['nullable', 'string', 'max:100'],
+            'line_limit' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        $validated = $validator->fails() ? [] : $validator->validated();
+
+        $days = max(1, min(1095, (int) ($validated['days'] ?? 90)));
+        $startDateInput = $validated['start_date'] ?? null;
+        $endDateInput = $validated['end_date'] ?? null;
+        $today = Carbon::today();
+
+        if ($startDateInput || $endDateInput) {
+            $startDate = $startDateInput ? Carbon::parse($startDateInput)->startOfDay() : $today->copy()->subDays($days - 1)->startOfDay();
+            $endDate = $endDateInput ? Carbon::parse($endDateInput)->endOfDay() : $today->copy()->endOfDay();
+        } else {
+            $endDate = $today->copy()->endOfDay();
+            $startDate = $today->copy()->subDays($days - 1)->startOfDay();
+        }
+
+        if ($startDate->gt($endDate)) {
+            [$startDate, $endDate] = [$endDate->copy()->startOfDay(), $startDate->copy()->endOfDay()];
+        }
+
+        return [
+            'days' => $days,
+            'start_date' => $startDate->toDateString(),
+            'end_date' => $endDate->toDateString(),
+            'group_by' => $validated['group_by'] ?? 'week',
+            'series_by' => $validated['series_by'] ?? 'event_type',
+            'date_field' => $validated['date_field'] ?? 'start_at',
+            'event_type_id' => isset($validated['event_type_id']) ? (int) $validated['event_type_id'] : null,
+            'entity_type_id' => isset($validated['entity_type_id']) ? (int) $validated['entity_type_id'] : null,
+            'tag' => isset($validated['tag']) && trim((string) $validated['tag']) !== '' ? trim((string) $validated['tag']) : null,
+            'line_limit' => max(1, min(100, (int) ($validated['line_limit'] ?? 10))),
+        ];
+    }
+
+    protected function buildGraphData(array $filters): array
+    {
+        $startDate = Carbon::parse($filters['start_date'])->startOfDay();
+        $endDate = Carbon::parse($filters['end_date'])->endOfDay();
+        $lineLimit = max(1, (int) $filters['line_limit']);
+        $groupBy = $filters['group_by'];
+        $seriesBy = $filters['series_by'];
+        $dateField = in_array($filters['date_field'], self::ALLOWED_DATE_FIELDS, true) ? $filters['date_field'] : 'start_at';
+
+        $baseQuery = Event::query()
+            ->whereBetween('events.'.$dateField, [$startDate, $endDate]);
+
+        if (!empty($filters['event_type_id'])) {
+            $baseQuery->where('events.event_type_id', $filters['event_type_id']);
+        }
+        if (!empty($filters['tag'])) {
+            $tag = $filters['tag'];
+            $baseQuery->whereHas('tags', function ($query) use ($tag): void {
+                $query->where('tags.name', 'like', '%'.$tag.'%')
+                    ->orWhere('tags.slug', 'like', '%'.$tag.'%');
+            });
+        }
+        // when the breakdown is not by entity, the entity type acts as an event filter instead
+        if (!empty($filters['entity_type_id']) && $seriesBy !== 'entity') {
+            $baseQuery->whereHas('entities', function ($query) use ($filters): void {
+                $query->where('entities.entity_type_id', $filters['entity_type_id']);
+            });
+        }
+
+        $seriesExpr = $this->applySeriesDimension($baseQuery, $seriesBy, $filters);
+
+        $topSeries = $this->resolveTopSeries(clone $baseQuery, $seriesExpr, $lineLimit);
+        $dailyRows = $this->queryDailyRows(clone $baseQuery, $seriesExpr, $dateField, $topSeries);
+        $labels = $this->buildBucketLabels($startDate, $endDate, $groupBy);
+        $rows = $this->bucketRows($dailyRows, $labels, $groupBy);
+        $datasets = $this->buildDatasets($topSeries, $labels, $rows);
+        $total = array_sum(array_map(fn ($row) => (int) $row->event_count, $rows->all()));
+
+        return [
+            'labels' => $labels,
+            'datasets' => $datasets,
+            'rows' => $rows,
+            'startDate' => $startDate,
+            'endDate' => $endDate,
+            'groupBy' => $groupBy,
+            'seriesBy' => $seriesBy,
+            'total' => $total,
+        ];
+    }
+
+    /**
+     * Add the joins needed for the requested breakdown and return the SQL expression
+     * that labels each series line.
+     *
+     * @param Builder<Event> $query
+     */
+    protected function applySeriesDimension(Builder $query, string $seriesBy, array $filters): string
+    {
+        switch ($seriesBy) {
+            case 'event_type':
+                $query->leftJoin('event_types', 'events.event_type_id', '=', 'event_types.id');
+
+                return "COALESCE(event_types.name, 'No type')";
+            case 'venue':
+                $query->leftJoin('entities as venue_entities', 'events.venue_id', '=', 'venue_entities.id');
+
+                return "COALESCE(venue_entities.name, 'No venue')";
+            case 'promoter':
+                $query->leftJoin('entities as promoter_entities', 'events.promoter_id', '=', 'promoter_entities.id');
+
+                return "COALESCE(promoter_entities.name, 'No promoter')";
+            case 'series':
+                $query->leftJoin('series as event_series', 'events.series_id', '=', 'event_series.id');
+
+                return "COALESCE(event_series.name, 'No series')";
+            case 'tag':
+                $query->join('event_tag', 'event_tag.event_id', '=', 'events.id')
+                    ->join('tags', 'tags.id', '=', 'event_tag.tag_id');
+
+                return 'tags.name';
+            case 'entity':
+                $query->join('entity_event', 'entity_event.event_id', '=', 'events.id')
+                    ->join('entities as related_entities', 'related_entities.id', '=', 'entity_event.entity_id');
+                if (!empty($filters['entity_type_id'])) {
+                    $query->where('related_entities.entity_type_id', $filters['entity_type_id']);
+                }
+
+                return 'related_entities.name';
+            default:
+                return "'Events'";
+        }
+    }
+
+    /**
+     * @param Builder<Event> $query
+     */
+    private function resolveTopSeries(Builder $query, string $seriesExpr, int $limit): array
+    {
+        return $query
+            ->selectRaw("{$seriesExpr} as series_label, COUNT(*) as total_count")
+            ->groupBy(DB::raw($seriesExpr))
+            ->orderByDesc('total_count')
+            ->limit($limit)
+            ->pluck('series_label')
+            ->map(fn ($label): string => (string) $label)
+            ->all();
+    }
+
+    /**
+     * @param Builder<Event> $query
+     */
+    private function queryDailyRows(Builder $query, string $seriesExpr, string $dateField, array $topSeries): Collection
+    {
+        if (empty($topSeries)) {
+            return collect();
+        }
+
+        $dateExpr = "DATE(events.{$dateField})";
+
+        return $query
+            ->selectRaw("{$dateExpr} as period, {$seriesExpr} as series_label, COUNT(*) as event_count")
+            ->groupBy(DB::raw($dateExpr), DB::raw($seriesExpr))
+            ->havingRaw('series_label IN ('.implode(',', array_fill(0, count($topSeries), '?')).')', $topSeries)
+            ->orderBy('period', 'asc')
+            ->orderBy('series_label', 'asc')
+            ->get()
+            ->map(function (mixed $row): array {
+                /** @var object{period: string, series_label: string, event_count: int} $row */
+                return [
+                    'period' => (string) $row->period,
+                    'series_label' => (string) $row->series_label,
+                    'event_count' => (int) $row->event_count,
+                ];
+            });
+    }
+
+    private function bucketRows(Collection $dailyRows, array $labels, string $groupBy): Collection
+    {
+        $bucketed = [];
+        foreach ($dailyRows as $row) {
+            $bucket = $this->getBucketLabel(Carbon::parse($row['period']), $groupBy);
+            $bucketed[$bucket][$row['series_label']] = ($bucketed[$bucket][$row['series_label']] ?? 0) + $row['event_count'];
+        }
+
+        $rows = collect();
+        foreach ($labels as $bucketLabel) {
+            foreach ($bucketed[$bucketLabel] ?? [] as $seriesLabel => $count) {
+                $rows->push((object) [
+                    'period' => $bucketLabel,
+                    'series_label' => $seriesLabel,
+                    'event_count' => $count,
+                ]);
+            }
+        }
+
+        return $rows;
+    }
+
+    private function buildDatasets(array $topSeries, array $labels, Collection $rows): array
+    {
+        $datasetsMap = [];
+        foreach ($topSeries as $seriesLabel) {
+            $datasetsMap[$seriesLabel] = array_fill_keys($labels, 0);
+        }
+
+        foreach ($rows as $row) {
+            if (isset($datasetsMap[$row->series_label][$row->period])) {
+                $datasetsMap[$row->series_label][$row->period] = (int) $row->event_count;
+            }
+        }
+
+        $datasets = [];
+        foreach ($datasetsMap as $seriesLabel => $countsByPeriod) {
+            $datasets[] = ['label' => $seriesLabel, 'data' => array_values($countsByPeriod)];
+        }
+
+        return $datasets;
+    }
+
+    protected function getGraphOptions(): array
+    {
+        return [
+            'seriesByOptions' => [
+                'total' => 'Total events',
+                'event_type' => 'Event type',
+                'venue' => 'Venue',
+                'promoter' => 'Promoter',
+                'series' => 'Series',
+                'tag' => 'Tag',
+                'entity' => 'Related entity',
+            ],
+            'dateFieldOptions' => [
+                'start_at' => 'Event date',
+                'created_at' => 'Created date',
+            ],
+            'eventTypeOptions' => ['' => 'All event types'] + EventType::orderBy('name', 'ASC')->pluck('name', 'id')->all(),
+            'entityTypeOptions' => ['' => 'All entity types'] + EntityType::orderBy('name', 'ASC')->pluck('name', 'id')->all(),
+            'daysOptions' => [30 => 'Last 30 days', 90 => 'Last 90 days', 180 => 'Last 180 days', 365 => 'Last year', 1095 => 'Last 3 years'],
+            'lineLimitOptions' => [5 => 'Top 5', 10 => 'Top 10', 20 => 'Top 20', 50 => 'Top 50'],
+            'groupByOptions' => array_combine(self::ALLOWED_GROUP_BY, array_map('ucfirst', self::ALLOWED_GROUP_BY)),
+        ];
+    }
+}

--- a/config/modules.php
+++ b/config/modules.php
@@ -54,6 +54,7 @@ return [
         ['name' => 'Blogs', 'url' => '/blogs', 'icon' => 'bi-journal-text', 'description' => 'Manage blog posts'],
         ['name' => 'Categories', 'url' => '/categories', 'icon' => 'bi-folder', 'description' => 'Manage forum categories'],
         ['name' => 'Entity Types', 'url' => '/entity-types', 'icon' => 'bi-diagram-3', 'description' => 'Manage entity types'],
+        ['name' => 'Event Graph', 'url' => '/events/graph', 'icon' => 'bi-bar-chart-line', 'description' => 'Visualize and export event trends by type, tag, venue and more'],
         ['name' => 'Forums', 'url' => '/forums', 'icon' => 'bi-chat-square-text', 'description' => 'Manage forum sections'],
         ['name' => 'Groups', 'url' => '/groups', 'icon' => 'bi-people-fill', 'description' => 'Manage user groups'],
         ['name' => 'Menus', 'url' => '/menus', 'icon' => 'bi-menu-button-wide', 'description' => 'Manage navigation menus'],

--- a/resources/views/events/graph-tw.blade.php
+++ b/resources/views/events/graph-tw.blade.php
@@ -1,0 +1,268 @@
+@extends('layouts.app-tw')
+
+@section('title', 'Event Graph')
+
+@section('content')
+<div class="mb-6">
+    <h1 class="text-3xl font-bold text-primary mb-2">Event Graph</h1>
+    <p class="text-muted-foreground">Admin-only event trends over time, broken down by type, tag, venue, series or related entities.</p>
+</div>
+
+<div class="card-tw p-4 mb-6">
+    <form method="GET" action="{{ route('events.graph') }}" id="graphForm" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        <div>
+            <label for="series_by" class="block text-sm text-muted-foreground mb-1">Break down by</label>
+            <select id="series_by" name="series_by" class="form-select-tw">
+                @foreach($seriesByOptions as $value => $label)
+                    <option value="{{ $value }}" {{ ($filters['series_by'] ?? 'event_type') === $value ? 'selected' : '' }}>{{ $label }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div>
+            <label for="date_field" class="block text-sm text-muted-foreground mb-1">Date basis</label>
+            <select id="date_field" name="date_field" class="form-select-tw">
+                @foreach($dateFieldOptions as $value => $label)
+                    <option value="{{ $value }}" {{ ($filters['date_field'] ?? 'start_at') === $value ? 'selected' : '' }}>{{ $label }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div>
+            <label for="group_by" class="block text-sm text-muted-foreground mb-1">Group by</label>
+            <select id="group_by" name="group_by" class="form-select-tw">
+                @foreach($groupByOptions as $value => $label)
+                    <option value="{{ $value }}" {{ ($filters['group_by'] ?? 'week') === $value ? 'selected' : '' }}>{{ $label }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div>
+            <label for="line_limit" class="block text-sm text-muted-foreground mb-1">Series lines</label>
+            <select id="line_limit" name="line_limit" class="form-select-tw">
+                @foreach($lineLimitOptions as $value => $label)
+                    <option value="{{ $value }}" {{ (int) ($filters['line_limit'] ?? 10) === (int) $value ? 'selected' : '' }}>{{ $label }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div>
+            <label for="days" class="block text-sm text-muted-foreground mb-1">Range</label>
+            <select id="days" name="days" class="form-select-tw">
+                @foreach($daysOptions as $value => $label)
+                    <option value="{{ $value }}" {{ (int) ($filters['days'] ?? 90) === (int) $value ? 'selected' : '' }}>{{ $label }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div>
+            <label for="start_date" class="block text-sm text-muted-foreground mb-1">Start date</label>
+            <input id="start_date" name="start_date" type="date" value="{{ $filters['start_date'] }}" class="form-input-tw">
+        </div>
+        <div>
+            <label for="end_date" class="block text-sm text-muted-foreground mb-1">End date</label>
+            <input id="end_date" name="end_date" type="date" value="{{ $filters['end_date'] }}" class="form-input-tw">
+        </div>
+        <div>
+            <label for="event_type_id" class="block text-sm text-muted-foreground mb-1">Event type</label>
+            <select id="event_type_id" name="event_type_id" class="form-select-tw">
+                @foreach($eventTypeOptions as $value => $label)
+                    <option value="{{ $value }}" {{ (string) ($filters['event_type_id'] ?? '') === (string) $value ? 'selected' : '' }}>{{ $label }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div>
+            <label for="entity_type_id" class="block text-sm text-muted-foreground mb-1">Entity type</label>
+            <select id="entity_type_id" name="entity_type_id" class="form-select-tw">
+                @foreach($entityTypeOptions as $value => $label)
+                    <option value="{{ $value }}" {{ (string) ($filters['entity_type_id'] ?? '') === (string) $value ? 'selected' : '' }}>{{ $label }}</option>
+                @endforeach
+            </select>
+            <p class="text-xs text-muted-foreground mt-1">Splits the entity breakdown, or filters events for other breakdowns.</p>
+        </div>
+        <div>
+            <label for="tag" class="block text-sm text-muted-foreground mb-1">Tag contains</label>
+            <input id="tag" name="tag" type="text" value="{{ $filters['tag'] ?? '' }}" placeholder="e.g. techno" class="form-input-tw">
+        </div>
+
+        <div class="lg:col-span-4 flex flex-wrap items-center gap-2">
+            <button type="submit" id="applyBtn" class="px-4 py-2 bg-accent text-foreground border border-primary rounded-lg hover:bg-accent/80 transition-colors">Apply</button>
+            <span id="loadingIndicator" class="hidden text-sm text-muted-foreground">Loading&hellip;</span>
+            <a href="{{ route('events.graph') }}" class="px-4 py-2 bg-card border border-border text-foreground rounded-lg hover:bg-accent transition-colors">Reset</a>
+            <a href="{{ route('events.graph.export', array_filter([
+                    'days'           => $filters['days'] ?? null,
+                    'start_date'     => $filters['start_date'] ?? null,
+                    'end_date'       => $filters['end_date'] ?? null,
+                    'group_by'       => $filters['group_by'] ?? null,
+                    'series_by'      => $filters['series_by'] ?? null,
+                    'date_field'     => $filters['date_field'] ?? null,
+                    'event_type_id'  => $filters['event_type_id'] ?? null,
+                    'entity_type_id' => $filters['entity_type_id'] ?? null,
+                    'tag'            => $filters['tag'] ?? null,
+                    'line_limit'     => $filters['line_limit'] ?? null,
+                ], fn($v) => $v !== null && $v !== '')) }}"
+               class="px-4 py-2 bg-card border border-border text-foreground rounded-lg hover:bg-accent transition-colors">Export CSV</a>
+        </div>
+    </form>
+</div>
+
+<div class="card-tw p-4 mb-6">
+    <div class="flex flex-wrap justify-between items-center gap-2 mb-4">
+        <div>
+            <h2 class="text-lg font-semibold">Events by {{ $seriesByOptions[$seriesBy] ?? $seriesBy }}, per {{ $groupBy }}</h2>
+            <span class="text-sm text-muted-foreground">
+                {{ $startDate->toDateString() }} to {{ $endDate->toDateString() }}
+                &mdash; <strong>{{ number_format($total) }}</strong> total {{ Str::plural('data point', $total) }}
+            </span>
+        </div>
+        <div class="flex gap-1" id="chartTypeToggle">
+            <button data-type="line"    class="chart-type-btn px-3 py-1 text-sm rounded-lg border border-border bg-accent text-foreground">Line</button>
+            <button data-type="bar"     class="chart-type-btn px-3 py-1 text-sm rounded-lg border border-border bg-card text-foreground hover:bg-accent transition-colors">Bar</button>
+            <button data-type="stacked" class="chart-type-btn px-3 py-1 text-sm rounded-lg border border-border bg-card text-foreground hover:bg-accent transition-colors">Stacked</button>
+        </div>
+    </div>
+    <canvas id="eventGraph" height="120"></canvas>
+    <p id="eventGraphEmpty" class="hidden mt-3 text-sm text-muted-foreground">No data available for the selected filters.</p>
+</div>
+
+<div class="card-tw p-4">
+    <h2 class="text-lg font-semibold mb-3">Data points</h2>
+    <div class="overflow-x-auto">
+        <table class="min-w-full text-sm">
+            <thead>
+                <tr class="text-left border-b border-border">
+                    <th class="py-2 pr-4">Period</th>
+                    <th class="py-2 pr-4">Series</th>
+                    <th class="py-2 pr-4">Count</th>
+                </tr>
+            </thead>
+            <tbody>
+                @forelse($rows as $row)
+                    <tr class="border-b border-border/40">
+                        <td class="py-2 pr-4">{{ $row->period }}</td>
+                        <td class="py-2 pr-4">{{ $row->series_label }}</td>
+                        <td class="py-2 pr-4">{{ $row->event_count }}</td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="3" class="py-3 text-muted-foreground">No events found for these filters.</td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+</div>
+@endsection
+
+@section('footer')
+<script type="module">
+    (function () {
+        const labels = @json($labels);
+        const groupBy = @json($groupBy);
+        const rawDatasets = @json($datasets);
+
+        const canvas = document.getElementById('eventGraph');
+        const emptyMessage = document.getElementById('eventGraphEmpty');
+        const daysSelect = document.getElementById('days');
+        const startDateInput = document.getElementById('start_date');
+        const endDateInput = document.getElementById('end_date');
+        const applyBtn = document.getElementById('applyBtn');
+        const loadingIndicator = document.getElementById('loadingIndicator');
+        const graphForm = document.getElementById('graphForm');
+
+        // ── date ↔ days bi-directional sync ────────────────────────────────
+        const toInputDate = (date) => {
+            const y = date.getFullYear();
+            const m = `${date.getMonth() + 1}`.padStart(2, '0');
+            const d = `${date.getDate()}`.padStart(2, '0');
+            return `${y}-${m}-${d}`;
+        };
+
+        if (daysSelect && startDateInput && endDateInput) {
+            daysSelect.addEventListener('change', () => {
+                const days = Number(daysSelect.value || 90);
+                if (!Number.isFinite(days) || days < 1) return;
+                const today = new Date();
+                const end = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+                const start = new Date(end);
+                start.setDate(start.getDate() - (days - 1));
+                startDateInput.value = toInputDate(start);
+                endDateInput.value = toInputDate(end);
+            });
+
+            const clearDaysOnManualDate = () => {
+                if (daysSelect.value !== '') {
+                    daysSelect.value = '';
+                }
+            };
+            startDateInput.addEventListener('change', clearDaysOnManualDate);
+            endDateInput.addEventListener('change', clearDaysOnManualDate);
+        }
+
+        // ── loading indicator ───────────────────────────────────────────────
+        if (graphForm && loadingIndicator && applyBtn) {
+            graphForm.addEventListener('submit', () => {
+                loadingIndicator.classList.remove('hidden');
+                applyBtn.disabled = true;
+            });
+        }
+
+        if (!canvas) return;
+
+        if (rawDatasets.length === 0) {
+            emptyMessage?.classList.remove('hidden');
+            return;
+        }
+
+        // ── chart rendering ─────────────────────────────────────────────────
+        const coloredDatasets = (stacked) => rawDatasets.map((dataset, index) => {
+            const hue = (index * 57) % 360;
+            return {
+                ...dataset,
+                borderColor: `hsl(${hue}, 70%, 55%)`,
+                backgroundColor: `hsl(${hue}, 70%, 55%)`,
+                tension: 0.25,
+                fill: stacked,
+            };
+        });
+
+        let currentType = 'line';
+        let currentStacked = false;
+
+        const buildConfig = (type, stacked) => ({
+            type: type === 'stacked' ? 'bar' : type,
+            data: { labels, datasets: coloredDatasets(stacked) },
+            options: {
+                responsive: true,
+                interaction: { mode: 'index', intersect: false },
+                plugins: { legend: { position: 'bottom' } },
+                scales: {
+                    y: {
+                        beginAtZero: true,
+                        stacked: stacked,
+                        title: { display: true, text: 'Events' },
+                    },
+                    x: {
+                        stacked: stacked,
+                        title: { display: true, text: `Period (${groupBy})` },
+                    },
+                },
+            },
+        });
+
+        let chart = new Chart(canvas, buildConfig(currentType, currentStacked));
+
+        // ── chart type toggle ───────────────────────────────────────────────
+        document.querySelectorAll('.chart-type-btn').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const type = btn.dataset.type;
+                currentType = type;
+                currentStacked = type === 'stacked';
+
+                document.querySelectorAll('.chart-type-btn').forEach(b => {
+                    b.classList.toggle('bg-accent', b === btn);
+                    b.classList.toggle('bg-card', b !== btn);
+                });
+
+                chart.destroy();
+                chart = new Chart(canvas, buildConfig(currentType, currentStacked));
+            });
+        });
+    })();
+</script>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -247,6 +247,8 @@ Route::get('events/tonight', [\App\Http\Controllers\EventTimeWindowController::c
 Route::get('events/today', [\App\Http\Controllers\EventTimeWindowController::class, 'show'])->defaults('window', 'today')->name('events.today');
 Route::get('events/this-weekend', [\App\Http\Controllers\EventTimeWindowController::class, 'show'])->defaults('window', 'this-weekend')->name('events.thisWeekend');
 Route::get('events/this-week', [\App\Http\Controllers\EventTimeWindowController::class, 'show'])->defaults('window', 'this-week')->name('events.thisWeek');
+Route::get('events/graph', [\App\Http\Controllers\EventGraphController::class, 'graph'])->name('events.graph')->middleware(['auth', 'can:admin']);
+Route::get('events/graph/export', [\App\Http\Controllers\EventGraphController::class, 'exportGraph'])->name('events.graph.export')->middleware(['auth', 'can:admin']);
 Route::match(['get', 'post'], 'events/grid', [\App\Http\Controllers\EventsController::class, 'indexGrid'])->name('events.grid');
 Route::get('events/grid/tag/{slug}', [\App\Http\Controllers\EventsController::class, 'indexGridTags'])->name('events.grid.tag');
 Route::get('events/grid/by-date/{year}/{month?}/{day?}', [\App\Http\Controllers\EventsController::class, 'indexGridByDate'])->name('events.grid.byDate')

--- a/tests/Feature/EventGraphTest.php
+++ b/tests/Feature/EventGraphTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Entity;
+use App\Models\Event;
+use App\Models\EventType;
+use App\Models\Tag;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EventGraphTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected bool $seed = true;
+
+    protected function makeAdmin(): User
+    {
+        $admin = User::factory()->create(['user_status_id' => 1]);
+        $admin->assignGroup('admin');
+
+        return $admin;
+    }
+
+    public function test_event_graph_is_admin_only(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = User::factory()->create(['user_status_id' => 1]);
+        $this->actingAs($user);
+
+        $this->get(route('events.graph'))->assertStatus(403);
+    }
+
+    public function test_admin_can_view_event_graph_by_event_type(): void
+    {
+        $this->actingAs($this->makeAdmin());
+
+        $concertType = EventType::factory()->create(['name' => 'Zz Concert Type', 'slug' => 'zz-concert-type']);
+        $clubType = EventType::factory()->create(['name' => 'Zz Club Night Type', 'slug' => 'zz-club-night-type']);
+
+        Event::factory()->create([
+            'event_type_id' => $concertType->id,
+            'start_at' => Carbon::today()->subDay(),
+        ]);
+        Event::factory()->create([
+            'event_type_id' => $clubType->id,
+            'start_at' => Carbon::today(),
+        ]);
+
+        $response = $this->get(route('events.graph', ['days' => 7, 'group_by' => 'day']));
+
+        $response->assertOk();
+        $response->assertSee('Event Graph');
+        $response->assertSee('Zz Concert Type');
+        $response->assertSee('Zz Club Night Type');
+    }
+
+    public function test_admin_can_view_event_graph_by_tag(): void
+    {
+        $this->actingAs($this->makeAdmin());
+
+        $tag = Tag::factory()->create(['name' => 'Zz Techno Tag']);
+        $event = Event::factory()->create(['start_at' => Carbon::today()]);
+        $event->tags()->attach($tag->id);
+
+        $response = $this->get(route('events.graph', ['days' => 7, 'series_by' => 'tag']));
+
+        $response->assertOk();
+        $response->assertSee('Zz Techno Tag');
+    }
+
+    public function test_admin_can_view_event_graph_by_related_entity(): void
+    {
+        $this->actingAs($this->makeAdmin());
+
+        $artist = Entity::factory()->create(['name' => 'Zz Artist Entity']);
+        $event = Event::factory()->create(['start_at' => Carbon::today()]);
+        $event->entities()->attach($artist->id);
+
+        $response = $this->get(route('events.graph', ['days' => 7, 'series_by' => 'entity']));
+
+        $response->assertOk();
+        $response->assertSee('Zz Artist Entity');
+    }
+
+    public function test_admin_can_export_event_graph_csv_grouped_by_week(): void
+    {
+        $this->actingAs($this->makeAdmin());
+
+        $eventType = EventType::factory()->create(['name' => 'Zz Export Type', 'slug' => 'zz-export-type']);
+        $firstDate = Carbon::parse('2026-01-14 20:00:00');
+        $secondDate = Carbon::parse('2026-01-15 21:00:00');
+        $weekStart = $firstDate->copy()->startOfWeek(Carbon::MONDAY)->format('Y-m-d');
+
+        Event::factory()->create(['event_type_id' => $eventType->id, 'start_at' => $firstDate]);
+        Event::factory()->create(['event_type_id' => $eventType->id, 'start_at' => $secondDate]);
+
+        $response = $this->get(route('events.graph.export', [
+            'start_date' => '2026-01-01',
+            'end_date' => '2026-01-31',
+            'group_by' => 'week',
+            'series_by' => 'event_type',
+            'line_limit' => 50,
+        ]));
+
+        $response->assertOk();
+        $this->assertStringContainsString('text/csv', (string) $response->headers->get('content-type'));
+        $content = $response->streamedContent();
+        $this->assertStringContainsString('Period,Series,Count', $content);
+        $this->assertStringContainsString($weekStart.',"Zz Export Type",2', $content);
+        $this->assertStringContainsString('Grouping,week', $content);
+        $this->assertStringContainsString('Breakdown,event_type', $content);
+    }
+
+    public function test_event_graph_total_breakdown_counts_events(): void
+    {
+        $this->actingAs($this->makeAdmin());
+
+        Event::factory()->count(2)->create(['start_at' => Carbon::today()]);
+
+        $response = $this->get(route('events.graph.export', [
+            'days' => 7,
+            'group_by' => 'day',
+            'series_by' => 'total',
+        ]));
+
+        $response->assertOk();
+        $content = $response->streamedContent();
+        $this->assertStringContainsString(Carbon::today()->toDateString().',Events,2', $content);
+    }
+}

--- a/tests/Feature/Web/PagesControllerTest.php
+++ b/tests/Feature/Web/PagesControllerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Web;
 
 use App\Models\Event;
+use App\Models\Photo;
 use App\Models\Tag;
 use App\Models\User;
 use App\Models\UserStatus;
@@ -63,6 +64,8 @@ class PagesControllerTest extends TestCase
         // visible event (plus photos) for each of the top 24 tags — 13k+ events
         // in prod — blowing php-fpm's memory_limit. The view only renders each
         // tag's single latest event, so only that one should be hydrated.
+        // The thumbnail query only considers events with a primary photo, so
+        // each event gets one attached.
         $tag = Tag::factory()->create();
 
         $older = Event::factory()->create([
@@ -78,6 +81,15 @@ class PagesControllerTest extends TestCase
             'start_at' => now()->subDay(),
         ]);
         $tag->events()->attach([$older->id, $middle->id, $latest->id]);
+
+        foreach ([$older, $middle, $latest] as $event) {
+            $photo = Photo::factory()->create([
+                'is_primary' => 1,
+                'path' => 'test.jpg',
+                'thumbnail' => 'test_thumb.jpg',
+            ]);
+            $event->photos()->attach($photo->id);
+        }
 
         $response = $this->get('/popular')->assertOk();
 


### PR DESCRIPTION
## Summary

Adds a new admin-only **Event Graph** module at `/events/graph`, modeled on the existing Activity Graph, for visualizing event trends over time with dynamic breakdowns.

### Features
- **Break down by**: total events, event type, venue, promoter, series, tag, or related entity. Tag and entity breakdowns go through the `event_tag` / `entity_event` pivots, so an event contributes to each of its tags/entities.
- **Entity type select**: splits the related-entity breakdown (e.g. only Artists), or acts as an event filter for other breakdowns.
- **Date basis**: chart by `start_at` (event trends) or `created_at` (data-entry trends).
- **Grouping & range**: day/week/month/year buckets; presets from 30 days to 3 years, or explicit start/end dates (future ranges supported); top 5–50 series lines; event type and "tag contains" filters.
- **Chart & export**: Chart.js line/bar/stacked toggle, data-points table, and CSV export — same UX as the activity graph.

### Implementation
- New `EventGraphController` with validated/whitelisted filters, gated by `auth` + `can:admin` (constructor and route middleware), with routes placed ahead of the wildcard `events/*` routes.
- Extracted the day/week/month/year bucketing helpers duplicated in `ActivityController` into a shared `BucketsGraphData` trait, now used by both graph controllers.
- New `events/graph-tw` Blade view following the activity graph layout.
- Added an "Event Graph" entry to the Admin Modules section of the All Modules page (`config/modules.php`).

## Testing
- New `tests/Feature/EventGraphTest.php` (6 tests): admin gate, event-type/tag/related-entity breakdowns, weekly CSV export aggregation, and total-count mode.
- Existing `ActivityGraphTest` passes against the refactored trait (10/10 tests green overall).
- `composer phpstan` clean.

## Notes
- Counts all non-deleted events regardless of visibility — reasonable for an admin view; apply `visible($user)` if this ever opens up to non-admins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)