### PR TITLE
Fix search page tag thumbnails and card sizing (#2037)

### DIFF
--- a/app/Services/SearchService.php
+++ b/app/Services/SearchService.php
@@ -192,6 +192,7 @@ class SearchService
     private function tags(string $keyword, int $perPage): Paginator
     {
         return Tag::query()
+            ->withGridThumbnail()
             ->where('name', 'like', '%' . $keyword . '%')
             ->orderBy('name', 'ASC')
             ->simplePaginate($perPage);

--- a/resources/views/pages/search.blade.php
+++ b/resources/views/pages/search.blade.php
@@ -262,7 +262,7 @@
 			</button>
 		</div>
 		<div id="search-tags" class="p-4">
-			<div class="flex flex-wrap gap-2">
+			<div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
 				@foreach($tags as $tag)
 					@include('tags.grid-card-tw')
 				@endforeach

--- a/tests/Feature/SearchTest.php
+++ b/tests/Feature/SearchTest.php
@@ -78,4 +78,36 @@ class SearchTest extends TestCase
         $this->assertNotFalse($relevancePos);
         $this->assertLessThan($relevancePos, $datePos);
     }
+
+    /** @test
+     * Search-page tag cards must render the real thumbnail image, not the
+     * placeholder icon. Regression for #2037 (SearchService dropped
+     * withGridThumbnail()).
+     */
+    public function search_tag_results_render_grid_thumbnails()
+    {
+        $this->signIn();
+        $keyword = 'thumbtagfest';
+
+        $tag = \App\Models\Tag::factory()->create(['name' => $keyword]);
+        $event = \App\Models\Event::factory()->create([
+            'name' => 'Unrelated Carrier Event',
+            'start_at' => now()->addDays(3),
+            'end_at' => now()->addDays(3)->addHour(),
+            'visibility_id' => \App\Models\Visibility::VISIBILITY_PUBLIC,
+        ]);
+        $event->tags()->attach($tag);
+        $photo = \App\Models\Photo::factory()->create([
+            'is_primary' => 1,
+            'thumbnail' => 'photos/thumbtagfest-thumb.jpg',
+        ]);
+        $event->photos()->attach($photo);
+
+        $response = $this->get('/search?keyword=' . $keyword);
+
+        $response->assertStatus(200);
+        // alt is the tag name, which distinguishes the tag card's img from the
+        // event card that also carries this photo.
+        $response->assertSee('alt="' . $keyword . '"', false);
+    }
 }


### PR DESCRIPTION
Fixes #2037 — on the search page, tag images didn't load and the cards were inconsistently sized on mobile.

## Root causes

**Images never loaded.** `SearchService::tags()` built a plain `Tag::query()->where('name', 'like', …)` without the `withGridThumbnail()` scope (`app/Models/Tag.php:115`), which is what attaches the `grid_thumbnail` column via its COALESCE subquery. With it missing, `$tag->grid_thumbnail` was always null in `resources/views/tags/grid-card-tw.blade.php`, so every card silently fell through to the placeholder tag-icon branch. The `/tags` index does call the scope, which is why thumbnails render there but not in search.

**Cards weren't the same size.** The search view wrapped the cards in `flex flex-wrap gap-2` rather than the responsive grid `/tags` uses. These cards are built for a grid — the image anchor is `aspect-square` with `w-full h-full`, so it needs a column to derive width from. In a flex container each card just shrank to its content, giving every card a different width. Most visible on mobile, where there's no slack to hide it.

## Changes

- `app/Services/SearchService.php` — add `->withGridThumbnail()` to the tag query.
- `resources/views/pages/search.blade.php` — use the same `grid grid-cols-2 sm:grid-cols-3 … xl:grid-cols-6 gap-4` wrapper as `tags/index-tw.blade.php`.
- `tests/Feature/SearchTest.php` — regression test asserting a tag with a primary event photo renders a real `<img>` in search results.

## Testing

`SearchTest`, `SearchVisibilityTest`, `SearchModulesTest`, `TwPageRenderSmokeTest` all pass; PHPStan clean on the changed file.

The regression test asserts on `alt="<tag name>"` rather than the thumbnail filename. An earlier version keyed on the filename and passed even with the fix reverted, because the carrier event also surfaces in the Events section rendering the same photo — `alt` is what distinguishes the tag card. Confirmed the final test fails on unfixed code and passes with the fix.

## Follow-up (not in this PR)

`PagesController::search()` doesn't pass `$userTags`, so the follow-heart re-runs `getTagsFollowing()` once per tag — the same N+1 fixed for `/tags` in #2060. The one-line fix depends on the partial changes in #2060, which is still open, so it should land there or after it rather than blocking this bugfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)