### PR TITLE
Add proactive feedback interview (#1998)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,10 @@ SESSION_DRIVER=file
 QUEUE_DRIVER=database
 QUEUE_NOTIFY_EMAIL=false
 
+# Proactive feedback interview (issue #1998). Off by default — must be set to
+# true in production for invitations to generate or the prompt to display.
+FEEDBACK_ENABLED=false
+
 # Sanctum personal access token lifetime, in minutes (default: 30 days). Leave blank for non-expiring tokens.
 SANCTUM_TOKEN_EXPIRATION=43200
 # Comma-separated extra CORS origins for non-production environments (optional).

--- a/app/Console/Commands/GenerateFeedbackInvitations.php
+++ b/app/Console/Commands/GenerateFeedbackInvitations.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\PostEventFeedbackGenerator;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Creates the day's feedback survey invitations and keeps the invitation table
+ * tidy (issue #1998).
+ *
+ * Scheduled daily in App\Console\Kernel. Safe to re-run: invitations are
+ * deduped by a unique index on (campaign, user, subject).
+ */
+class GenerateFeedbackInvitations extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'feedback:generate
+                            {--dry-run : Report what would be created without writing anything}
+                            {--campaign= : Restrict to one campaign slug (default: every active campaign)}
+                            {--single-event= : Only consider this event slug or numeric ID}
+                            {--lookback-days= : Override the configured lookback window}
+                            {--limit= : Stop after creating this many invitations}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate proactive feedback survey invitations, expire stale ones, and clean up invitations whose subject was deleted.';
+
+    public function handle(PostEventFeedbackGenerator $generator): int
+    {
+        if (! config('feedback.enabled')) {
+            $this->warn('Feedback feature is disabled (config feedback.enabled). Nothing to do.');
+
+            return self::SUCCESS;
+        }
+
+        $isDryRun = (bool) $this->option('dry-run');
+        $campaignFilter = $this->option('campaign');
+        $singleEvent = $this->option('single-event');
+        $lookbackDays = $this->option('lookback-days');
+        $limit = $this->option('limit');
+
+        if ($isDryRun) {
+            $this->warn('DRY RUN — no invitations will be written.');
+        }
+
+        if ($singleEvent) {
+            $this->warn("SINGLE EVENT MODE — only considering event: {$singleEvent}");
+        }
+
+        $created = 0;
+
+        // Post-event attendee campaign.
+        if ($this->shouldRunPostEvent($campaignFilter)) {
+            try {
+                $result = $generator->generate([
+                    'dry_run' => $isDryRun,
+                    'lookback_days' => $lookbackDays !== null ? (int) $lookbackDays : null,
+                    'event' => $singleEvent,
+                    'limit' => $limit !== null ? (int) $limit : null,
+                ]);
+
+                $created += $result['created'];
+
+                $this->info(sprintf(
+                    'Post-event attendee: %d candidate(s), %d invitation(s) %s, %d skipped by volume caps.',
+                    $result['candidates'],
+                    $result['created'],
+                    $isDryRun ? 'would be created' : 'created',
+                    $result['skipped_volume']
+                ));
+            } catch (Throwable $e) {
+                $this->error('Post-event attendee generation failed: '.$e->getMessage());
+                Log::error('feedback:generate post-event generation failed', ['exception' => $e]);
+
+                return self::FAILURE;
+            }
+        } else {
+            $this->line('Post-event attendee campaign skipped.');
+        }
+
+        // Housekeeping runs regardless of which campaign was targeted, but never
+        // during a dry run.
+        if (! $isDryRun) {
+            $expired = $generator->sweepExpired();
+            $this->info("Expired {$expired} stale invitation(s).");
+
+            $dangling = $generator->cleanupDanglingEventSubjects();
+
+            if ($dangling > 0) {
+                $this->warn("Removed {$dangling} invitation(s) whose event no longer exists.");
+            }
+
+            if ($created > 0) {
+                Log::info("feedback:generate created {$created} invitation(s).");
+            }
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Whether the post-event campaign should run given --campaign and config.
+     */
+    private function shouldRunPostEvent(?string $campaignFilter): bool
+    {
+        if (! config('feedback.post_event.enabled', true)) {
+            return false;
+        }
+
+        return $campaignFilter === null
+            || $campaignFilter === \App\Models\SurveyCampaign::POST_EVENT_ATTENDEE;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -7,6 +7,7 @@ use App\Console\Commands\AdminTest;
 use App\Console\Commands\AutomateInstagramPosts;
 use App\Console\Commands\CleanupExports;
 use App\Console\Commands\CreateSeriesEvents;
+use App\Console\Commands\GenerateFeedbackInvitations;
 use App\Console\Commands\InitializeEventShares;
 use App\Console\Commands\Notify;
 use App\Console\Commands\NotifyEntities;
@@ -34,6 +35,7 @@ class Kernel extends ConsoleKernel
         InitializeEventShares::class,
         CleanupExports::class,
         CreateSeriesEvents::class,
+        GenerateFeedbackInvitations::class,
     ];
 
     /**
@@ -61,6 +63,10 @@ class Kernel extends ConsoleKernel
 
         // schedule daily cleanup of old export files
         $schedule->command('cleanup:exports')->daily()->timezone('America/New_York')->at('03:00');
+
+        // generate proactive feedback invitations for recently finished events,
+        // and expire stale ones (issue #1998). No-ops unless FEEDBACK_ENABLED.
+        $schedule->command('feedback:generate')->daily()->timezone('America/New_York')->at('10:00');
 
         // schedule daily creation of next series events
         // DISABLED - need to reconsider if we want this

--- a/app/Filters/SurveyResponseFilters.php
+++ b/app/Filters/SurveyResponseFilters.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Filters;
+
+use App\Models\SurveyQuestion;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Filters for the admin feedback response list (issue #1998).
+ *
+ * Subject is polymorphic, so the event filter matches against the denormalized
+ * subject columns rather than a relation — which is exactly why campaign and
+ * subject live on survey_responses in the first place.
+ */
+class SurveyResponseFilters extends QueryFilter
+{
+    public function campaign(?string $value = null): Builder
+    {
+        if (! isset($value) || $value === '') {
+            return $this->builder;
+        }
+
+        return $this->builder->whereHas('campaign', function ($q) use ($value) {
+            $q->where('slug', $value);
+        });
+    }
+
+    public function user(?string $value = null): Builder
+    {
+        if (! isset($value) || $value === '') {
+            return $this->builder;
+        }
+
+        return $this->builder->whereHas('user', function ($q) use ($value) {
+            $q->where('name', 'like', '%'.$value.'%');
+        });
+    }
+
+    /**
+     * Match by event name, or by exact event id when a number is supplied.
+     */
+    public function event(?string $value = null): Builder
+    {
+        if (! isset($value) || $value === '') {
+            return $this->builder;
+        }
+
+        return $this->builder
+            ->where('survey_responses.subject_type', 'event')
+            ->whereIn('survey_responses.subject_id', function ($q) use ($value) {
+                $q->select('id')->from('events')->where('name', 'like', '%'.$value.'%');
+
+                if (is_numeric($value)) {
+                    $q->orWhere('id', (int) $value);
+                }
+            });
+    }
+
+    /**
+     * Responses whose overall rating is at least this value.
+     */
+    public function rating(?string $value = null): Builder
+    {
+        if (! isset($value) || $value === '') {
+            return $this->builder;
+        }
+
+        return $this->builder->whereHas('answers', function ($q) use ($value) {
+            $q->where('value_int', '>=', (int) $value)
+                ->whereHas('question', function ($qq) {
+                    $qq->where('type', SurveyQuestion::TYPE_RATING);
+                });
+        });
+    }
+
+    public function visibility(?string $value = null): Builder
+    {
+        if (! isset($value) || $value === '') {
+            return $this->builder;
+        }
+
+        return $this->builder->where('survey_responses.visibility_id', (int) $value);
+    }
+
+    public function submitted_after(?string $value = null): Builder
+    {
+        if (! isset($value) || $value === '') {
+            return $this->builder;
+        }
+
+        return $this->builder->where('survey_responses.submitted_at', '>=', $value);
+    }
+
+    public function submitted_before(?string $value = null): Builder
+    {
+        if (! isset($value) || $value === '') {
+            return $this->builder;
+        }
+
+        return $this->builder->where('survey_responses.submitted_at', '<=', $value);
+    }
+}

--- a/app/Filters/SurveyResponseFilters.php
+++ b/app/Filters/SurveyResponseFilters.php
@@ -82,6 +82,18 @@ class SurveyResponseFilters extends QueryFilter
         return $this->builder->where('survey_responses.visibility_id', (int) $value);
     }
 
+    /**
+     * The admin moderation decision — pending, approved or rejected.
+     */
+    public function display_status(?string $value = null): Builder
+    {
+        if (! isset($value) || $value === '') {
+            return $this->builder;
+        }
+
+        return $this->builder->where('survey_responses.display_status', $value);
+    }
+
     public function submitted_after(?string $value = null): Builder
     {
         if (! isset($value) || $value === '') {

--- a/app/Http/Controllers/FeedbackAdminController.php
+++ b/app/Http/Controllers/FeedbackAdminController.php
@@ -1,0 +1,298 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Filters\SurveyResponseFilters;
+use App\Models\Event;
+use App\Models\SurveyCampaign;
+use App\Models\SurveyInvitation;
+use App\Models\SurveyQuestion;
+use App\Models\SurveyResponse;
+use App\Models\Visibility;
+use Carbon\Carbon;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\View\View;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+/**
+ * Admin reporting over collected feedback (issue #1998).
+ *
+ * Responses are private by default, so every route here is admin-gated. This
+ * follows the newer EventGraphController shape — validated request filters and
+ * a plain paginator — rather than the older ListParameterSessionStore ceremony,
+ * because nothing here needs filters persisted across navigations.
+ *
+ * Note this is deliberately separate from the existing Event Reviews feature:
+ * reviews are unsolicited, public and editorial; feedback is solicited,
+ * private-by-default and campaign-driven. The summary cross-links the two.
+ */
+class FeedbackAdminController extends Controller
+{
+    /**
+     * Filters accepted by the response list.
+     */
+    protected const ALLOWED_FILTERS = [
+        'campaign', 'user', 'event', 'rating', 'visibility',
+        'submitted_after', 'submitted_before',
+    ];
+
+    protected const PER_PAGE = 25;
+
+    public function __construct()
+    {
+        $this->middleware(['auth', 'can:admin']);
+        parent::__construct();
+    }
+
+    /**
+     * Paginated list of submitted responses.
+     */
+    public function index(Request $request, SurveyResponseFilters $filters): View
+    {
+        $applied = $this->appliedFilters($request);
+
+        $query = SurveyResponse::with(['campaign', 'user', 'subject', 'answers.question'])
+            ->orderByDesc('submitted_at');
+
+        $filters->applyFilters($query, $applied);
+
+        /** @var LengthAwarePaginator $responses */
+        $responses = $query->paginate(self::PER_PAGE)->appends($request->query());
+
+        return view('feedback.admin.index-tw')
+            ->with('responses', $responses)
+            ->with('filters', $applied)
+            ->with('campaigns', SurveyCampaign::orderBy('name')->get())
+            ->with('visibilities', Visibility::orderBy('id')->get());
+    }
+
+    /**
+     * A single response with all of its answers.
+     */
+    public function show(SurveyResponse $surveyResponse): View
+    {
+        $surveyResponse->load(['campaign', 'user', 'subject', 'answers.question', 'visibility', 'invitation']);
+
+        return view('feedback.admin.show-tw')->with('response', $surveyResponse);
+    }
+
+    /**
+     * Per-campaign rollup: completion rate, rating averages, option histograms.
+     */
+    public function summary(Request $request): View
+    {
+        $slug = $request->query('campaign') ?: SurveyCampaign::POST_EVENT_ATTENDEE;
+        $eventId = $request->query('event');
+
+        $campaign = SurveyCampaign::where('slug', $slug)->first();
+
+        if (! $campaign) {
+            return view('feedback.admin.summary-tw')
+                ->with('campaign', null)
+                ->with('campaigns', SurveyCampaign::orderBy('name')->get())
+                ->with('stats', [])
+                ->with('event', null)
+                ->with('counts', ['invitations' => 0, 'responses' => 0, 'completion' => 0.0]);
+        }
+
+        $campaign->load('questions');
+
+        $event = $eventId ? Event::find($eventId) : null;
+
+        return view('feedback.admin.summary-tw')
+            ->with('campaign', $campaign)
+            ->with('campaigns', SurveyCampaign::orderBy('name')->get())
+            ->with('event', $event)
+            ->with('counts', $this->counts($campaign, $event))
+            ->with('stats', $this->questionStats($campaign, $event))
+            ->with('comments', $this->recentComments($campaign, $event));
+    }
+
+    /**
+     * CSV of responses: one row per response, one column per question key.
+     */
+    public function export(Request $request, SurveyResponseFilters $filters): StreamedResponse
+    {
+        $applied = $this->appliedFilters($request);
+
+        $query = SurveyResponse::with(['campaign.questions', 'user', 'subject', 'answers.question'])
+            ->orderByDesc('submitted_at');
+
+        $filters->applyFilters($query, $applied);
+
+        $responses = $query->get();
+
+        // Column set is the union of every question key present, so a mixed
+        // campaign export still lines up.
+        $questionKeys = $responses
+            ->flatMap(fn (SurveyResponse $r) => $r->campaign?->questions->pluck('key') ?? collect())
+            ->unique()
+            ->values()
+            ->all();
+
+        $filename = 'feedback-responses-'.Carbon::now()->format('Ymd-His').'.csv';
+
+        return response()->streamDownload(function () use ($responses, $questionKeys, $applied): void {
+            $output = fopen('php://output', 'w');
+
+            if ($output === false) {
+                Log::error('Failed to open output stream for feedback export', ['filters' => $applied]);
+
+                return;
+            }
+
+            fputcsv($output, array_merge(
+                ['Response ID', 'Campaign', 'User', 'Subject', 'Visibility', 'Submitted'],
+                $questionKeys
+            ));
+
+            foreach ($responses as $response) {
+                $byKey = [];
+
+                foreach ($response->answers as $answer) {
+                    $key = $answer->question?->key;
+
+                    if (! $key) {
+                        continue;
+                    }
+
+                    // Multi-choice stores one row per option; join them back up.
+                    $byKey[$key] = isset($byKey[$key])
+                        ? $byKey[$key].'|'.$answer->displayValue()
+                        : $answer->displayValue();
+                }
+
+                fputcsv($output, array_merge([
+                    $response->id,
+                    $response->campaign?->name,
+                    $response->user?->name,
+                    $response->subject->name ?? null,
+                    $response->isPublic() ? 'public' : 'private',
+                    $response->submitted_at?->toDateTimeString(),
+                ], array_map(fn ($key) => $byKey[$key] ?? '', $questionKeys)));
+            }
+
+            fclose($output);
+        }, $filename, ['Content-Type' => 'text/csv']);
+    }
+
+    /**
+     * Only the whitelisted, non-empty filters from the request.
+     *
+     * @return array<string, string>
+     */
+    private function appliedFilters(Request $request): array
+    {
+        return array_filter(
+            $request->only(self::ALLOWED_FILTERS),
+            static fn ($value) => $value !== null && $value !== ''
+        );
+    }
+
+    /**
+     * @return array{invitations: int, responses: int, completion: float}
+     */
+    private function counts(SurveyCampaign $campaign, ?Event $event): array
+    {
+        $invitations = SurveyInvitation::where('survey_campaign_id', $campaign->id)
+            ->when($event, fn ($q) => $q->where('subject_type', 'event')->where('subject_id', $event->id))
+            ->count();
+
+        $responses = SurveyResponse::where('survey_campaign_id', $campaign->id)
+            ->when($event, fn ($q) => $q->where('subject_type', 'event')->where('subject_id', $event->id))
+            ->count();
+
+        return [
+            'invitations' => $invitations,
+            'responses' => $responses,
+            'completion' => $invitations > 0 ? round(($responses / $invitations) * 100, 1) : 0.0,
+        ];
+    }
+
+    /**
+     * Per-question aggregates — average for ratings, a histogram for choices.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function questionStats(SurveyCampaign $campaign, ?Event $event): array
+    {
+        $responseIds = SurveyResponse::where('survey_campaign_id', $campaign->id)
+            ->when($event, fn ($q) => $q->where('subject_type', 'event')->where('subject_id', $event->id))
+            ->pluck('id');
+
+        $stats = [];
+
+        foreach ($campaign->questions->sortBy('sort') as $question) {
+            if ($question->type === SurveyQuestion::TYPE_TEXT) {
+                continue;
+            }
+
+            $base = DB::table('survey_answers')
+                ->where('survey_question_id', $question->id)
+                ->whereIn('survey_response_id', $responseIds);
+
+            if ($question->type === SurveyQuestion::TYPE_RATING) {
+                $stats[] = [
+                    'question' => $question,
+                    'kind' => 'rating',
+                    'average' => round((float) ($base->clone()->avg('value_int') ?? 0), 2),
+                    'count' => $base->clone()->count(),
+                    'histogram' => [],
+                ];
+
+                continue;
+            }
+
+            $rows = $base->clone()
+                ->select('value_option', DB::raw('COUNT(*) as total'))
+                ->groupBy('value_option')
+                ->orderByDesc('total')
+                ->get();
+
+            $stats[] = [
+                'question' => $question,
+                'kind' => 'choice',
+                'average' => null,
+                'count' => (int) $rows->sum('total'),
+                'histogram' => $rows->map(fn ($row) => [
+                    'value' => $row->value_option,
+                    'label' => $question->labelForOption((string) $row->value_option),
+                    'total' => (int) $row->total,
+                ])->all(),
+            ];
+        }
+
+        return $stats;
+    }
+
+    /**
+     * Most recent free-text answers, for the qualitative half of the picture.
+     *
+     * @return \Illuminate\Support\Collection<int, \App\Models\SurveyAnswer>
+     */
+    private function recentComments(SurveyCampaign $campaign, ?Event $event)
+    {
+        $textQuestionIds = $campaign->questions
+            ->where('type', SurveyQuestion::TYPE_TEXT)
+            ->pluck('id');
+
+        if ($textQuestionIds->isEmpty()) {
+            return collect();
+        }
+
+        $responseIds = SurveyResponse::where('survey_campaign_id', $campaign->id)
+            ->when($event, fn ($q) => $q->where('subject_type', 'event')->where('subject_id', $event->id))
+            ->pluck('id');
+
+        return \App\Models\SurveyAnswer::with(['response.user', 'response.subject'])
+            ->whereIn('survey_question_id', $textQuestionIds)
+            ->whereIn('survey_response_id', $responseIds)
+            ->whereNotNull('value_text')
+            ->orderByDesc('id')
+            ->limit(20)
+            ->get();
+    }
+}

--- a/app/Http/Controllers/FeedbackAdminController.php
+++ b/app/Http/Controllers/FeedbackAdminController.php
@@ -11,9 +11,11 @@ use App\Models\SurveyResponse;
 use App\Models\Visibility;
 use Carbon\Carbon;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\Rule;
 use Illuminate\View\View;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -35,7 +37,7 @@ class FeedbackAdminController extends Controller
      * Filters accepted by the response list.
      */
     protected const ALLOWED_FILTERS = [
-        'campaign', 'user', 'event', 'rating', 'visibility',
+        'campaign', 'user', 'event', 'rating', 'visibility', 'display_status',
         'submitted_after', 'submitted_before',
     ];
 
@@ -74,9 +76,39 @@ class FeedbackAdminController extends Controller
      */
     public function show(SurveyResponse $surveyResponse): View
     {
-        $surveyResponse->load(['campaign', 'user', 'subject', 'answers.question', 'visibility', 'invitation']);
+        $surveyResponse->load(['campaign', 'user', 'subject', 'answers.question', 'visibility', 'invitation', 'approver']);
 
-        return view('feedback.admin.show-tw')->with('response', $surveyResponse);
+        return view('feedback.admin.show-tw')
+            ->with('response', $surveyResponse)
+            ->with('visibilities', Visibility::orderBy('id')->get());
+    }
+
+    /**
+     * Set the two display gates on a response.
+     *
+     * Visibility is the submitter's consent and display_status the admin's
+     * moderation decision; an admin may override either, but both still have
+     * to agree before anything is shown (SurveyResponse::scopeDisplayable).
+     */
+    public function update(Request $request, SurveyResponse $surveyResponse): RedirectResponse
+    {
+        $validated = $request->validate([
+            'visibility_id' => ['required', 'integer', Rule::exists('visibilities', 'id')],
+            'display_status' => ['required', 'string', Rule::in(SurveyResponse::DISPLAY_STATUSES)],
+        ]);
+
+        $surveyResponse->visibility_id = (int) $validated['visibility_id'];
+        $surveyResponse->setDisplayStatus($validated['display_status'], $request->user());
+        $surveyResponse->save();
+
+        flash()->success('Success', sprintf(
+            'Feedback response %d is now %s and %s.',
+            $surveyResponse->id,
+            $surveyResponse->isPublic() ? 'public' : 'private',
+            $surveyResponse->display_status
+        ));
+
+        return redirect()->route('feedback.admin.show', $surveyResponse->id);
     }
 
     /**
@@ -145,7 +177,7 @@ class FeedbackAdminController extends Controller
             }
 
             fputcsv($output, array_merge(
-                ['Response ID', 'Campaign', 'User', 'Subject', 'Visibility', 'Submitted'],
+                ['Response ID', 'Campaign', 'User', 'Subject', 'Visibility', 'Display', 'Submitted'],
                 $questionKeys
             ));
 
@@ -171,6 +203,7 @@ class FeedbackAdminController extends Controller
                     $response->user?->name,
                     $response->subject->name ?? null,
                     $response->isPublic() ? 'public' : 'private',
+                    $response->display_status,
                     $response->submitted_at?->toDateTimeString(),
                 ], array_map(fn ($key) => $byKey[$key] ?? '', $questionKeys)));
             }

--- a/app/Http/Controllers/FeedbackController.php
+++ b/app/Http/Controllers/FeedbackController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Action;
 use App\Models\Activity;
+use App\Models\Event;
 use App\Models\Profile;
 use App\Models\SurveyAnswer;
 use App\Models\SurveyInvitation;
@@ -12,6 +13,7 @@ use App\Models\SurveyResponse;
 use App\Models\User;
 use App\Models\Visibility;
 use App\Services\FeedbackPromptService;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -62,7 +64,12 @@ class FeedbackController extends Controller
         $this->assertOwner($request, $invitation);
         $this->assertActionable($invitation);
 
-        $invitation->loadMissing(['campaign.questions', 'subject']);
+        $invitation->loadMissing([
+            'campaign.questions',
+            'subject' => fn (MorphTo $morphTo) => $morphTo->morphWith([
+                Event::class => ['venue', 'photos'],
+            ]),
+        ]);
         $invitation->markShown();
 
         return view('feedback.show-tw')

--- a/app/Http/Controllers/FeedbackController.php
+++ b/app/Http/Controllers/FeedbackController.php
@@ -1,0 +1,294 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Action;
+use App\Models\Activity;
+use App\Models\Profile;
+use App\Models\SurveyAnswer;
+use App\Models\SurveyInvitation;
+use App\Models\SurveyQuestion;
+use App\Models\SurveyResponse;
+use App\Models\User;
+use App\Models\Visibility;
+use App\Services\FeedbackPromptService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\View\View;
+
+/**
+ * Proactive feedback interview (issue #1998).
+ *
+ * Drives the in-app prompt and the standalone feedback page. Invitations are
+ * bound by token, not id.
+ */
+class FeedbackController extends Controller
+{
+    public function __construct(private readonly FeedbackPromptService $prompts)
+    {
+        parent::__construct();
+    }
+
+    /**
+     * The payload for whatever prompt this user should see, if any.
+     *
+     * Marks the invitation as shown. Returns a null invitation rather than an
+     * error when there's nothing pending, so the modal can quietly self-close.
+     */
+    public function prompt(Request $request): JsonResponse
+    {
+        $this->assertFeatureEnabled();
+
+        $invitation = $this->prompts->pendingFor($request->user());
+
+        if (! $invitation) {
+            return response()->json(['invitation' => null]);
+        }
+
+        $invitation->markShown();
+
+        return response()->json($this->prompts->payload($invitation));
+    }
+
+    /**
+     * Standalone (non-modal) feedback page. Also the seam for a future emailed
+     * feedback link — it already takes the invitation token.
+     */
+    public function show(Request $request, SurveyInvitation $invitation): View
+    {
+        $this->assertFeatureEnabled();
+        $this->assertOwner($request, $invitation);
+        $this->assertActionable($invitation);
+
+        $invitation->loadMissing(['campaign.questions', 'subject']);
+        $invitation->markShown();
+
+        return view('feedback.show-tw')
+            ->with('payload', $this->prompts->payload($invitation));
+    }
+
+    /**
+     * Record that the prompt was displayed, without answering it.
+     */
+    public function shown(Request $request, SurveyInvitation $invitation): JsonResponse
+    {
+        $this->assertFeatureEnabled();
+        $this->assertOwner($request, $invitation);
+
+        $invitation->markShown();
+
+        return response()->json(['success' => true]);
+    }
+
+    /**
+     * Store a submission and close out the invitation.
+     */
+    public function store(Request $request, SurveyInvitation $invitation): JsonResponse|RedirectResponse
+    {
+        $this->assertFeatureEnabled();
+        $this->assertOwner($request, $invitation);
+        $this->assertActionable($invitation);
+
+        /** @var User $user */
+        $user = $request->user();
+
+        // Defense in depth: opting out already dismisses pending invitations,
+        // so this should be unreachable — but the submit path must enforce it.
+        abort_if((int) ($user->profile?->setting_feedback_requests ?? 0) !== 1, 403);
+
+        $invitation->loadMissing('campaign.questions');
+        $campaign = $invitation->campaign;
+
+        $validated = $request->validate($this->prompts->rulesFor($campaign));
+
+        $answers = $validated['answers'] ?? [];
+        $isPublic = (bool) ($validated['public'] ?? false);
+
+        $response = DB::transaction(function () use ($invitation, $campaign, $user, $answers, $isPublic) {
+            $response = SurveyResponse::create([
+                'survey_invitation_id' => $invitation->id,
+                'survey_campaign_id' => $campaign->id,
+                'user_id' => $user->id,
+                'subject_type' => $invitation->subject_type,
+                'subject_id' => $invitation->subject_id,
+                'visibility_id' => $isPublic
+                    ? Visibility::VISIBILITY_PUBLIC
+                    : $campaign->default_visibility_id,
+                'submitted_at' => now(),
+            ]);
+
+            $this->storeAnswers($response, $campaign->questions->where('is_active', true), $answers);
+
+            $invitation->markCompleted();
+
+            return $response;
+        });
+
+        $this->logActivity($invitation, $user);
+
+        if ($request->expectsJson()) {
+            return response()->json([
+                'success' => true,
+                'response_id' => $response->id,
+                'message' => "Thanks — that's genuinely useful.",
+            ]);
+        }
+
+        flash()->success('Thanks', 'Your feedback has been recorded.');
+
+        return redirect()->route('home');
+    }
+
+    /**
+     * Push this invitation out by a week without dismissing it.
+     */
+    public function snooze(Request $request, SurveyInvitation $invitation): JsonResponse
+    {
+        $this->assertFeatureEnabled();
+        $this->assertOwner($request, $invitation);
+        $this->assertActionable($invitation);
+
+        $invitation->snoozed_until = now()->addWeek();
+        $invitation->save();
+
+        return response()->json(['success' => true]);
+    }
+
+    /**
+     * Decline this one invitation. Does not opt the user out of future ones.
+     */
+    public function dismiss(Request $request, SurveyInvitation $invitation): JsonResponse
+    {
+        $this->assertFeatureEnabled();
+        $this->assertOwner($request, $invitation);
+
+        $invitation->markDismissed();
+
+        return response()->json(['success' => true]);
+    }
+
+    /**
+     * Permanently opt out of all feedback requests.
+     *
+     * Also dismisses everything currently outstanding, which is what makes the
+     * submit-time opt-out check structurally sound rather than decorative.
+     */
+    public function optOut(Request $request): JsonResponse
+    {
+        $this->assertFeatureEnabled();
+
+        /** @var User $user */
+        $user = $request->user();
+
+        // Some legacy users have no profile row yet; create one on demand.
+        $profile = $user->profile ?: new Profile(['user_id' => $user->id]);
+        $profile->user_id = $user->id;
+        $profile->setting_feedback_requests = 0;
+        $profile->save();
+
+        $user->surveyInvitations()
+            ->whereIn('status', SurveyInvitation::OPEN_STATUSES)
+            ->update([
+                'status' => SurveyInvitation::STATUS_DISMISSED,
+                'dismissed_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+        SurveyInvitation::forgetPendingCache($user->id);
+
+        return response()->json(['success' => true]);
+    }
+
+    /**
+     * Write one answer row per value. Multi-choice produces one row per option,
+     * which is exactly what the admin group-by wants.
+     *
+     * @param  \Illuminate\Support\Collection<int, SurveyQuestion>  $questions
+     * @param  array<string, mixed>  $answers
+     */
+    private function storeAnswers(SurveyResponse $response, $questions, array $answers): void
+    {
+        foreach ($questions as $question) {
+            // Unknown keys are ignored; absent optional answers are not stored.
+            if (! array_key_exists($question->key, $answers)) {
+                continue;
+            }
+
+            $value = $answers[$question->key];
+
+            if ($value === null || $value === '' || $value === []) {
+                continue;
+            }
+
+            match ($question->type) {
+                SurveyQuestion::TYPE_RATING => SurveyAnswer::create([
+                    'survey_response_id' => $response->id,
+                    'survey_question_id' => $question->id,
+                    'value_int' => (int) $value,
+                ]),
+                SurveyQuestion::TYPE_SINGLE_CHOICE => SurveyAnswer::create([
+                    'survey_response_id' => $response->id,
+                    'survey_question_id' => $question->id,
+                    'value_option' => (string) $value,
+                ]),
+                SurveyQuestion::TYPE_MULTI_CHOICE => $this->storeMultiChoice($response, $question, (array) $value),
+                default => SurveyAnswer::create([
+                    'survey_response_id' => $response->id,
+                    'survey_question_id' => $question->id,
+                    'value_text' => (string) $value,
+                ]),
+            };
+        }
+    }
+
+    /**
+     * @param  array<int, mixed>  $values
+     */
+    private function storeMultiChoice(SurveyResponse $response, SurveyQuestion $question, array $values): void
+    {
+        foreach (array_unique($values) as $value) {
+            SurveyAnswer::create([
+                'survey_response_id' => $response->id,
+                'survey_question_id' => $question->id,
+                'value_option' => (string) $value,
+            ]);
+        }
+    }
+
+    /**
+     * Log against the invitation's subject rather than the response.
+     *
+     * Activity::log() reads $object->name and resolves the action with
+     * findOrFail(); a new Action row would need both a seeder entry and a data
+     * migration, since production never re-runs seeders.
+     */
+    private function logActivity(SurveyInvitation $invitation, User $user): void
+    {
+        $subject = $invitation->subject;
+
+        if ($subject && isset($subject->name)) {
+            Activity::log($subject, $user, Action::CREATE, 'Submitted post-event feedback');
+        }
+    }
+
+    private function assertFeatureEnabled(): void
+    {
+        abort_unless(config('feedback.enabled'), 404);
+    }
+
+    private function assertOwner(Request $request, SurveyInvitation $invitation): void
+    {
+        abort_unless($request->user() && $invitation->user_id === $request->user()->id, 403);
+    }
+
+    /**
+     * 410 Gone rather than 404: the invitation existed, it just can no longer
+     * be answered.
+     */
+    private function assertActionable(SurveyInvitation $invitation): void
+    {
+        abort_unless($invitation->isActionable(), 410);
+    }
+}

--- a/app/Http/Controllers/FeedbackController.php
+++ b/app/Http/Controllers/FeedbackController.php
@@ -129,10 +129,19 @@ class FeedbackController extends Controller
         $this->logActivity($invitation, $user);
 
         if ($request->expectsJson()) {
+            // Hand back the next invitation inline so "save & next" doesn't
+            // need a second round trip. Null means the queue is now empty.
+            $next = $this->prompts->pendingFor($user->fresh());
+
+            if ($next) {
+                $next->markShown();
+            }
+
             return response()->json([
                 'success' => true,
                 'response_id' => $response->id,
                 'message' => "Thanks — that's genuinely useful.",
+                'next' => $next ? $this->prompts->payload($next) : null,
             ]);
         }
 

--- a/app/Http/Controllers/FeedbackController.php
+++ b/app/Http/Controllers/FeedbackController.php
@@ -216,6 +216,13 @@ class FeedbackController extends Controller
                 continue;
             }
 
+            // Belt and braces: exclude_unless in the rules already strips
+            // answers whose branch wasn't taken, but never store one if it
+            // somehow survives.
+            if (! $question->appliesGiven($answers)) {
+                continue;
+            }
+
             $value = $answers[$question->key];
 
             if ($value === null || $value === '' || $value === []) {

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -422,6 +422,7 @@ class UsersController extends Controller
         $input['setting_forum_update'] = isset($input['setting_forum_update']) ? 1 : 0;
         $input['setting_notify_threads_by_follow'] = isset($input['setting_notify_threads_by_follow']) ? 1 : 0;
         $input['setting_public_profile'] = isset($input['setting_public_profile']) ? 1 : 0;
+        $input['setting_feedback_requests'] = isset($input['setting_feedback_requests']) ? 1 : 0;
 
         $user->fill($input)->save();
         // Some legacy users have no profile row yet (EVENTREPO-VW); create one on demand.

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -518,7 +518,8 @@ class Event extends Model
      */
     public function attendees(): BelongsToMany
     {
-        return $this->belongsToMany(User::class, "event_responses")->wherePivot("response_type_id", 1);
+        return $this->belongsToMany(User::class, "event_responses")
+            ->wherePivot("response_type_id", ResponseType::ATTENDING);
     }
 
 

--- a/app/Models/EventStatus.php
+++ b/app/Models/EventStatus.php
@@ -8,6 +8,23 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class EventStatus extends Eloquent
 {
+    /**
+     * Seeded event status ids (see EventStatusesTableSeeder).
+     */
+    public const DRAFT = 1;
+
+    public const PROPOSAL = 2;
+
+    public const APPROVED = 3;
+
+    public const HAPPENING_NOW = 4;
+
+    public const PAST = 5;
+
+    public const REJECTED = 6;
+
+    public const CANCELLED = 7;
+
     protected $fillable = [
         'name',
     ];

--- a/app/Models/Profile.php
+++ b/app/Models/Profile.php
@@ -30,6 +30,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
  * @property int|null                                                    $setting_forum_update
  * @property int|null                                                    $setting_notify_threads_by_follow
  * @property int|null                                                    $setting_public_profile
+ * @property int|null                                                    $setting_feedback_requests
  * @property \Illuminate\Support\Carbon|null                             $onboarding_completed_at
  * @property \Illuminate\Support\Carbon|null                             $onboarding_dismissed_at
  * @property mixed                                                       $full_name
@@ -67,7 +68,7 @@ class Profile extends Eloquent
     }
 
     protected $fillable = [
-        'first_name', 'last_name', 'bio', 'alias', 'location', 'facebook_username', 'twitter_username', 'instagram_username','default_theme', 'setting_weekly_update', 'setting_daily_update', 'setting_instant_update', 'setting_forum_update', 'setting_notify_threads_by_follow', 'setting_public_profile', 'onboarding_completed_at', 'onboarding_dismissed_at'
+        'first_name', 'last_name', 'bio', 'alias', 'location', 'facebook_username', 'twitter_username', 'instagram_username','default_theme', 'setting_weekly_update', 'setting_daily_update', 'setting_instant_update', 'setting_forum_update', 'setting_notify_threads_by_follow', 'setting_public_profile', 'setting_feedback_requests', 'onboarding_completed_at', 'onboarding_dismissed_at'
     ];
 
     protected $attributes = [

--- a/app/Models/ResponseType.php
+++ b/app/Models/ResponseType.php
@@ -9,6 +9,23 @@ class ResponseType extends Eloquent
 {
     use HasFactory;
 
+    /**
+     * Seeded response type ids (see ResponseTypesTableSeeder).
+     *
+     * Only ATTENDING is used in practice — every attend path writes it.
+     */
+    public const ATTENDING = 1;
+
+    public const INTERESTED = 2;
+
+    public const INTERESTED_UNABLE = 3;
+
+    public const UNINTERESTED = 4;
+
+    public const CONFIRMED = 5;
+
+    public const IGNORE = 6;
+
     protected $fillable = [
         'name', 'description',
     ];

--- a/app/Models/SurveyAnswer.php
+++ b/app/Models/SurveyAnswer.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * App\Models\SurveyAnswer.
+ *
+ * One value within a response. Which column is populated depends on the
+ * question type: rating -> value_int, single/multi choice -> value_option
+ * (one row per selected option), text -> value_text.
+ *
+ * Typed columns rather than a single JSON blob because the admin summary is
+ * AVG(value_int) per question and GROUP BY value_option, both of which want
+ * plain indexed SQL.
+ *
+ * @property int                             $id
+ * @property int                             $survey_response_id
+ * @property int                             $survey_question_id
+ * @property int|null                        $value_int
+ * @property string|null                     $value_option
+ * @property string|null                     $value_text
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \App\Models\SurveyResponse      $response
+ * @property \App\Models\SurveyQuestion      $question
+ *
+ * @method static Builder|SurveyAnswer newModelQuery()
+ * @method static Builder|SurveyAnswer newQuery()
+ * @method static Builder|SurveyAnswer query()
+ *
+ * @mixin \Eloquent
+ */
+class SurveyAnswer extends Eloquent
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'survey_response_id', 'survey_question_id',
+        'value_int', 'value_option', 'value_text',
+    ];
+
+    protected $casts = [
+        'value_int' => 'integer',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function response(): BelongsTo
+    {
+        return $this->belongsTo(SurveyResponse::class, 'survey_response_id');
+    }
+
+    public function question(): BelongsTo
+    {
+        return $this->belongsTo(SurveyQuestion::class, 'survey_question_id');
+    }
+
+    /**
+     * The stored value, whichever column holds it.
+     */
+    public function value(): int|string|null
+    {
+        return $this->value_int ?? $this->value_option ?? $this->value_text;
+    }
+
+    /**
+     * Human-readable value for admin display and CSV export.
+     */
+    public function displayValue(): string
+    {
+        if ($this->value_int !== null) {
+            return (string) $this->value_int;
+        }
+
+        if ($this->value_option !== null) {
+            return $this->question?->labelForOption($this->value_option) ?? $this->value_option;
+        }
+
+        return (string) ($this->value_text ?? '');
+    }
+}

--- a/app/Models/SurveyCampaign.php
+++ b/app/Models/SurveyCampaign.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * App\Models\SurveyCampaign.
+ *
+ * A named set of questions plus the rules for who gets asked. Campaigns are
+ * seeded rows keyed by slug, so adding a new one (issue #1998 also asks for
+ * "why did you skip", interest polls and promoter outreach) is a seeder block
+ * rather than a migration.
+ *
+ * @property int                             $id
+ * @property string                          $slug
+ * @property string                          $name
+ * @property string|null                     $intro
+ * @property string|null                     $subject_type
+ * @property bool                            $is_active
+ * @property int                             $priority
+ * @property int|null                        $expires_after_days
+ * @property int                             $default_visibility_id
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Illuminate\Database\Eloquent\Collection<int, \App\Models\SurveyQuestion>   $questions
+ * @property \Illuminate\Database\Eloquent\Collection<int, \App\Models\SurveyInvitation> $invitations
+ * @property \Illuminate\Database\Eloquent\Collection<int, \App\Models\SurveyResponse>   $responses
+ *
+ * @method static Builder|SurveyCampaign active()
+ * @method static Builder|SurveyCampaign newModelQuery()
+ * @method static Builder|SurveyCampaign newQuery()
+ * @method static Builder|SurveyCampaign query()
+ *
+ * @mixin \Eloquent
+ */
+class SurveyCampaign extends Eloquent
+{
+    use HasFactory;
+
+    /**
+     * Slug of the post-event attendee campaign.
+     *
+     * Always reference campaigns by slug — seeded ids are not stable across
+     * environments.
+     */
+    public const POST_EVENT_ATTENDEE = 'post-event-attendee';
+
+    protected $fillable = [
+        'slug', 'name', 'intro', 'subject_type', 'is_active', 'priority',
+        'expires_after_days', 'default_visibility_id',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+        'priority' => 'integer',
+        'expires_after_days' => 'integer',
+        'default_visibility_id' => 'integer',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    /**
+     * The questions asked by this campaign, in display order.
+     */
+    public function questions(): HasMany
+    {
+        return $this->hasMany(SurveyQuestion::class)->orderBy('sort');
+    }
+
+    /**
+     * Only the questions currently being asked.
+     */
+    public function activeQuestions(): HasMany
+    {
+        return $this->questions()->where('is_active', true);
+    }
+
+    public function invitations(): HasMany
+    {
+        return $this->hasMany(SurveyInvitation::class);
+    }
+
+    public function responses(): HasMany
+    {
+        return $this->hasMany(SurveyResponse::class);
+    }
+
+    /**
+     * @param  Builder<SurveyCampaign>  $query
+     * @return Builder<SurveyCampaign>
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('is_active', true);
+    }
+
+    /**
+     * Look up a campaign by its slug. Campaign rows are read-mostly and hit on
+     * every generation run, so they are worth a short cache.
+     */
+    public static function bySlug(string $slug): ?self
+    {
+        try {
+            /** @var SurveyCampaign|null $campaign */
+            $campaign = Cache::remember(
+                'survey.campaign.'.$slug,
+                3600,
+                fn () => static::where('slug', $slug)->first()
+            );
+
+            return $campaign;
+        } catch (Throwable $e) {
+            // The cache is an optimization over a single indexed row read —
+            // an unwritable cache directory must not take the feature down.
+            Log::warning('Survey campaign cache unavailable, falling back to a direct query.', [
+                'slug' => $slug,
+                'exception' => $e->getMessage(),
+            ]);
+
+            return static::where('slug', $slug)->first();
+        }
+    }
+
+    /**
+     * Drop the cached copy of this campaign. Called by the seeder so a re-seed
+     * is immediately visible.
+     */
+    public static function forgetCached(string $slug): void
+    {
+        try {
+            Cache::forget('survey.campaign.'.$slug);
+        } catch (Throwable $e) {
+            // Nothing to invalidate if the cache is unavailable.
+        }
+    }
+
+    /**
+     * How long an invitation for this campaign stays actionable.
+     */
+    public function expiresAfterDays(): ?int
+    {
+        return $this->expires_after_days;
+    }
+}

--- a/app/Models/SurveyInvitation.php
+++ b/app/Models/SurveyInvitation.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+
+/**
+ * App\Models\SurveyInvitation.
+ *
+ * A request for one user to answer one campaign, optionally about one subject.
+ * Generated in batches by `feedback:generate`; most never become a response.
+ *
+ * Routed by `token` rather than id so the handle is unguessable and directly
+ * reusable by a future emailed feedback link.
+ *
+ * @property int                             $id
+ * @property int                             $survey_campaign_id
+ * @property int                             $user_id
+ * @property string                          $subject_type
+ * @property int                             $subject_id
+ * @property string                          $token
+ * @property string                          $status
+ * @property string                          $source
+ * @property \Illuminate\Support\Carbon|null $shown_at
+ * @property \Illuminate\Support\Carbon|null $completed_at
+ * @property \Illuminate\Support\Carbon|null $dismissed_at
+ * @property \Illuminate\Support\Carbon|null $snoozed_until
+ * @property \Illuminate\Support\Carbon|null $expires_at
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \App\Models\SurveyCampaign      $campaign
+ * @property \App\Models\User|null           $user
+ * @property \Illuminate\Database\Eloquent\Model|null $subject
+ * @property \App\Models\SurveyResponse|null $response
+ *
+ * @method static Builder|SurveyInvitation actionable()
+ * @method static Builder|SurveyInvitation newModelQuery()
+ * @method static Builder|SurveyInvitation newQuery()
+ * @method static Builder|SurveyInvitation query()
+ *
+ * @mixin \Eloquent
+ */
+class SurveyInvitation extends Eloquent
+{
+    use HasFactory;
+
+    public const STATUS_PENDING = 'pending';
+
+    public const STATUS_SHOWN = 'shown';
+
+    public const STATUS_COMPLETED = 'completed';
+
+    public const STATUS_DISMISSED = 'dismissed';
+
+    public const STATUS_EXPIRED = 'expired';
+
+    /**
+     * Statuses that can still lead to a response.
+     *
+     * @var array<int, string>
+     */
+    public const OPEN_STATUSES = [self::STATUS_PENDING, self::STATUS_SHOWN];
+
+    public const SOURCE_APP = 'app';
+
+    public const SOURCE_EMAIL = 'email';
+
+    protected $fillable = [
+        'survey_campaign_id', 'user_id', 'subject_type', 'subject_id',
+        'token', 'status', 'source', 'shown_at', 'completed_at',
+        'dismissed_at', 'snoozed_until', 'expires_at',
+    ];
+
+    protected $casts = [
+        'shown_at' => 'datetime',
+        'completed_at' => 'datetime',
+        'dismissed_at' => 'datetime',
+        'snoozed_until' => 'datetime',
+        'expires_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    protected static function booted(): void
+    {
+        // Mint a token for any invitation created without one.
+        static::creating(function (SurveyInvitation $invitation): void {
+            if (empty($invitation->token)) {
+                $invitation->token = static::generateToken();
+            }
+        });
+
+        // The prompt lookup is cached per user on every authenticated page
+        // load; any write to an invitation has to drop that cache or a
+        // dismissed prompt keeps reappearing for up to the TTL.
+        static::saved(fn (SurveyInvitation $invitation) => static::forgetPendingCache($invitation->user_id));
+        static::deleted(fn (SurveyInvitation $invitation) => static::forgetPendingCache($invitation->user_id));
+    }
+
+    /**
+     * Bind route parameters by token, never by id.
+     */
+    public function getRouteKeyName(): string
+    {
+        return 'token';
+    }
+
+    public static function generateToken(): string
+    {
+        return Str::random(40);
+    }
+
+    /**
+     * Cache key holding the id of a user's current prompt (or 0 for none).
+     */
+    public static function pendingCacheKey(int $userId): string
+    {
+        return 'feedback.pending.'.$userId;
+    }
+
+    public static function forgetPendingCache(int $userId): void
+    {
+        try {
+            Cache::forget(static::pendingCacheKey($userId));
+        } catch (\Throwable $e) {
+            // Nothing to invalidate if the cache is unavailable. Must not throw
+            // — this runs from model save/delete hooks on the write path.
+        }
+    }
+
+    public function campaign(): BelongsTo
+    {
+        return $this->belongsTo(SurveyCampaign::class, 'survey_campaign_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * What the invitation is about — an Event today, an Entity or nothing for
+     * campaigns added later. Uses the singular lowercase morph map registered
+     * in AppServiceProvider.
+     */
+    public function subject(): MorphTo
+    {
+        return $this->morphTo('subject', 'subject_type', 'subject_id');
+    }
+
+    public function response(): HasOne
+    {
+        return $this->hasOne(SurveyResponse::class);
+    }
+
+    /**
+     * Invitations that can still be shown and answered.
+     *
+     * @param  Builder<SurveyInvitation>  $query
+     * @return Builder<SurveyInvitation>
+     */
+    public function scopeActionable(Builder $query): Builder
+    {
+        return $query->whereIn('status', self::OPEN_STATUSES)
+            ->where(fn (Builder $q) => $q->whereNull('expires_at')->orWhere('expires_at', '>', now()))
+            ->where(fn (Builder $q) => $q->whereNull('snoozed_until')->orWhere('snoozed_until', '<=', now()));
+    }
+
+    /**
+     * Whether this invitation can still be shown and answered right now.
+     */
+    public function isActionable(): bool
+    {
+        if (! in_array($this->status, self::OPEN_STATUSES, true)) {
+            return false;
+        }
+
+        if ($this->expires_at !== null && $this->expires_at->isPast()) {
+            return false;
+        }
+
+        if ($this->snoozed_until !== null && $this->snoozed_until->isFuture()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * True when the invitation has no subject (a general poll).
+     */
+    public function hasSubject(): bool
+    {
+        return $this->subject_type !== '' && $this->subject_id > 0;
+    }
+
+    public function markShown(): void
+    {
+        // Only the first view sets shown_at; status stays 'shown' thereafter.
+        if ($this->status === self::STATUS_PENDING) {
+            $this->status = self::STATUS_SHOWN;
+            $this->shown_at = now();
+            $this->save();
+        }
+    }
+
+    public function markCompleted(): void
+    {
+        $this->status = self::STATUS_COMPLETED;
+        $this->completed_at = now();
+        $this->save();
+    }
+
+    public function markDismissed(): void
+    {
+        $this->status = self::STATUS_DISMISSED;
+        $this->dismissed_at = now();
+        $this->save();
+    }
+}

--- a/app/Models/SurveyQuestion.php
+++ b/app/Models/SurveyQuestion.php
@@ -27,6 +27,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property int|null                                                         $max_value
  * @property bool                                                             $is_required
  * @property bool                                                             $is_active
+ * @property string|null                                                      $depends_on_key
+ * @property string|null                                                      $depends_on_value
  * @property \Illuminate\Support\Carbon|null                                  $created_at
  * @property \Illuminate\Support\Carbon|null                                  $updated_at
  * @property \App\Models\SurveyCampaign                                       $campaign
@@ -70,6 +72,7 @@ class SurveyQuestion extends Eloquent
     protected $fillable = [
         'survey_campaign_id', 'key', 'sort', 'type', 'prompt', 'help',
         'options', 'min_value', 'max_value', 'is_required', 'is_active',
+        'depends_on_key', 'depends_on_value',
     ];
 
     protected $casts = [
@@ -91,6 +94,39 @@ class SurveyQuestion extends Eloquent
     public function answers(): HasMany
     {
         return $this->hasMany(SurveyAnswer::class);
+    }
+
+    /**
+     * True when this question only applies given a particular earlier answer.
+     */
+    public function isConditional(): bool
+    {
+        return $this->depends_on_key !== null && $this->depends_on_value !== null;
+    }
+
+    /**
+     * Whether this question applies, given the answers collected so far.
+     *
+     * Unconditional questions always apply. A conditional one applies only when
+     * its controlling question holds the expected value — which also means an
+     * unanswered controller hides everything downstream of it.
+     *
+     * @param  array<string, mixed>  $answers  keyed by question key
+     */
+    public function appliesGiven(array $answers): bool
+    {
+        if (! $this->isConditional()) {
+            return true;
+        }
+
+        $actual = $answers[$this->depends_on_key] ?? null;
+
+        // Multi-choice controllers are unusual but cheap to support.
+        if (is_array($actual)) {
+            return in_array($this->depends_on_value, $actual, true);
+        }
+
+        return $actual !== null && (string) $actual === (string) $this->depends_on_value;
     }
 
     /**

--- a/app/Models/SurveyQuestion.php
+++ b/app/Models/SurveyQuestion.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * App\Models\SurveyQuestion.
+ *
+ * One question within a campaign. The `key` is the stable identifier used by
+ * the JSON payload, by submitted answers and by the CSV export — never the
+ * autoincrement id, which is not stable across environments.
+ *
+ * @property int                                                              $id
+ * @property int                                                              $survey_campaign_id
+ * @property string                                                           $key
+ * @property int                                                              $sort
+ * @property string                                                           $type
+ * @property string                                                           $prompt
+ * @property string|null                                                      $help
+ * @property array<int, array{value: string, label: string}>|null             $options
+ * @property int|null                                                         $min_value
+ * @property int|null                                                         $max_value
+ * @property bool                                                             $is_required
+ * @property bool                                                             $is_active
+ * @property \Illuminate\Support\Carbon|null                                  $created_at
+ * @property \Illuminate\Support\Carbon|null                                  $updated_at
+ * @property \App\Models\SurveyCampaign                                       $campaign
+ * @property \Illuminate\Database\Eloquent\Collection<int, \App\Models\SurveyAnswer> $answers
+ *
+ * @method static Builder|SurveyQuestion newModelQuery()
+ * @method static Builder|SurveyQuestion newQuery()
+ * @method static Builder|SurveyQuestion query()
+ *
+ * @mixin \Eloquent
+ */
+class SurveyQuestion extends Eloquent
+{
+    use HasFactory;
+
+    public const TYPE_RATING = 'rating';
+
+    public const TYPE_SINGLE_CHOICE = 'single_choice';
+
+    public const TYPE_MULTI_CHOICE = 'multi_choice';
+
+    public const TYPE_TEXT = 'text';
+
+    /**
+     * Every question type the engine knows how to render, validate and store.
+     *
+     * @var array<int, string>
+     */
+    public const TYPES = [
+        self::TYPE_RATING,
+        self::TYPE_SINGLE_CHOICE,
+        self::TYPE_MULTI_CHOICE,
+        self::TYPE_TEXT,
+    ];
+
+    /**
+     * Ceiling on stored free text, mirrored by the validation rules.
+     */
+    public const TEXT_MAX_LENGTH = 2000;
+
+    protected $fillable = [
+        'survey_campaign_id', 'key', 'sort', 'type', 'prompt', 'help',
+        'options', 'min_value', 'max_value', 'is_required', 'is_active',
+    ];
+
+    protected $casts = [
+        'options' => 'array',
+        'sort' => 'integer',
+        'min_value' => 'integer',
+        'max_value' => 'integer',
+        'is_required' => 'boolean',
+        'is_active' => 'boolean',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function campaign(): BelongsTo
+    {
+        return $this->belongsTo(SurveyCampaign::class, 'survey_campaign_id');
+    }
+
+    public function answers(): HasMany
+    {
+        return $this->hasMany(SurveyAnswer::class);
+    }
+
+    /**
+     * True when the question stores its value in `value_option`.
+     */
+    public function isChoice(): bool
+    {
+        return in_array($this->type, [self::TYPE_SINGLE_CHOICE, self::TYPE_MULTI_CHOICE], true);
+    }
+
+    /**
+     * The permitted `value` strings for a choice question.
+     *
+     * @return array<int, string>
+     */
+    public function optionValues(): array
+    {
+        $options = $this->options ?? [];
+
+        return array_values(array_filter(array_map(
+            static fn ($option) => is_array($option) && isset($option['value']) ? (string) $option['value'] : null,
+            $options
+        )));
+    }
+
+    /**
+     * Look up an option's display label, falling back to the raw value so a
+     * label removed from the seed data never blanks out historical answers.
+     */
+    public function labelForOption(string $value): string
+    {
+        foreach ($this->options ?? [] as $option) {
+            if (is_array($option) && ($option['value'] ?? null) === $value) {
+                return (string) ($option['label'] ?? $value);
+            }
+        }
+
+        return $value;
+    }
+}

--- a/app/Models/SurveyResponse.php
+++ b/app/Models/SurveyResponse.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+/**
+ * App\Models\SurveyResponse.
+ *
+ * One completed submission. Private by default — `visibility_id` defaults to
+ * Visibility::VISIBILITY_PRIVATE and only flips to public when the user ticks
+ * the share box (issue #1998).
+ *
+ * Campaign and subject are denormalized off the invitation so that admin
+ * listing, filtering, export and public display never join invitations.
+ *
+ * @property int                             $id
+ * @property int|null                        $survey_invitation_id
+ * @property int                             $survey_campaign_id
+ * @property int                             $user_id
+ * @property string                          $subject_type
+ * @property int                             $subject_id
+ * @property int                             $visibility_id
+ * @property \Illuminate\Support\Carbon|null $submitted_at
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \App\Models\SurveyCampaign         $campaign
+ * @property \App\Models\SurveyInvitation|null  $invitation
+ * @property \App\Models\User|null              $user
+ * @property \App\Models\Visibility|null        $visibility
+ * @property \Illuminate\Database\Eloquent\Model|null $subject
+ * @property \Illuminate\Database\Eloquent\Collection<int, \App\Models\SurveyAnswer> $answers
+ *
+ * @method static Builder|SurveyResponse newModelQuery()
+ * @method static Builder|SurveyResponse newQuery()
+ * @method static Builder|SurveyResponse public()
+ * @method static Builder|SurveyResponse query()
+ *
+ * @mixin \Eloquent
+ */
+class SurveyResponse extends Eloquent
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'survey_invitation_id', 'survey_campaign_id', 'user_id',
+        'subject_type', 'subject_id', 'visibility_id', 'submitted_at',
+    ];
+
+    protected $casts = [
+        'visibility_id' => 'integer',
+        'submitted_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function campaign(): BelongsTo
+    {
+        return $this->belongsTo(SurveyCampaign::class, 'survey_campaign_id');
+    }
+
+    public function invitation(): BelongsTo
+    {
+        return $this->belongsTo(SurveyInvitation::class, 'survey_invitation_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function visibility(): BelongsTo
+    {
+        return $this->belongsTo(Visibility::class);
+    }
+
+    public function subject(): MorphTo
+    {
+        return $this->morphTo('subject', 'subject_type', 'subject_id');
+    }
+
+    public function answers(): HasMany
+    {
+        return $this->hasMany(SurveyAnswer::class);
+    }
+
+    /**
+     * Responses the submitting user chose to share publicly.
+     *
+     * @param  Builder<SurveyResponse>  $query
+     * @return Builder<SurveyResponse>
+     */
+    public function scopePublic(Builder $query): Builder
+    {
+        return $query->where('visibility_id', Visibility::VISIBILITY_PUBLIC);
+    }
+
+    public function isPublic(): bool
+    {
+        return $this->visibility_id === Visibility::VISIBILITY_PUBLIC;
+    }
+
+    public function hasSubject(): bool
+    {
+        return $this->subject_type !== '' && $this->subject_id > 0;
+    }
+}

--- a/app/Models/SurveyResponse.php
+++ b/app/Models/SurveyResponse.php
@@ -16,6 +16,12 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
  * Visibility::VISIBILITY_PRIVATE and only flips to public when the user ticks
  * the share box (issue #1998).
  *
+ * Two independent gates control whether a response could ever be shown on the
+ * site: `visibility_id` is the submitter's consent, `display_status` is the
+ * admin's moderation decision. Both must agree — see scopeDisplayable(). An
+ * admin approval never overrides a private response, and a user sharing
+ * publicly never skips moderation.
+ *
  * Campaign and subject are denormalized off the invitation so that admin
  * listing, filtering, export and public display never join invitations.
  *
@@ -26,16 +32,21 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
  * @property string                          $subject_type
  * @property int                             $subject_id
  * @property int                             $visibility_id
+ * @property string                          $display_status
+ * @property \Illuminate\Support\Carbon|null $approved_at
+ * @property int|null                        $approved_by
  * @property \Illuminate\Support\Carbon|null $submitted_at
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property \App\Models\SurveyCampaign         $campaign
  * @property \App\Models\SurveyInvitation|null  $invitation
  * @property \App\Models\User|null              $user
+ * @property \App\Models\User|null              $approver
  * @property \App\Models\Visibility|null        $visibility
  * @property \Illuminate\Database\Eloquent\Model|null $subject
  * @property \Illuminate\Database\Eloquent\Collection<int, \App\Models\SurveyAnswer> $answers
  *
+ * @method static Builder|SurveyResponse displayable()
  * @method static Builder|SurveyResponse newModelQuery()
  * @method static Builder|SurveyResponse newQuery()
  * @method static Builder|SurveyResponse public()
@@ -47,16 +58,47 @@ class SurveyResponse extends Eloquent
 {
     use HasFactory;
 
+    /**
+     * Awaiting an admin decision — the state every response is created in.
+     */
+    public const DISPLAY_PENDING = 'pending';
+
+    /**
+     * An admin cleared this for display on the site.
+     */
+    public const DISPLAY_APPROVED = 'approved';
+
+    /**
+     * An admin decided this should never be shown.
+     */
+    public const DISPLAY_REJECTED = 'rejected';
+
+    /**
+     * @var array<int, string>
+     */
+    public const DISPLAY_STATUSES = [
+        self::DISPLAY_PENDING,
+        self::DISPLAY_APPROVED,
+        self::DISPLAY_REJECTED,
+    ];
+
     protected $fillable = [
         'survey_invitation_id', 'survey_campaign_id', 'user_id',
         'subject_type', 'subject_id', 'visibility_id', 'submitted_at',
+        'display_status', 'approved_at', 'approved_by',
     ];
 
     protected $casts = [
         'visibility_id' => 'integer',
+        'approved_by' => 'integer',
+        'approved_at' => 'datetime',
         'submitted_at' => 'datetime',
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
+    ];
+
+    protected $attributes = [
+        'display_status' => self::DISPLAY_PENDING,
     ];
 
     public function campaign(): BelongsTo
@@ -77,6 +119,14 @@ class SurveyResponse extends Eloquent
     public function visibility(): BelongsTo
     {
         return $this->belongsTo(Visibility::class);
+    }
+
+    /**
+     * The admin who last set display_status to approved.
+     */
+    public function approver(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'approved_by');
     }
 
     public function subject(): MorphTo
@@ -100,9 +150,75 @@ class SurveyResponse extends Eloquent
         return $query->where('visibility_id', Visibility::VISIBILITY_PUBLIC);
     }
 
+    /**
+     * Responses that may actually be rendered on the site: the submitter
+     * shared them AND an admin approved them.
+     *
+     * This is the only query any future public display should use — neither
+     * public() nor approved alone is sufficient.
+     *
+     * @param  Builder<SurveyResponse>  $query
+     * @return Builder<SurveyResponse>
+     */
+    public function scopeDisplayable(Builder $query): Builder
+    {
+        return $query
+            ->where('visibility_id', Visibility::VISIBILITY_PUBLIC)
+            ->where('display_status', self::DISPLAY_APPROVED);
+    }
+
     public function isPublic(): bool
     {
         return $this->visibility_id === Visibility::VISIBILITY_PUBLIC;
+    }
+
+    public function isApproved(): bool
+    {
+        return $this->display_status === self::DISPLAY_APPROVED;
+    }
+
+    public function isRejected(): bool
+    {
+        return $this->display_status === self::DISPLAY_REJECTED;
+    }
+
+    /**
+     * Whether this response would be shown if a public display existed.
+     *
+     * The row-level counterpart to scopeDisplayable(); keep the two in step.
+     */
+    public function isDisplayable(): bool
+    {
+        return $this->isPublic() && $this->isApproved();
+    }
+
+    /**
+     * Approved by an admin, but the submitter kept it private — so it still
+     * will not be shown. Worth surfacing in the admin UI, since the approval
+     * looks like it did something.
+     */
+    public function isApprovedButNotShared(): bool
+    {
+        return $this->isApproved() && ! $this->isPublic();
+    }
+
+    /**
+     * Record an admin's display decision, keeping the approval audit columns
+     * consistent with the status.
+     */
+    public function setDisplayStatus(string $status, ?User $admin = null): void
+    {
+        $this->display_status = $status;
+
+        if ($status === self::DISPLAY_APPROVED) {
+            $this->approved_at = now();
+            $this->approved_by = $admin?->id;
+        } else {
+            // Rejecting or resetting to pending clears the audit trail, so a
+            // stale "approved by X" never sits next to a non-approved row.
+            $this->approved_at = null;
+            $this->approved_by = null;
+        }
     }
 
     public function hasSubject(): bool

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -282,7 +282,23 @@ class User extends Authenticatable implements AuthorizableContract, CanResetPass
     public function attendingEvents(): BelongsToMany
     {
         return $this->belongsToMany(Event::class, 'event_responses')
-            ->wherePivot('response_type_id', 1);
+            ->wherePivot('response_type_id', ResponseType::ATTENDING);
+    }
+
+    /**
+     * Feedback survey invitations addressed to this user (issue #1998).
+     */
+    public function surveyInvitations(): HasMany
+    {
+        return $this->hasMany(SurveyInvitation::class);
+    }
+
+    /**
+     * Feedback survey responses this user has submitted.
+     */
+    public function surveyResponses(): HasMany
+    {
+        return $this->hasMany(SurveyResponse::class);
     }
 
     /**

--- a/app/Providers/ViewComposerServiceProvider.php
+++ b/app/Providers/ViewComposerServiceProvider.php
@@ -5,7 +5,9 @@ namespace App\Providers;
 use App\Models\Forum;
 use App\Models\Menu;
 use App\Models\Role;
+use App\Services\FeedbackPromptService;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 
 class ViewComposerServiceProvider extends ServiceProvider
@@ -18,6 +20,7 @@ class ViewComposerServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->composeNavigation();
+        $this->composeFeedbackPrompt();
     }
 
     /**
@@ -27,6 +30,28 @@ class ViewComposerServiceProvider extends ServiceProvider
      */
     public function register()
     {
+    }
+
+    /**
+     * Share the pending feedback prompt, if any, with the main layout.
+     *
+     * Scoped to the one layout rather than '*' on purpose: AppServiceProvider
+     * already registers a wildcard composer, and a second one would fire on
+     * every partial render. FeedbackPromptService short-circuits on the
+     * feature flag before touching the database.
+     */
+    private function composeFeedbackPrompt(): void
+    {
+        view()->composer('layouts.app-tw', function ($view) {
+            $service = app(FeedbackPromptService::class);
+            $user = Auth::user();
+
+            $invitation = $service->mayDisplayInRequest(request(), $user)
+                ? $service->pendingFor($user)
+                : null;
+
+            $view->with('feedbackPrompt', $invitation ? $service->payload($invitation) : null);
+        });
     }
 
     /**

--- a/app/Services/DataExportService.php
+++ b/app/Services/DataExportService.php
@@ -186,6 +186,7 @@ class DataExportService
                     'subject_type' => $response->subject_type ?: null,
                     'subject_name' => $response->subject->name ?? null,
                     'visibility' => $response->isPublic() ? 'public' : 'private',
+                    'display_status' => $response->display_status,
                     'submitted_at' => $response->submitted_at,
                     'answers' => $response->answers->map(fn ($answer) => [
                         'question' => $answer->question ? $answer->question->prompt : null,

--- a/app/Services/DataExportService.php
+++ b/app/Services/DataExportService.php
@@ -171,8 +171,29 @@ class DataExportService
                 'setting_forum_update' => $user->profile->setting_forum_update,
                 'setting_notify_threads_by_follow' => $user->profile->setting_notify_threads_by_follow,
                 'setting_public_profile' => $user->profile->setting_public_profile,
+                'setting_feedback_requests' => $user->profile->setting_feedback_requests,
             ] : null,
         ];
+
+        // Feedback survey responses the user has submitted (issue #1998).
+        // Private by default, so they must be covered by the personal export.
+        $surveyResponses = $user->surveyResponses()
+            ->with(['campaign', 'answers.question', 'subject'])
+            ->get()
+            ->map(function (\App\Models\SurveyResponse $response) {
+                return [
+                    'campaign' => $response->campaign ? $response->campaign->name : null,
+                    'subject_type' => $response->subject_type ?: null,
+                    'subject_name' => $response->subject->name ?? null,
+                    'visibility' => $response->isPublic() ? 'public' : 'private',
+                    'submitted_at' => $response->submitted_at,
+                    'answers' => $response->answers->map(fn ($answer) => [
+                        'question' => $answer->question ? $answer->question->prompt : null,
+                        'question_key' => $answer->question ? $answer->question->key : null,
+                        'value' => $answer->displayValue(),
+                    ])->values()->all(),
+                ];
+            });
         
         // Photos associated with user (metadata only, images not included to keep file size manageable)
         $photos = $user->photos()->get();
@@ -196,6 +217,7 @@ class DataExportService
             'blogs' => $blogs,
             'follows' => $follows,
             'event_responses' => $eventResponses,
+            'survey_responses' => $surveyResponses,
             'profile' => $profile,
             'photos' => $photosData,
             'constants' => $constants,

--- a/app/Services/FeedbackPromptService.php
+++ b/app/Services/FeedbackPromptService.php
@@ -248,6 +248,10 @@ class FeedbackPromptService
                 'maxlength' => $question->type === SurveyQuestion::TYPE_TEXT
                     ? SurveyQuestion::TEXT_MAX_LENGTH
                     : null,
+                // Drives show/hide in the modal; null means always shown.
+                'depends_on' => $question->isConditional()
+                    ? ['key' => $question->depends_on_key, 'value' => $question->depends_on_value]
+                    : null,
             ])
             ->values()
             ->all();
@@ -277,29 +281,45 @@ class FeedbackPromptService
 
         foreach ($campaign->questions->where('is_active', true) as $question) {
             $field = 'answers.'.$question->key;
+
+            // A conditional question is dropped from the validated payload
+            // entirely when its branch isn't taken. That makes "required" mean
+            // "required when shown", and stops a stale value the client left
+            // behind — say a rating entered before switching to "didn't go" —
+            // from being stored against the wrong branch.
+            $gate = $question->isConditional()
+                ? ['exclude_unless:answers.'.$question->depends_on_key.','.$question->depends_on_value]
+                : [];
+
             $required = $question->is_required ? 'required' : 'nullable';
 
             switch ($question->type) {
                 case SurveyQuestion::TYPE_RATING:
-                    $rules[$field] = [
+                    $rules[$field] = array_merge($gate, [
                         $required,
                         'integer',
                         'between:'.($question->min_value ?? 1).','.($question->max_value ?? 5),
-                    ];
+                    ]);
                     break;
 
                 case SurveyQuestion::TYPE_SINGLE_CHOICE:
-                    $rules[$field] = [$required, 'string', 'in:'.implode(',', $question->optionValues())];
+                    $rules[$field] = array_merge($gate, [
+                        $required, 'string', 'in:'.implode(',', $question->optionValues()),
+                    ]);
                     break;
 
                 case SurveyQuestion::TYPE_MULTI_CHOICE:
-                    $rules[$field] = [$required, 'array'];
-                    $rules[$field.'.*'] = ['string', 'in:'.implode(',', $question->optionValues())];
+                    $rules[$field] = array_merge($gate, [$required, 'array']);
+                    $rules[$field.'.*'] = array_merge($gate, [
+                        'string', 'in:'.implode(',', $question->optionValues()),
+                    ]);
                     break;
 
                 case SurveyQuestion::TYPE_TEXT:
                 default:
-                    $rules[$field] = [$required, 'string', 'max:'.SurveyQuestion::TEXT_MAX_LENGTH];
+                    $rules[$field] = array_merge($gate, [
+                        $required, 'string', 'max:'.SurveyQuestion::TEXT_MAX_LENGTH,
+                    ]);
                     break;
             }
         }

--- a/app/Services/FeedbackPromptService.php
+++ b/app/Services/FeedbackPromptService.php
@@ -174,6 +174,19 @@ class FeedbackPromptService
     }
 
     /**
+     * How many invitations this user still has open, including the one they're
+     * being shown. Drives the "1 of 3" counter in the modal.
+     */
+    public function queueCountFor(User $user): int
+    {
+        if (! $this->isEnabledFor($user)) {
+            return 0;
+        }
+
+        return $this->resolveQuery($user)->count();
+    }
+
+    /**
      * Build the JSON payload the modal renders.
      *
      * @return array<string, mixed>
@@ -197,6 +210,13 @@ class FeedbackPromptService
             'visibility' => [
                 'prompt' => $this->visibilityPrompt($invitation),
                 'default' => false,
+            ],
+            'queue' => [
+                // Includes the invitation being shown, so 3 means "this one
+                // plus two more". The modal turns it into "1 of 3".
+                'remaining' => $invitation->user
+                    ? $this->queueCountFor($invitation->user)
+                    : 1,
             ],
         ];
     }

--- a/app/Services/FeedbackPromptService.php
+++ b/app/Services/FeedbackPromptService.php
@@ -1,0 +1,309 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Event;
+use App\Models\SurveyCampaign;
+use App\Models\SurveyInvitation;
+use App\Models\SurveyQuestion;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Decides whether to show a user a feedback prompt, and builds the payload the
+ * modal renders (issue #1998).
+ *
+ * The resolution path runs on every authenticated page load, so it is guarded
+ * in four layers, cheapest first:
+ *
+ *   1. config('feedback.enabled')                  — zero queries
+ *   2. profile opt-out                             — profile is already warm
+ *   3. onboarding mutual exclusion                 — never stack two modals
+ *   4. short-lived cache of the invitation id      — avoids a per-request query
+ *
+ * Only a non-zero cached id causes the full hydration query to run.
+ */
+class FeedbackPromptService
+{
+    /**
+     * Seconds to cache "which invitation, if any". Bounded staleness against
+     * the daily generator; writes invalidate it eagerly.
+     */
+    private const CACHE_TTL = 300;
+
+    /**
+     * Resolve the invitation to prompt this user with, if any.
+     */
+    public function pendingFor(?User $user): ?SurveyInvitation
+    {
+        if (! $this->isEnabledFor($user)) {
+            return null;
+        }
+
+        /** @var User $user */
+        $resolve = fn () => (int) ($this->resolveQuery($user)->value('survey_invitations.id') ?? 0);
+
+        try {
+            // Deliberately caches a scalar, never a serialized Eloquent model.
+            $invitationId = Cache::remember(
+                SurveyInvitation::pendingCacheKey($user->id),
+                self::CACHE_TTL,
+                $resolve
+            );
+        } catch (Throwable $e) {
+            // This runs on every authenticated page load. The cache saves a
+            // query; it must never be able to take the whole site down.
+            Log::warning('Feedback prompt cache unavailable, falling back to a direct query.', [
+                'user_id' => $user->id,
+                'exception' => $e->getMessage(),
+            ]);
+
+            $invitationId = $resolve();
+        }
+
+        if ($invitationId === 0) {
+            return null;
+        }
+
+        $invitation = SurveyInvitation::with(['campaign.questions', 'subject'])->find($invitationId);
+
+        // Guard against a cache entry that outlived its row, and against an
+        // invitation whose subject was hard-deleted (nothing soft-deletes here,
+        // and there is no FK on the polymorphic subject columns).
+        if (! $invitation || ! $invitation->isActionable()) {
+            SurveyInvitation::forgetPendingCache($user->id);
+
+            return null;
+        }
+
+        if ($invitation->hasSubject() && $invitation->subject === null) {
+            SurveyInvitation::forgetPendingCache($user->id);
+
+            return null;
+        }
+
+        return $invitation;
+    }
+
+    /**
+     * The cheap guards: feature flag, per-user opt-out, and onboarding.
+     */
+    public function isEnabledFor(?User $user): bool
+    {
+        if (! config('feedback.enabled')) {
+            return false;
+        }
+
+        if (! $user) {
+            return false;
+        }
+
+        // A missing profile row counts as not opted in, matching the strict
+        // `$user?->profile?->setting_x !== 1` guard used across the app.
+        if ((int) ($user->profile?->setting_feedback_requests ?? 0) !== 1) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Whether a prompt may be displayed in the layout right now. Onboarding
+     * wins — two stacked modals is a bug, not a feature.
+     */
+    public function mayDisplayFor(?User $user): bool
+    {
+        if (! $this->isEnabledFor($user)) {
+            return false;
+        }
+
+        /** @var User $user */
+        if ($user->shouldSeeOnboarding() || session('show_onboarding')) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Whether the layout should render the prompt for this specific request.
+     *
+     * On top of mayDisplayFor(), skips non-GET requests, XHR, and the feedback
+     * pages themselves — the standalone page renders the component inline and
+     * would otherwise get a second copy stacked over it.
+     */
+    public function mayDisplayInRequest(?Request $request, ?User $user): bool
+    {
+        if (! $this->mayDisplayFor($user)) {
+            return false;
+        }
+
+        if (! $request) {
+            return true;
+        }
+
+        if (! $request->isMethod('GET') || $request->ajax()) {
+            return false;
+        }
+
+        $routeName = $request->route()?->getName();
+
+        return ! ($routeName && str_starts_with($routeName, 'feedback.'));
+    }
+
+    /**
+     * Highest-priority actionable invitation for this user.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder<SurveyInvitation>
+     */
+    private function resolveQuery(User $user)
+    {
+        return SurveyInvitation::query()
+            ->join('survey_campaigns', 'survey_campaigns.id', '=', 'survey_invitations.survey_campaign_id')
+            ->where('survey_invitations.user_id', $user->id)
+            ->where('survey_campaigns.is_active', true)
+            ->actionable()
+            ->orderByDesc('survey_campaigns.priority')
+            ->orderBy('survey_invitations.created_at');
+    }
+
+    /**
+     * Build the JSON payload the modal renders.
+     *
+     * @return array<string, mixed>
+     */
+    public function payload(SurveyInvitation $invitation): array
+    {
+        $campaign = $invitation->campaign;
+
+        return [
+            'invitation' => [
+                'token' => $invitation->token,
+                'url' => route('feedback.show', $invitation),
+            ],
+            'campaign' => [
+                'slug' => $campaign->slug,
+                'name' => $campaign->name,
+                'intro' => $campaign->intro,
+            ],
+            'subject' => $this->subjectPayload($invitation),
+            'questions' => $this->questionsPayload($campaign),
+            'visibility' => [
+                'prompt' => $this->visibilityPrompt($invitation),
+                'default' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function subjectPayload(SurveyInvitation $invitation): ?array
+    {
+        if (! $invitation->hasSubject()) {
+            return null;
+        }
+
+        $subject = $invitation->subject;
+
+        if (! $subject) {
+            return null;
+        }
+
+        $payload = [
+            'type' => $invitation->subject_type,
+            'name' => $subject->name ?? null,
+            'url' => null,
+            'date' => null,
+        ];
+
+        if ($subject instanceof Event) {
+            $payload['url'] = route('events.show', $subject->slug ?: $subject->getKey());
+            $payload['date'] = $subject->start_at?->format('D M j, Y');
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function questionsPayload(SurveyCampaign $campaign): array
+    {
+        return $campaign->questions
+            ->where('is_active', true)
+            ->sortBy('sort')
+            ->map(fn (SurveyQuestion $question) => [
+                'key' => $question->key,
+                'type' => $question->type,
+                'prompt' => $question->prompt,
+                'help' => $question->help,
+                'required' => (bool) $question->is_required,
+                'min' => $question->min_value,
+                'max' => $question->max_value,
+                'options' => $question->options ?? [],
+                'maxlength' => $question->type === SurveyQuestion::TYPE_TEXT
+                    ? SurveyQuestion::TEXT_MAX_LENGTH
+                    : null,
+            ])
+            ->values()
+            ->all();
+    }
+
+    private function visibilityPrompt(SurveyInvitation $invitation): string
+    {
+        if ($invitation->subject_type === 'event') {
+            return "Show my feedback publicly on this event's page";
+        }
+
+        return 'Share my feedback publicly';
+    }
+
+    /**
+     * Validation rules for a submission, derived from the campaign's active
+     * questions rather than hand-maintained alongside them.
+     *
+     * @return array<string, mixed>
+     */
+    public function rulesFor(SurveyCampaign $campaign): array
+    {
+        $rules = [
+            'answers' => ['required', 'array'],
+            'public' => ['sometimes', 'boolean'],
+        ];
+
+        foreach ($campaign->questions->where('is_active', true) as $question) {
+            $field = 'answers.'.$question->key;
+            $required = $question->is_required ? 'required' : 'nullable';
+
+            switch ($question->type) {
+                case SurveyQuestion::TYPE_RATING:
+                    $rules[$field] = [
+                        $required,
+                        'integer',
+                        'between:'.($question->min_value ?? 1).','.($question->max_value ?? 5),
+                    ];
+                    break;
+
+                case SurveyQuestion::TYPE_SINGLE_CHOICE:
+                    $rules[$field] = [$required, 'string', 'in:'.implode(',', $question->optionValues())];
+                    break;
+
+                case SurveyQuestion::TYPE_MULTI_CHOICE:
+                    $rules[$field] = [$required, 'array'];
+                    $rules[$field.'.*'] = ['string', 'in:'.implode(',', $question->optionValues())];
+                    break;
+
+                case SurveyQuestion::TYPE_TEXT:
+                default:
+                    $rules[$field] = [$required, 'string', 'max:'.SurveyQuestion::TEXT_MAX_LENGTH];
+                    break;
+            }
+        }
+
+        return $rules;
+    }
+}

--- a/app/Services/FeedbackPromptService.php
+++ b/app/Services/FeedbackPromptService.php
@@ -167,7 +167,10 @@ class FeedbackPromptService
             ->where('survey_campaigns.is_active', true)
             ->actionable()
             ->orderByDesc('survey_campaigns.priority')
-            ->orderBy('survey_invitations.created_at');
+            // Insertion order, which the generator writes freshest-event-first,
+            // so a queued user is asked about their most recent event next.
+            // created_at is too coarse — a run inserts several within a second.
+            ->orderBy('survey_invitations.id');
     }
 
     /**

--- a/app/Services/FeedbackPromptService.php
+++ b/app/Services/FeedbackPromptService.php
@@ -7,6 +7,7 @@ use App\Models\SurveyCampaign;
 use App\Models\SurveyInvitation;
 use App\Models\SurveyQuestion;
 use App\Models\User;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
@@ -68,7 +69,15 @@ class FeedbackPromptService
             return null;
         }
 
-        $invitation = SurveyInvitation::with(['campaign.questions', 'subject'])->find($invitationId);
+        // Preload what the payload reads off an Event subject. getPrimaryPhoto()
+        // is relation-load aware, so eager-loading photos here keeps the whole
+        // prompt to a fixed query count instead of adding two per page render.
+        $invitation = SurveyInvitation::with([
+            'campaign.questions',
+            'subject' => fn (MorphTo $morphTo) => $morphTo->morphWith([
+                Event::class => ['venue', 'photos'],
+            ]),
+        ])->find($invitationId);
 
         // Guard against a cache entry that outlived its row, and against an
         // invitation whose subject was hard-deleted (nothing soft-deletes here,
@@ -241,11 +250,20 @@ class FeedbackPromptService
             'name' => $subject->name ?? null,
             'url' => null,
             'date' => null,
+            'venue' => null,
+            'venue_url' => null,
+            'image' => null,
         ];
 
         if ($subject instanceof Event) {
             $payload['url'] = route('events.show', $subject->slug ?: $subject->getKey());
             $payload['date'] = $subject->start_at?->format('D M j, Y');
+            $payload['image'] = $subject->getPrimaryPhotoThumbnailPath();
+
+            if ($subject->venue) {
+                $payload['venue'] = $subject->venue->name;
+                $payload['venue_url'] = route('entities.show', $subject->venue->slug ?: $subject->venue->id);
+            }
         }
 
         return $payload;

--- a/app/Services/PostEventFeedbackGenerator.php
+++ b/app/Services/PostEventFeedbackGenerator.php
@@ -20,11 +20,6 @@ use Illuminate\Support\Facades\DB;
 class PostEventFeedbackGenerator
 {
     /**
-     * How many candidate rows to process per chunk.
-     */
-    private const DEFAULT_CHUNK_SIZE = 500;
-
-    /**
      * Find eligible (user, event) pairs and create invitations for them.
      *
      * @param  array{dry_run?: bool, lookback_days?: int|null, event?: int|string|null, limit?: int|null}  $options
@@ -59,59 +54,52 @@ class PostEventFeedbackGenerator
         // wildly overstate what the real run does.
         $grantedThisRun = [];
 
-        $chunkSize = (int) config('feedback.generation_chunk_size', self::DEFAULT_CHUNK_SIZE);
+        // cursor(), not chunk()/chunkById(): this query filters on
+        // `survey_invitations.id is null` and a real run inserts exactly those
+        // rows, so OFFSET paging would walk off a shrinking result set and skip
+        // roughly a page per boundary. cursor() executes once and iterates a
+        // single snapshot, which is both safe under that mutation and free to
+        // order by event recency — chunkById cannot, since it must order by its
+        // cursor column. PDO MySQL is buffered by default here, so writes on the
+        // same connection during iteration are fine.
+        foreach ($this->candidateQuery($campaign->id, $windowStart, $windowEnd, $options['event'] ?? null)->cursor() as $row) {
+            if ($limit !== null && $created >= $limit) {
+                break;
+            }
 
-        // chunkById, not chunk: this query filters on `survey_invitations.id is
-        // null`, and a real run inserts exactly those rows. Under OFFSET-based
-        // chunk() the result set shrinks beneath us between pages and roughly a
-        // full page of eligible candidates gets skipped every time. Keyset
-        // pagination on event_responses.id is stable under that mutation.
-        $this->candidateQuery($campaign->id, $windowStart, $windowEnd, $options['event'] ?? null)
-            ->chunkById($chunkSize, function ($rows) use (
-                $campaign, $expireDays, $dryRun, $limit,
-                &$created, &$candidates, &$skippedVolume, &$touchedUsers, &$grantedThisRun
-            ) {
-                foreach ($rows as $row) {
-                    if ($limit !== null && $created >= $limit) {
-                        return false;
-                    }
+            $userId = (int) $row->user_id;
+            $candidates++;
 
-                    $userId = (int) $row->user_id;
-                    $candidates++;
+            $alreadyGranted = $dryRun ? ($grantedThisRun[$userId] ?? 0) : 0;
 
-                    $alreadyGranted = $dryRun ? ($grantedThisRun[$userId] ?? 0) : 0;
+            if (! $this->withinVolumeLimits($userId, $alreadyGranted)) {
+                $skippedVolume++;
 
-                    if (! $this->withinVolumeLimits($userId, $alreadyGranted)) {
-                        $skippedVolume++;
+                continue;
+            }
 
-                        continue;
-                    }
+            if (! $dryRun) {
+                SurveyInvitation::firstOrCreate(
+                    [
+                        'survey_campaign_id' => $campaign->id,
+                        'user_id' => $row->user_id,
+                        'subject_type' => 'event',
+                        'subject_id' => $row->event_id,
+                    ],
+                    [
+                        'token' => SurveyInvitation::generateToken(),
+                        'status' => SurveyInvitation::STATUS_PENDING,
+                        'source' => SurveyInvitation::SOURCE_APP,
+                        'expires_at' => now()->addDays($expireDays),
+                    ]
+                );
 
-                    if (! $dryRun) {
-                        SurveyInvitation::firstOrCreate(
-                            [
-                                'survey_campaign_id' => $campaign->id,
-                                'user_id' => $row->user_id,
-                                'subject_type' => 'event',
-                                'subject_id' => $row->event_id,
-                            ],
-                            [
-                                'token' => SurveyInvitation::generateToken(),
-                                'status' => SurveyInvitation::STATUS_PENDING,
-                                'source' => SurveyInvitation::SOURCE_APP,
-                                'expires_at' => now()->addDays($expireDays),
-                            ]
-                        );
+                $touchedUsers[$userId] = true;
+            }
 
-                        $touchedUsers[$userId] = true;
-                    }
-
-                    $grantedThisRun[$userId] = ($grantedThisRun[$userId] ?? 0) + 1;
-                    $created++;
-                }
-
-                return true;
-            }, 'event_responses.id', 'candidate_id');
+            $grantedThisRun[$userId] = ($grantedThisRun[$userId] ?? 0) + 1;
+            $created++;
+        }
 
         foreach (array_keys($touchedUsers) as $userId) {
             SurveyInvitation::forgetPendingCache($userId);
@@ -168,13 +156,14 @@ class PostEventFeedbackGenerator
             ->where('user_statuses.can_login', 1)
             ->whereNotNull('users.email_verified_at')
             ->where('profiles.setting_feedback_requests', 1)
-            // candidate_id is the keyset cursor for chunkById; no orderBy here,
-            // chunkById supplies its own.
-            ->select(
-                'event_responses.id as candidate_id',
-                'event_responses.user_id',
-                'event_responses.event_id'
-            );
+            ->select('event_responses.user_id', 'event_responses.event_id')
+            // Grouped by user, freshest event first. The per-user volume cap
+            // means only the first few candidates for a user become
+            // invitations, so this decides which ones — and asking while the
+            // memory is sharp gets better answers than asking about whichever
+            // event they happened to RSVP to first.
+            ->orderBy('event_responses.user_id')
+            ->orderByRaw("$eventEnd DESC");
 
         if ($eventFilter !== null) {
             $query->where(function ($q) use ($eventFilter) {
@@ -210,15 +199,17 @@ class PostEventFeedbackGenerator
 
         $minDays = (int) config('feedback.min_days_between_prompts', 7);
 
+        // The cooldown deliberately keys off dismissal only, not completion.
+        // Someone who just answered is engaged — making them wait a week to be
+        // asked about their other event is the opposite of the right signal,
+        // and it's how events used to age out of the lookback window unasked.
+        // Someone who dismissed is telling us to back off, so we do.
         if ($minDays > 0) {
-            $recent = SurveyInvitation::where('user_id', $userId)
-                ->where(function ($q) use ($minDays) {
-                    $q->where('completed_at', '>', now()->subDays($minDays))
-                        ->orWhere('dismissed_at', '>', now()->subDays($minDays));
-                })
+            $recentlyDismissed = SurveyInvitation::where('user_id', $userId)
+                ->where('dismissed_at', '>', now()->subDays($minDays))
                 ->exists();
 
-            if ($recent) {
+            if ($recentlyDismissed) {
                 return false;
             }
         }

--- a/app/Services/PostEventFeedbackGenerator.php
+++ b/app/Services/PostEventFeedbackGenerator.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\EventStatus;
+use App\Models\ResponseType;
+use App\Models\SurveyCampaign;
+use App\Models\SurveyInvitation;
+use App\Models\Visibility;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Builds post-event feedback invitations for users who marked "Attending" on an
+ * event that has since finished (issue #1998).
+ *
+ * Lives in a service rather than the command so the query is testable on its
+ * own and the command stays about flags, output and error handling.
+ */
+class PostEventFeedbackGenerator
+{
+    /**
+     * How many candidate rows to process per chunk.
+     */
+    private const DEFAULT_CHUNK_SIZE = 500;
+
+    /**
+     * Find eligible (user, event) pairs and create invitations for them.
+     *
+     * @param  array{dry_run?: bool, lookback_days?: int|null, event?: int|string|null, limit?: int|null}  $options
+     * @return array{created: int, candidates: int, skipped_volume: int}
+     */
+    public function generate(array $options = []): array
+    {
+        $dryRun = (bool) ($options['dry_run'] ?? false);
+        $limit = $options['limit'] ?? null;
+
+        $campaign = SurveyCampaign::bySlug(SurveyCampaign::POST_EVENT_ATTENDEE);
+
+        if (! $campaign || ! $campaign->is_active) {
+            return ['created' => 0, 'candidates' => 0, 'skipped_volume' => 0];
+        }
+
+        $lookbackDays = $options['lookback_days'] ?? (int) config('feedback.post_event.lookback_days', 14);
+        $delayHours = (int) config('feedback.post_event.delay_hours', 12);
+        $expireDays = $campaign->expiresAfterDays() ?? (int) config('feedback.post_event.expire_days', 30);
+
+        $windowEnd = now()->subHours($delayHours);
+        $windowStart = now()->subDays($lookbackDays);
+
+        $created = 0;
+        $candidates = 0;
+        $skippedVolume = 0;
+        $touchedUsers = [];
+
+        // Counts what this run has already granted each user. A real run sees
+        // its own writes through the DB query below; a dry run writes nothing,
+        // so without this it would report every candidate as creatable and
+        // wildly overstate what the real run does.
+        $grantedThisRun = [];
+
+        $chunkSize = (int) config('feedback.generation_chunk_size', self::DEFAULT_CHUNK_SIZE);
+
+        // chunkById, not chunk: this query filters on `survey_invitations.id is
+        // null`, and a real run inserts exactly those rows. Under OFFSET-based
+        // chunk() the result set shrinks beneath us between pages and roughly a
+        // full page of eligible candidates gets skipped every time. Keyset
+        // pagination on event_responses.id is stable under that mutation.
+        $this->candidateQuery($campaign->id, $windowStart, $windowEnd, $options['event'] ?? null)
+            ->chunkById($chunkSize, function ($rows) use (
+                $campaign, $expireDays, $dryRun, $limit,
+                &$created, &$candidates, &$skippedVolume, &$touchedUsers, &$grantedThisRun
+            ) {
+                foreach ($rows as $row) {
+                    if ($limit !== null && $created >= $limit) {
+                        return false;
+                    }
+
+                    $userId = (int) $row->user_id;
+                    $candidates++;
+
+                    $alreadyGranted = $dryRun ? ($grantedThisRun[$userId] ?? 0) : 0;
+
+                    if (! $this->withinVolumeLimits($userId, $alreadyGranted)) {
+                        $skippedVolume++;
+
+                        continue;
+                    }
+
+                    if (! $dryRun) {
+                        SurveyInvitation::firstOrCreate(
+                            [
+                                'survey_campaign_id' => $campaign->id,
+                                'user_id' => $row->user_id,
+                                'subject_type' => 'event',
+                                'subject_id' => $row->event_id,
+                            ],
+                            [
+                                'token' => SurveyInvitation::generateToken(),
+                                'status' => SurveyInvitation::STATUS_PENDING,
+                                'source' => SurveyInvitation::SOURCE_APP,
+                                'expires_at' => now()->addDays($expireDays),
+                            ]
+                        );
+
+                        $touchedUsers[$userId] = true;
+                    }
+
+                    $grantedThisRun[$userId] = ($grantedThisRun[$userId] ?? 0) + 1;
+                    $created++;
+                }
+
+                return true;
+            }, 'event_responses.id', 'candidate_id');
+
+        foreach (array_keys($touchedUsers) as $userId) {
+            SurveyInvitation::forgetPendingCache($userId);
+        }
+
+        return [
+            'created' => $created,
+            'candidates' => $candidates,
+            'skipped_volume' => $skippedVolume,
+        ];
+    }
+
+    /**
+     * Attendees of events that finished inside the window and who don't already
+     * have an invitation for that event.
+     *
+     * @param  int|string|null  $eventFilter  event id or slug, for --single-event
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function candidateQuery(int $campaignId, Carbon $windowStart, Carbon $windowEnd, $eventFilter = null)
+    {
+        // Events have no dedicated "ended at"; end_at is nullable and falls back
+        // to start_at for single-point events.
+        $eventEnd = 'COALESCE(events.end_at, events.start_at)';
+
+        $query = DB::table('event_responses')
+            ->join('events', 'events.id', '=', 'event_responses.event_id')
+            ->join('users', 'users.id', '=', 'event_responses.user_id')
+            ->join('user_statuses', 'user_statuses.id', '=', 'users.user_status_id')
+            // Inner-value check on this left join deliberately excludes users
+            // with no profile row (a real legacy condition, see UsersController)
+            // — matching the app-wide `$user?->profile?->setting_x !== 1` guard.
+            ->leftJoin('profiles', 'profiles.user_id', '=', 'users.id')
+            ->leftJoin('survey_invitations', function ($join) use ($campaignId) {
+                $join->on('survey_invitations.user_id', '=', 'event_responses.user_id')
+                    ->on('survey_invitations.subject_id', '=', 'event_responses.event_id')
+                    ->where('survey_invitations.subject_type', '=', 'event')
+                    ->where('survey_invitations.survey_campaign_id', '=', $campaignId);
+            })
+            ->whereNull('survey_invitations.id')
+            ->where('event_responses.response_type_id', ResponseType::ATTENDING)
+            // Indexable pre-filter. COALESCE() alone cannot use the start_at
+            // index, and without this the join full-scans event_responses.
+            // The extra day on the lower bound covers multi-day events whose
+            // end_at trails start_at.
+            ->whereBetween('events.start_at', [$windowStart->copy()->subDay(), $windowEnd])
+            ->whereRaw("$eventEnd >= ?", [$windowStart])
+            ->whereRaw("$eventEnd <= ?", [$windowEnd])
+            ->where('events.visibility_id', '!=', Visibility::VISIBILITY_CANCELLED)
+            ->where(function ($q) {
+                $q->whereNull('events.event_status_id')
+                    ->orWhere('events.event_status_id', '!=', EventStatus::CANCELLED);
+            })
+            ->where('user_statuses.can_login', 1)
+            ->whereNotNull('users.email_verified_at')
+            ->where('profiles.setting_feedback_requests', 1)
+            // candidate_id is the keyset cursor for chunkById; no orderBy here,
+            // chunkById supplies its own.
+            ->select(
+                'event_responses.id as candidate_id',
+                'event_responses.user_id',
+                'event_responses.event_id'
+            );
+
+        if ($eventFilter !== null) {
+            $query->where(function ($q) use ($eventFilter) {
+                $q->where('events.slug', $eventFilter);
+
+                if (is_numeric($eventFilter)) {
+                    $q->orWhere('events.id', (int) $eventFilter);
+                }
+            });
+        }
+
+        return $query;
+    }
+
+    /**
+     * Whether this user is under the per-user prompt volume caps.
+     *
+     * Without these a heavy attendee gets a prompt for every event they went to
+     * over a busy weekend.
+     */
+    private function withinVolumeLimits(int $userId, int $alreadyGrantedThisRun = 0): bool
+    {
+        $maxPending = (int) config('feedback.max_pending_per_user', 1);
+
+        if ($maxPending > 0) {
+            $pending = SurveyInvitation::where('user_id', $userId)->actionable()->count()
+                + $alreadyGrantedThisRun;
+
+            if ($pending >= $maxPending) {
+                return false;
+            }
+        }
+
+        $minDays = (int) config('feedback.min_days_between_prompts', 7);
+
+        if ($minDays > 0) {
+            $recent = SurveyInvitation::where('user_id', $userId)
+                ->where(function ($q) use ($minDays) {
+                    $q->where('completed_at', '>', now()->subDays($minDays))
+                        ->orWhere('dismissed_at', '>', now()->subDays($minDays));
+                })
+                ->exists();
+
+            if ($recent) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Flip open invitations whose expiry has passed.
+     */
+    public function sweepExpired(): int
+    {
+        return SurveyInvitation::whereIn('status', SurveyInvitation::OPEN_STATUSES)
+            ->whereNotNull('expires_at')
+            ->where('expires_at', '<', now())
+            ->update([
+                'status' => SurveyInvitation::STATUS_EXPIRED,
+                'updated_at' => now(),
+            ]);
+    }
+
+    /**
+     * Delete invitations pointing at events that no longer exist.
+     *
+     * Nothing in this app soft-deletes and there is no FK on the polymorphic
+     * subject columns, so a hard-deleted event leaves invitations dangling.
+     */
+    public function cleanupDanglingEventSubjects(): int
+    {
+        return SurveyInvitation::where('subject_type', 'event')
+            ->whereNotIn('subject_id', DB::table('events')->select('id'))
+            ->delete();
+    }
+}

--- a/config/feedback.php
+++ b/config/feedback.php
@@ -36,17 +36,22 @@ return [
     ],
 
     /*
-    | Volume controls, applied across all campaigns. Without these a heavy
-    | attendee gets a prompt for every event they went to over a busy weekend.
+    | Volume controls, applied across all campaigns.
+    |
+    | max_pending_per_user is a queue depth, not a display limit — the modal
+    | always shows one invitation at a time, freshest event first. It is above 1
+    | because the lookback window governs *creation* while an invitation lives
+    | for expire_days once it exists; with a depth of 1 a user who attended
+    | several events in a week would see the extras age out of the window
+    | before they were ever asked.
     */
-    'max_pending_per_user' => 1,
-
-    'min_days_between_prompts' => 7,
+    'max_pending_per_user' => 3,
 
     /*
-    | Candidate rows processed per keyset chunk by feedback:generate. Lowered in
-    | tests to exercise multi-chunk behaviour.
+    | Cooldown after a user *dismisses* a prompt. Completing one does not start
+    | a cooldown — someone who just answered is engaged, and can work through
+    | their queue as fast as they like.
     */
-    'generation_chunk_size' => 500,
+    'min_days_between_prompts' => 7,
 
 ];

--- a/config/feedback.php
+++ b/config/feedback.php
@@ -1,0 +1,52 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Proactive feedback interview (issue #1998)
+    |--------------------------------------------------------------------------
+    |
+    | Master switch for the entire feedback survey feature. When false:
+    | no invitations are generated, no prompt is displayed, and every
+    | feedback endpoint returns 404.
+    |
+    | Always read these through config(), never env() — production caches
+    | the config and env() returns null outside of config files.
+    |
+    */
+
+    'enabled' => env('FEEDBACK_ENABLED', false),
+
+    /*
+    | Post-event attendee campaign. Targets users who marked "Attending" on
+    | an event that has since ended.
+    */
+    'post_event' => [
+        'enabled' => env('FEEDBACK_POST_EVENT_ENABLED', true),
+
+        // Wait this long after the event ends before asking.
+        'delay_hours' => 12,
+
+        // Don't ask about events that ended more than this many days ago.
+        'lookback_days' => 14,
+
+        // Invitations self-expire after this many days.
+        'expire_days' => 30,
+    ],
+
+    /*
+    | Volume controls, applied across all campaigns. Without these a heavy
+    | attendee gets a prompt for every event they went to over a busy weekend.
+    */
+    'max_pending_per_user' => 1,
+
+    'min_days_between_prompts' => 7,
+
+    /*
+    | Candidate rows processed per keyset chunk by feedback:generate. Lowered in
+    | tests to exercise multi-chunk behaviour.
+    */
+    'generation_chunk_size' => 500,
+
+];

--- a/config/modules.php
+++ b/config/modules.php
@@ -55,6 +55,7 @@ return [
         ['name' => 'Categories', 'url' => '/categories', 'icon' => 'bi-folder', 'description' => 'Manage forum categories'],
         ['name' => 'Entity Types', 'url' => '/entity-types', 'icon' => 'bi-diagram-3', 'description' => 'Manage entity types'],
         ['name' => 'Event Graph', 'url' => '/events/graph', 'icon' => 'bi-bar-chart-line', 'description' => 'Visualize and export event trends by type, tag, venue and more'],
+        ['name' => 'Feedback', 'url' => '/feedback/responses', 'icon' => 'bi-chat-square-quote', 'description' => 'Survey campaign responses and summaries'],
         ['name' => 'Forums', 'url' => '/forums', 'icon' => 'bi-chat-square-text', 'description' => 'Manage forum sections'],
         ['name' => 'Groups', 'url' => '/groups', 'icon' => 'bi-people-fill', 'description' => 'Manage user groups'],
         ['name' => 'Menus', 'url' => '/menus', 'icon' => 'bi-menu-button-wide', 'description' => 'Manage navigation menus'],

--- a/database/factories/EventResponseFactory.php
+++ b/database/factories/EventResponseFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Event;
+use App\Models\EventResponse;
+use App\Models\ResponseType;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class EventResponseFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = EventResponse::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * Defaults to Attending, which is the only response type the application
+     * actually writes.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            'event_id' => fn () => Event::factory()->create()->id,
+            'user_id' => fn () => User::factory()->create()->id,
+            'response_type_id' => ResponseType::ATTENDING,
+        ];
+    }
+
+    /**
+     * Interested, rather than attending.
+     */
+    public function interested(): static
+    {
+        return $this->state(fn () => ['response_type_id' => ResponseType::INTERESTED]);
+    }
+}

--- a/database/factories/ProfileFactory.php
+++ b/database/factories/ProfileFactory.php
@@ -35,7 +35,8 @@ class ProfileFactory extends Factory
             'location' => $this->faker->optional->city,
             'setting_weekly_update' => 1,
             'setting_daily_update' => 1,
-            'setting_instant_update' => 1
+            'setting_instant_update' => 1,
+            'setting_feedback_requests' => 1,
         ];
     }
 }

--- a/database/factories/SurveyAnswerFactory.php
+++ b/database/factories/SurveyAnswerFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\SurveyAnswer;
+use App\Models\SurveyQuestion;
+use App\Models\SurveyResponse;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class SurveyAnswerFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = SurveyAnswer::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            'survey_response_id' => fn () => SurveyResponse::factory()->create()->id,
+            'survey_question_id' => fn () => SurveyQuestion::factory()->create()->id,
+            'value_int' => null,
+            'value_option' => null,
+            'value_text' => $this->faker->sentence(),
+        ];
+    }
+
+    public function rating(int $value): static
+    {
+        return $this->state(fn () => [
+            'value_int' => $value,
+            'value_option' => null,
+            'value_text' => null,
+        ]);
+    }
+
+    public function option(string $value): static
+    {
+        return $this->state(fn () => [
+            'value_int' => null,
+            'value_option' => $value,
+            'value_text' => null,
+        ]);
+    }
+}

--- a/database/factories/SurveyCampaignFactory.php
+++ b/database/factories/SurveyCampaignFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\SurveyCampaign;
+use App\Models\Visibility;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class SurveyCampaignFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = SurveyCampaign::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            'slug' => $this->faker->unique()->slug(3),
+            'name' => $this->faker->sentence(3),
+            'intro' => $this->faker->sentence(),
+            'subject_type' => 'event',
+            'is_active' => true,
+            'priority' => 0,
+            'expires_after_days' => 30,
+            'default_visibility_id' => Visibility::VISIBILITY_PRIVATE,
+        ];
+    }
+
+    public function inactive(): static
+    {
+        return $this->state(fn () => ['is_active' => false]);
+    }
+
+    /**
+     * A campaign with no subject, e.g. a general interest poll.
+     */
+    public function subjectless(): static
+    {
+        return $this->state(fn () => ['subject_type' => null]);
+    }
+}

--- a/database/factories/SurveyInvitationFactory.php
+++ b/database/factories/SurveyInvitationFactory.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Event;
+use App\Models\SurveyCampaign;
+use App\Models\SurveyInvitation;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Model;
+
+class SurveyInvitationFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = SurveyInvitation::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            'survey_campaign_id' => fn () => SurveyCampaign::factory()->create()->id,
+            'user_id' => fn () => User::factory()->create()->id,
+            'subject_type' => 'event',
+            'subject_id' => fn () => Event::factory()->create()->id,
+            'token' => SurveyInvitation::generateToken(),
+            'status' => SurveyInvitation::STATUS_PENDING,
+            'source' => SurveyInvitation::SOURCE_APP,
+            'expires_at' => now()->addDays(30),
+        ];
+    }
+
+    /**
+     * Point the invitation at a specific model using the morph map.
+     */
+    public function about(Model $subject): static
+    {
+        return $this->state(fn () => [
+            'subject_type' => $subject->getMorphClass(),
+            'subject_id' => $subject->getKey(),
+        ]);
+    }
+
+    /**
+     * No subject at all, e.g. a general interest poll.
+     */
+    public function subjectless(): static
+    {
+        return $this->state(fn () => ['subject_type' => '', 'subject_id' => 0]);
+    }
+
+    public function shown(): static
+    {
+        return $this->state(fn () => [
+            'status' => SurveyInvitation::STATUS_SHOWN,
+            'shown_at' => now(),
+        ]);
+    }
+
+    public function completed(): static
+    {
+        return $this->state(fn () => [
+            'status' => SurveyInvitation::STATUS_COMPLETED,
+            'completed_at' => now(),
+        ]);
+    }
+
+    public function dismissed(): static
+    {
+        return $this->state(fn () => [
+            'status' => SurveyInvitation::STATUS_DISMISSED,
+            'dismissed_at' => now(),
+        ]);
+    }
+
+    /**
+     * Past its expiry but not yet swept by the generator.
+     */
+    public function expired(): static
+    {
+        return $this->state(fn () => ['expires_at' => now()->subDay()]);
+    }
+
+    public function snoozed(): static
+    {
+        return $this->state(fn () => ['snoozed_until' => now()->addWeek()]);
+    }
+}

--- a/database/factories/SurveyQuestionFactory.php
+++ b/database/factories/SurveyQuestionFactory.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\SurveyCampaign;
+use App\Models\SurveyQuestion;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class SurveyQuestionFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = SurveyQuestion::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            'survey_campaign_id' => fn () => SurveyCampaign::factory()->create()->id,
+            'key' => $this->faker->unique()->word(),
+            'sort' => 0,
+            'type' => SurveyQuestion::TYPE_TEXT,
+            'prompt' => $this->faker->sentence(),
+            'help' => null,
+            'options' => null,
+            'min_value' => null,
+            'max_value' => null,
+            'is_required' => false,
+            'is_active' => true,
+        ];
+    }
+
+    public function rating(int $min = 1, int $max = 5): static
+    {
+        return $this->state(fn () => [
+            'type' => SurveyQuestion::TYPE_RATING,
+            'min_value' => $min,
+            'max_value' => $max,
+        ]);
+    }
+
+    /**
+     * @param  array<int, string>  $values
+     */
+    public function singleChoice(array $values = ['yes', 'no']): static
+    {
+        return $this->state(fn () => [
+            'type' => SurveyQuestion::TYPE_SINGLE_CHOICE,
+            'options' => array_map(
+                static fn (string $value) => ['value' => $value, 'label' => ucfirst($value)],
+                $values
+            ),
+        ]);
+    }
+
+    /**
+     * @param  array<int, string>  $values
+     */
+    public function multiChoice(array $values = ['one', 'two', 'three']): static
+    {
+        return $this->state(fn () => [
+            'type' => SurveyQuestion::TYPE_MULTI_CHOICE,
+            'options' => array_map(
+                static fn (string $value) => ['value' => $value, 'label' => ucfirst($value)],
+                $values
+            ),
+        ]);
+    }
+
+    public function required(): static
+    {
+        return $this->state(fn () => ['is_required' => true]);
+    }
+}

--- a/database/factories/SurveyResponseFactory.php
+++ b/database/factories/SurveyResponseFactory.php
@@ -31,6 +31,9 @@ class SurveyResponseFactory extends Factory
             'subject_type' => 'event',
             'subject_id' => fn () => Event::factory()->create()->id,
             'visibility_id' => Visibility::VISIBILITY_PRIVATE,
+            'display_status' => SurveyResponse::DISPLAY_PENDING,
+            'approved_at' => null,
+            'approved_by' => null,
             'submitted_at' => now(),
         ];
     }
@@ -49,5 +52,26 @@ class SurveyResponseFactory extends Factory
     public function shared(): static
     {
         return $this->state(fn () => ['visibility_id' => Visibility::VISIBILITY_PUBLIC]);
+    }
+
+    /**
+     * An admin cleared this for display. Note this alone does not make the
+     * response displayable — pair with shared() for that.
+     */
+    public function approved(): static
+    {
+        return $this->state(fn () => [
+            'display_status' => SurveyResponse::DISPLAY_APPROVED,
+            'approved_at' => now(),
+            'approved_by' => fn () => User::factory()->create()->id,
+        ]);
+    }
+
+    /**
+     * An admin decided this should never be shown.
+     */
+    public function rejected(): static
+    {
+        return $this->state(fn () => ['display_status' => SurveyResponse::DISPLAY_REJECTED]);
     }
 }

--- a/database/factories/SurveyResponseFactory.php
+++ b/database/factories/SurveyResponseFactory.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Event;
+use App\Models\SurveyCampaign;
+use App\Models\SurveyResponse;
+use App\Models\User;
+use App\Models\Visibility;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Model;
+
+class SurveyResponseFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = SurveyResponse::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            'survey_invitation_id' => null,
+            'survey_campaign_id' => fn () => SurveyCampaign::factory()->create()->id,
+            'user_id' => fn () => User::factory()->create()->id,
+            'subject_type' => 'event',
+            'subject_id' => fn () => Event::factory()->create()->id,
+            'visibility_id' => Visibility::VISIBILITY_PRIVATE,
+            'submitted_at' => now(),
+        ];
+    }
+
+    public function about(Model $subject): static
+    {
+        return $this->state(fn () => [
+            'subject_type' => $subject->getMorphClass(),
+            'subject_id' => $subject->getKey(),
+        ]);
+    }
+
+    /**
+     * The submitter opted to share this response publicly.
+     */
+    public function shared(): static
+    {
+        return $this->state(fn () => ['visibility_id' => Visibility::VISIBILITY_PUBLIC]);
+    }
+}

--- a/database/migrations/2026_08_07_000000_create_survey_definition_tables.php
+++ b/database/migrations/2026_08_07_000000_create_survey_definition_tables.php
@@ -1,0 +1,90 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Definition side of the proactive feedback survey engine (issue #1998).
+ *
+ * Campaigns and their questions are seeded rows, not config arrays, so that
+ * survey_answers can carry a stable FK to a question and the admin summary
+ * can aggregate in SQL. Adding a new campaign is a seeder block, not a
+ * migration — that is the point of this split.
+ *
+ * The collection side (invitations/responses/answers) lands in the sibling
+ * migration and FKs into these tables.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('survey_campaigns')) {
+            Schema::create('survey_campaigns', function (Blueprint $table) {
+                $table->id();
+                $table->string('slug', 64)->unique();
+                $table->string('name', 191);
+                $table->text('intro')->nullable();
+
+                // Morph-map key of the expected subject ('event', 'entity', …).
+                // Null means the campaign has no subject, e.g. a general poll.
+                $table->string('subject_type', 64)->nullable();
+
+                $table->boolean('is_active')->default(true)->index();
+
+                // Arbitration when a user has more than one pending invitation.
+                $table->smallInteger('priority')->default(0);
+
+                $table->unsignedSmallInteger('expires_after_days')->nullable()->default(30);
+
+                // Visibility::VISIBILITY_PRIVATE — admin-only unless the user opts in.
+                $table->unsignedInteger('default_visibility_id')->default(2);
+
+                $table->timestamps();
+            });
+        }
+
+        if (! Schema::hasTable('survey_questions')) {
+            Schema::create('survey_questions', function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('survey_campaign_id')->constrained()->cascadeOnDelete();
+
+                // Stable identifier used by the API payload and CSV export.
+                // Answers are submitted keyed by this, never by autoincrement id.
+                $table->string('key', 64);
+
+                $table->unsignedSmallInteger('sort')->default(0);
+
+                // rating | single_choice | multi_choice | text
+                $table->string('type', 20);
+
+                $table->string('prompt', 512);
+                $table->string('help', 512)->nullable();
+
+                // [{"value": "sound", "label": "Sound & production"}, …]
+                // Kept as JSON rather than a sixth table: options are display
+                // labels over a stable string value, and aggregation joins on
+                // the indexed survey_answers.value_option, never on an options row.
+                $table->json('options')->nullable();
+
+                // Rating bounds. Null for non-rating types.
+                $table->smallInteger('min_value')->nullable();
+                $table->smallInteger('max_value')->nullable();
+
+                $table->boolean('is_required')->default(false);
+                $table->boolean('is_active')->default(true);
+
+                $table->timestamps();
+
+                $table->unique(['survey_campaign_id', 'key'], 'survey_questions_campaign_key_unique');
+                $table->index(['survey_campaign_id', 'sort'], 'survey_questions_campaign_sort_index');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('survey_questions');
+        Schema::dropIfExists('survey_campaigns');
+    }
+};

--- a/database/migrations/2026_08_07_000001_create_survey_collection_tables.php
+++ b/database/migrations/2026_08_07_000001_create_survey_collection_tables.php
@@ -1,0 +1,136 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Collection side of the proactive feedback survey engine (issue #1998).
+ *
+ * Invitations are the targeting/lifecycle artifact: generated in batches,
+ * deduped by unique index, expirable, and frequently terminal without ever
+ * producing a response. Responses are the content artifact: immutable,
+ * carrying visibility, exported, potentially shown publicly. Hence two tables
+ * rather than one wide mostly-null one.
+ *
+ * NOTE ON TYPES: users.id, events.id and visibilities.id are `int unsigned`
+ * in this schema, not bigint. foreignId() would emit `bigint unsigned` and
+ * the FK constraint would fail to create — so references into legacy tables
+ * use unsignedInteger() + an explicit foreign(). Only FKs between two new
+ * tables use foreignId()/constrained().
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('survey_invitations')) {
+            Schema::create('survey_invitations', function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('survey_campaign_id')->constrained()->cascadeOnDelete();
+                $table->unsignedInteger('user_id');
+
+                // Morph-map key + id of what the invitation is about. Singular
+                // lowercase keys per the map in AppServiceProvider ('event').
+                //
+                // NOT NULL with ''/0 defaults on purpose: MySQL treats NULLs as
+                // distinct in a unique index, so nullable columns would make the
+                // dedupe constraint below a no-op for subject-less campaigns.
+                $table->string('subject_type', 64)->default('');
+                $table->unsignedInteger('subject_id')->default(0);
+
+                // Opaque route key. Prevents enumeration, and is the handle a
+                // future emailed feedback link will use.
+                $table->string('token', 40)->unique();
+
+                // pending -> shown -> completed | dismissed | expired
+                // Internal state machine values, deliberately not a lookup table:
+                // they are never admin-managed or form-selectable.
+                $table->string('status', 20)->default('pending');
+
+                // app | email — which delivery path created this invitation.
+                $table->string('source', 20)->default('app');
+
+                $table->timestamp('shown_at')->nullable();
+                $table->timestamp('completed_at')->nullable();
+                $table->timestamp('dismissed_at')->nullable();
+                $table->timestamp('snoozed_until')->nullable();
+                $table->timestamp('expires_at')->nullable();
+
+                $table->timestamps();
+
+                $table->unique(
+                    ['survey_campaign_id', 'user_id', 'subject_type', 'subject_id'],
+                    'survey_invitations_target_unique'
+                );
+
+                // The hot lookup: "does this user have anything pending?"
+                $table->index(['user_id', 'status'], 'survey_invitations_user_status_index');
+                $table->index(['subject_type', 'subject_id'], 'survey_invitations_subject_index');
+                $table->index(['status', 'expires_at'], 'survey_invitations_expiry_index');
+
+                $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+            });
+        }
+
+        if (! Schema::hasTable('survey_responses')) {
+            Schema::create('survey_responses', function (Blueprint $table) {
+                $table->id();
+
+                // Nullable so an unsolicited response (someone following a link
+                // with no invitation) is representable later.
+                $table->foreignId('survey_invitation_id')->nullable()->unique()
+                    ->constrained()->nullOnDelete();
+
+                // Campaign and subject are denormalized off the invitation so
+                // admin listing, filtering, export and any public display never
+                // need to join invitations.
+                $table->foreignId('survey_campaign_id')->constrained()->cascadeOnDelete();
+                $table->unsignedInteger('user_id');
+                $table->string('subject_type', 64)->default('');
+                $table->unsignedInteger('subject_id')->default(0);
+
+                // Visibility::VISIBILITY_PRIVATE by default; the user may opt in
+                // to VISIBILITY_PUBLIC per response.
+                $table->unsignedInteger('visibility_id')->default(2);
+
+                $table->timestamp('submitted_at')->nullable();
+                $table->timestamps();
+
+                $table->index(['survey_campaign_id', 'submitted_at'], 'survey_responses_campaign_submitted_index');
+                $table->index(['subject_type', 'subject_id'], 'survey_responses_subject_index');
+                $table->index('visibility_id', 'survey_responses_visibility_index');
+
+                $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+                $table->foreign('visibility_id')->references('id')->on('visibilities');
+            });
+        }
+
+        if (! Schema::hasTable('survey_answers')) {
+            Schema::create('survey_answers', function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('survey_response_id')->constrained()->cascadeOnDelete();
+                $table->foreignId('survey_question_id')->constrained()->cascadeOnDelete();
+
+                // Typed columns rather than one JSON value: the admin payoff is
+                // AVG(value_int) per question and GROUP BY value_option, both of
+                // which are trivial indexed SQL here. A multi_choice answer is
+                // stored as N rows, which is what the group-by wants anyway.
+                $table->smallInteger('value_int')->nullable();
+                $table->string('value_option', 64)->nullable();
+                $table->text('value_text')->nullable();
+
+                $table->timestamps();
+
+                $table->index('survey_response_id', 'survey_answers_response_index');
+                $table->index(['survey_question_id', 'value_option'], 'survey_answers_question_option_index');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('survey_answers');
+        Schema::dropIfExists('survey_responses');
+        Schema::dropIfExists('survey_invitations');
+    }
+};

--- a/database/migrations/2026_08_07_000002_add_display_moderation_to_survey_responses.php
+++ b/database/migrations/2026_08_07_000002_add_display_moderation_to_survey_responses.php
@@ -1,0 +1,69 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Admin moderation gate for publicly displaying feedback (issue #1998).
+ *
+ * `visibility_id` already records what the *submitter* consented to. This adds
+ * what the *admin* decided, deliberately as a separate column rather than a
+ * fourth visibility value: the two are independent facts, and collapsing them
+ * would make an admin approval silently overwrite user consent.
+ *
+ * A response is only ever displayable when both agree — see
+ * SurveyResponse::scopeDisplayable(). Nothing renders public feedback yet;
+ * this is the gate that future display code must go through.
+ *
+ * NOTE ON TYPES: users.id is `int unsigned` in this schema, so approved_by
+ * uses unsignedInteger() + explicit foreign(), matching the sibling migration.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('survey_responses')) {
+            return;
+        }
+
+        Schema::table('survey_responses', function (Blueprint $table) {
+            if (! Schema::hasColumn('survey_responses', 'display_status')) {
+                // pending -> approved | rejected. Admin-facing but never
+                // user-selectable, so a string column rather than a lookup
+                // table, matching survey_invitations.status.
+                $table->string('display_status', 20)
+                    ->default('pending')
+                    ->after('visibility_id');
+            }
+
+            if (! Schema::hasColumn('survey_responses', 'approved_at')) {
+                $table->timestamp('approved_at')->nullable()->after('display_status');
+            }
+
+            if (! Schema::hasColumn('survey_responses', 'approved_by')) {
+                $table->unsignedInteger('approved_by')->nullable()->after('approved_at');
+            }
+        });
+
+        Schema::table('survey_responses', function (Blueprint $table) {
+            // The display lookup is always "public AND approved", so index the
+            // pair rather than display_status alone.
+            $table->index(['visibility_id', 'display_status'], 'survey_responses_display_index');
+            $table->foreign('approved_by')->references('id')->on('users')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('survey_responses')) {
+            return;
+        }
+
+        Schema::table('survey_responses', function (Blueprint $table) {
+            $table->dropForeign(['approved_by']);
+            $table->dropIndex('survey_responses_display_index');
+            $table->dropColumn(['display_status', 'approved_at', 'approved_by']);
+        });
+    }
+};

--- a/database/migrations/2026_08_07_000002_add_setting_feedback_requests_to_profiles_table.php
+++ b/database/migrations/2026_08_07_000002_add_setting_feedback_requests_to_profiles_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Per-user opt-out for the proactive feedback interview (issue #1998).
+ *
+ * Defaults to 1 (opted in), matching the polarity of every other setting on
+ * this table. Unlike setting_notify_threads_by_follow — which defaults to 0
+ * because it sends email — this only gates an in-app prompt that carries a
+ * one-click permanent opt-out, so existing profiles are left opted in.
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasTable('profiles')) {
+            return;
+        }
+        Schema::table('profiles', function (Blueprint $table) {
+            if (!Schema::hasColumn('profiles', 'setting_feedback_requests')) {
+                $table->boolean('setting_feedback_requests')
+                    ->default(1)
+                    ->after('setting_public_profile');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('profiles')) {
+            return;
+        }
+        Schema::table('profiles', function (Blueprint $table) {
+            if (Schema::hasColumn('profiles', 'setting_feedback_requests')) {
+                $table->dropColumn('setting_feedback_requests');
+            }
+        });
+    }
+};

--- a/database/migrations/2026_08_07_000003_add_conditional_display_to_survey_questions.php
+++ b/database/migrations/2026_08_07_000003_add_conditional_display_to_survey_questions.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Lets a survey question depend on the answer to an earlier one (issue #1998).
+ *
+ * Needed so the post-event campaign can ask "did you make it?" up front and
+ * branch: attendees get the how-was-it questions, no-shows get asked why
+ * instead. Deliberately generic rather than special-cased, because the
+ * deferred "why did you skip this event" campaign needs the same mechanism.
+ *
+ * A question with a null depends_on_key always shows.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('survey_questions')) {
+            return;
+        }
+
+        Schema::table('survey_questions', function (Blueprint $table) {
+            if (! Schema::hasColumn('survey_questions', 'depends_on_key')) {
+                // `key` of another question in the same campaign.
+                $table->string('depends_on_key', 64)->nullable()->after('is_active');
+            }
+
+            if (! Schema::hasColumn('survey_questions', 'depends_on_value')) {
+                // Value that question must hold for this one to apply.
+                $table->string('depends_on_value', 64)->nullable()->after('depends_on_key');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('survey_questions')) {
+            return;
+        }
+
+        Schema::table('survey_questions', function (Blueprint $table) {
+            foreach (['depends_on_key', 'depends_on_value'] as $column) {
+                if (Schema::hasColumn('survey_questions', $column)) {
+                    $table->dropColumn($column);
+                }
+            }
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -89,6 +89,9 @@ class DatabaseSeeder extends Seeder
         $this->call(ThreadsTableSeeder::class);
         $this->command->info('Threads table seeded.');
 
+        $this->call(SurveyCampaignsTableSeeder::class);
+        $this->command->info('Survey campaigns table seeded.');
+
         // $this->call(ForumsTableSeeder::class);
         // $this->command->info('Forums table seeded.');
 

--- a/database/seeders/SurveyCampaignsTableSeeder.php
+++ b/database/seeders/SurveyCampaignsTableSeeder.php
@@ -30,9 +30,12 @@ class SurveyCampaignsTableSeeder extends Seeder
     /**
      * Post-event feedback for users who marked "Attending".
      *
-     * Six questions, one required. The required one is a single tap, so an
-     * abandoned survey still yields a usable rating. Q2 and Q3 share an option
-     * vocabulary so the admin summary can show liked-vs-disliked per dimension.
+     * Branches on a required "did you make it?" gate: no-shows are asked why
+     * instead of being asked to rate something they didn't see. The gate is a
+     * single tap, so even an abandoned survey tells us whether they turned up.
+     *
+     * `liked_most` and `liked_least` share an option vocabulary so the admin
+     * summary can line them up against each other per dimension.
      */
     private function seedPostEventAttendee(): void
     {
@@ -40,7 +43,7 @@ class SurveyCampaignsTableSeeder extends Seeder
             ['slug' => SurveyCampaign::POST_EVENT_ATTENDEE],
             [
                 'name' => 'Post-event feedback',
-                'intro' => 'You said you were going to this one — how was it? Six quick questions, about a minute. Only the first is required.',
+                'intro' => 'You said you were going to this one. Did you make it? A handful of quick questions, about a minute. Only the first is required.',
                 'subject_type' => 'event',
                 'is_active' => true,
                 'priority' => 10,
@@ -62,9 +65,69 @@ class SurveyCampaignsTableSeeder extends Seeder
         ];
 
         $questions = [
+            // Gate question. Invitations go to everyone who marked "Attending",
+            // but plenty of them won't have actually gone — and "how was the
+            // sound?" is meaningless if they weren't there. Everything below
+            // branches off this answer.
+            [
+                'key' => 'attended',
+                'sort' => 1,
+                'type' => SurveyQuestion::TYPE_SINGLE_CHOICE,
+                'prompt' => 'Did you make it to this one?',
+                'help' => null,
+                'options' => [
+                    ['value' => 'yes', 'label' => 'Yes, I went'],
+                    ['value' => 'no', 'label' => "No, I didn't make it"],
+                ],
+                'min_value' => null,
+                'max_value' => null,
+                'is_required' => true,
+                'depends_on_key' => null,
+                'depends_on_value' => null,
+            ],
+            // --- No-show branch -------------------------------------------------
+            [
+                'key' => 'not_attended_reason',
+                'sort' => 2,
+                'type' => SurveyQuestion::TYPE_MULTI_CHOICE,
+                'prompt' => 'What got in the way?',
+                'help' => 'Optional, and genuinely useful — it tells promoters what loses people.',
+                'options' => [
+                    ['value' => 'cost', 'label' => 'Too expensive'],
+                    ['value' => 'timing', 'label' => 'Bad timing — too late or too early'],
+                    ['value' => 'lineup', 'label' => 'Lineup changed or lost interest'],
+                    ['value' => 'venue', 'label' => "Didn't want to go to that venue"],
+                    ['value' => 'distance', 'label' => 'Too far away'],
+                    ['value' => 'transport', 'label' => 'Getting there or parking'],
+                    ['value' => 'weather', 'label' => 'Weather'],
+                    ['value' => 'health', 'label' => 'Illness'],
+                    ['value' => 'plans_changed', 'label' => 'Plans changed / something came up'],
+                    ['value' => 'forgot', 'label' => 'Forgot about it'],
+                    ['value' => 'other', 'label' => 'Something else'],
+                ],
+                'min_value' => null,
+                'max_value' => null,
+                'is_required' => false,
+                'depends_on_key' => 'attended',
+                'depends_on_value' => 'no',
+            ],
+            [
+                'key' => 'not_attended_detail',
+                'sort' => 3,
+                'type' => SurveyQuestion::TYPE_TEXT,
+                'prompt' => 'Anything more on why you skipped it?',
+                'help' => 'Optional.',
+                'options' => null,
+                'min_value' => null,
+                'max_value' => null,
+                'is_required' => false,
+                'depends_on_key' => 'attended',
+                'depends_on_value' => 'no',
+            ],
+            // --- Attended branch ------------------------------------------------
             [
                 'key' => 'overall_rating',
-                'sort' => 1,
+                'sort' => 4,
                 'type' => SurveyQuestion::TYPE_RATING,
                 'prompt' => 'Overall, how was it?',
                 'help' => null,
@@ -72,10 +135,12 @@ class SurveyCampaignsTableSeeder extends Seeder
                 'min_value' => 1,
                 'max_value' => 5,
                 'is_required' => true,
+                'depends_on_key' => 'attended',
+                'depends_on_value' => 'yes',
             ],
             [
                 'key' => 'liked_most',
-                'sort' => 2,
+                'sort' => 5,
                 'type' => SurveyQuestion::TYPE_MULTI_CHOICE,
                 'prompt' => 'What worked? Pick anything that stood out.',
                 'help' => null,
@@ -83,10 +148,12 @@ class SurveyCampaignsTableSeeder extends Seeder
                 'min_value' => null,
                 'max_value' => null,
                 'is_required' => false,
+                'depends_on_key' => 'attended',
+                'depends_on_value' => 'yes',
             ],
             [
                 'key' => 'liked_least',
-                'sort' => 3,
+                'sort' => 6,
                 'type' => SurveyQuestion::TYPE_MULTI_CHOICE,
                 'prompt' => "What didn't? Be honest — this goes to the promoter and venue.",
                 'help' => null,
@@ -96,10 +163,12 @@ class SurveyCampaignsTableSeeder extends Seeder
                 'min_value' => null,
                 'max_value' => null,
                 'is_required' => false,
+                'depends_on_key' => 'attended',
+                'depends_on_value' => 'yes',
             ],
             [
                 'key' => 'want_more',
-                'sort' => 4,
+                'sort' => 7,
                 'type' => SurveyQuestion::TYPE_MULTI_CHOICE,
                 'prompt' => 'What would make you more likely to come back?',
                 'help' => null,
@@ -117,10 +186,12 @@ class SurveyCampaignsTableSeeder extends Seeder
                 'min_value' => null,
                 'max_value' => null,
                 'is_required' => false,
+                'depends_on_key' => 'attended',
+                'depends_on_value' => 'yes',
             ],
             [
                 'key' => 'return_likelihood',
-                'sort' => 5,
+                'sort' => 8,
                 'type' => SurveyQuestion::TYPE_SINGLE_CHOICE,
                 'prompt' => 'Would you go to another event by this promoter?',
                 'help' => null,
@@ -133,10 +204,12 @@ class SurveyCampaignsTableSeeder extends Seeder
                 'min_value' => null,
                 'max_value' => null,
                 'is_required' => false,
+                'depends_on_key' => 'attended',
+                'depends_on_value' => 'yes',
             ],
             [
                 'key' => 'comments',
-                'sort' => 6,
+                'sort' => 9,
                 'type' => SurveyQuestion::TYPE_TEXT,
                 'prompt' => "Anything else you'd want the promoter or venue to know?",
                 'help' => 'One specific thing is more useful than a general vibe.',
@@ -144,6 +217,8 @@ class SurveyCampaignsTableSeeder extends Seeder
                 'min_value' => null,
                 'max_value' => null,
                 'is_required' => false,
+                'depends_on_key' => 'attended',
+                'depends_on_value' => 'yes',
             ],
         ];
 

--- a/database/seeders/SurveyCampaignsTableSeeder.php
+++ b/database/seeders/SurveyCampaignsTableSeeder.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\SurveyCampaign;
+use App\Models\SurveyQuestion;
+use App\Models\Visibility;
+use Illuminate\Database\Seeder;
+
+/**
+ * Seeds the feedback survey campaigns and their questions (issue #1998).
+ *
+ * IMPORTANT — this seeder deliberately does NOT follow the pattern used by the
+ * other lookup seeders in this directory. Those begin with
+ * `DB::table('x')->delete()` and insert hardcoded ids; doing that here would
+ * cascade-delete every invitation, response and answer on the next seed run.
+ *
+ * Instead everything is `updateOrCreate`, keyed on the campaign slug and on
+ * (campaign, question key). Re-running is safe and preserves collected data.
+ * Application code must reference campaigns by slug constant, never by id —
+ * seeded ids are not stable across environments.
+ */
+class SurveyCampaignsTableSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $this->seedPostEventAttendee();
+    }
+
+    /**
+     * Post-event feedback for users who marked "Attending".
+     *
+     * Six questions, one required. The required one is a single tap, so an
+     * abandoned survey still yields a usable rating. Q2 and Q3 share an option
+     * vocabulary so the admin summary can show liked-vs-disliked per dimension.
+     */
+    private function seedPostEventAttendee(): void
+    {
+        $campaign = SurveyCampaign::updateOrCreate(
+            ['slug' => SurveyCampaign::POST_EVENT_ATTENDEE],
+            [
+                'name' => 'Post-event feedback',
+                'intro' => 'You said you were going to this one — how was it? Six quick questions, about a minute. Only the first is required.',
+                'subject_type' => 'event',
+                'is_active' => true,
+                'priority' => 10,
+                'expires_after_days' => 30,
+                'default_visibility_id' => Visibility::VISIBILITY_PRIVATE,
+            ]
+        );
+
+        // Shared vocabulary between "what worked" and "what didn't", so the
+        // summary can line them up against each other.
+        $dimensions = [
+            ['value' => 'lineup', 'label' => 'The lineup / music'],
+            ['value' => 'sound', 'label' => 'Sound & production'],
+            ['value' => 'venue', 'label' => 'The venue & space'],
+            ['value' => 'crowd', 'label' => 'The crowd & vibe'],
+            ['value' => 'value', 'label' => 'Value for the price'],
+            ['value' => 'organization', 'label' => 'Organization — timing, entry, staff'],
+            ['value' => 'safety', 'label' => 'Felt safe & comfortable'],
+        ];
+
+        $questions = [
+            [
+                'key' => 'overall_rating',
+                'sort' => 1,
+                'type' => SurveyQuestion::TYPE_RATING,
+                'prompt' => 'Overall, how was it?',
+                'help' => null,
+                'options' => null,
+                'min_value' => 1,
+                'max_value' => 5,
+                'is_required' => true,
+            ],
+            [
+                'key' => 'liked_most',
+                'sort' => 2,
+                'type' => SurveyQuestion::TYPE_MULTI_CHOICE,
+                'prompt' => 'What worked? Pick anything that stood out.',
+                'help' => null,
+                'options' => $dimensions,
+                'min_value' => null,
+                'max_value' => null,
+                'is_required' => false,
+            ],
+            [
+                'key' => 'liked_least',
+                'sort' => 3,
+                'type' => SurveyQuestion::TYPE_MULTI_CHOICE,
+                'prompt' => "What didn't? Be honest — this goes to the promoter and venue.",
+                'help' => null,
+                'options' => array_merge($dimensions, [
+                    ['value' => 'nothing', 'label' => 'Nothing — it was great'],
+                ]),
+                'min_value' => null,
+                'max_value' => null,
+                'is_required' => false,
+            ],
+            [
+                'key' => 'want_more',
+                'sort' => 4,
+                'type' => SurveyQuestion::TYPE_MULTI_CHOICE,
+                'prompt' => 'What would make you more likely to come back?',
+                'help' => null,
+                'options' => [
+                    ['value' => 'more_genre', 'label' => 'More of this kind of music'],
+                    ['value' => 'bigger_lineup', 'label' => 'A bigger or different lineup'],
+                    ['value' => 'more_locals', 'label' => 'More local openers'],
+                    ['value' => 'better_sound', 'label' => 'Better sound'],
+                    ['value' => 'earlier_start', 'label' => 'Earlier start'],
+                    ['value' => 'later_end', 'label' => 'Later end'],
+                    ['value' => 'cheaper', 'label' => 'Cheaper entry'],
+                    ['value' => 'diff_venue', 'label' => 'A different venue'],
+                    ['value' => 'more_space', 'label' => 'More room / seating'],
+                ],
+                'min_value' => null,
+                'max_value' => null,
+                'is_required' => false,
+            ],
+            [
+                'key' => 'return_likelihood',
+                'sort' => 5,
+                'type' => SurveyQuestion::TYPE_SINGLE_CHOICE,
+                'prompt' => 'Would you go to another event by this promoter?',
+                'help' => null,
+                'options' => [
+                    ['value' => 'definitely', 'label' => 'Definitely'],
+                    ['value' => 'probably', 'label' => 'Probably'],
+                    ['value' => 'maybe', 'label' => 'Maybe'],
+                    ['value' => 'no', 'label' => 'Probably not'],
+                ],
+                'min_value' => null,
+                'max_value' => null,
+                'is_required' => false,
+            ],
+            [
+                'key' => 'comments',
+                'sort' => 6,
+                'type' => SurveyQuestion::TYPE_TEXT,
+                'prompt' => "Anything else you'd want the promoter or venue to know?",
+                'help' => 'One specific thing is more useful than a general vibe.',
+                'options' => null,
+                'min_value' => null,
+                'max_value' => null,
+                'is_required' => false,
+            ],
+        ];
+
+        foreach ($questions as $question) {
+            SurveyQuestion::updateOrCreate(
+                [
+                    'survey_campaign_id' => $campaign->id,
+                    'key' => $question['key'],
+                ],
+                array_merge($question, ['is_active' => true])
+            );
+        }
+
+        SurveyCampaign::forgetCached(SurveyCampaign::POST_EVENT_ATTENDEE);
+    }
+}

--- a/resources/views/feedback/admin/index-tw.blade.php
+++ b/resources/views/feedback/admin/index-tw.blade.php
@@ -58,6 +58,15 @@
             </select>
         </div>
         <div>
+            <label for="display_status" class="block text-sm text-muted-foreground mb-1">Display status</label>
+            <select id="display_status" name="display_status" class="form-select-tw">
+                <option value="">Any</option>
+                @foreach(\App\Models\SurveyResponse::DISPLAY_STATUSES as $status)
+                    <option value="{{ $status }}" {{ ($filters['display_status'] ?? '') === $status ? 'selected' : '' }}>{{ ucfirst($status) }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div>
             <label for="submitted_after" class="block text-sm text-muted-foreground mb-1">Submitted after</label>
             <input type="date" id="submitted_after" name="submitted_after" value="{{ $filters['submitted_after'] ?? '' }}" class="form-input-tw">
         </div>
@@ -86,6 +95,7 @@
                         <th class="py-2 pr-4">Subject</th>
                         <th class="py-2 pr-4">Rating</th>
                         <th class="py-2 pr-4">Visibility</th>
+                        <th class="py-2 pr-4">Display</th>
                         <th class="py-2"></th>
                     </tr>
                 </thead>
@@ -117,8 +127,13 @@
                                     {{ $response->isPublic() ? 'Public' : 'Private' }}
                                 </x-ui.badge>
                             </td>
+                            <td class="py-2 pr-4">
+                                <x-ui.badge :variant="$response->isApproved() ? 'default' : ($response->isRejected() ? 'destructive' : 'secondary')">
+                                    {{ ucfirst($response->display_status) }}
+                                </x-ui.badge>
+                            </td>
                             <td class="py-2 text-right">
-                                <a href="{{ route('feedback.admin.show', $response->id) }}" class="text-primary hover:underline">View</a>
+                                <a href="{{ route('feedback.admin.show', $response->id) }}" class="text-primary hover:underline">Moderate</a>
                             </td>
                         </tr>
                     @endforeach

--- a/resources/views/feedback/admin/index-tw.blade.php
+++ b/resources/views/feedback/admin/index-tw.blade.php
@@ -1,0 +1,134 @@
+@extends('layouts.app-tw')
+
+@section('title', 'Feedback Responses')
+
+@section('content')
+{{-- Admin listing of collected survey feedback (issue #1998). Responses are
+     private by default, so this whole page is behind can:admin. --}}
+<div class="mb-6 flex flex-wrap items-start justify-between gap-3">
+    <div>
+        <h1 class="text-3xl font-bold text-primary mb-2">Feedback Responses</h1>
+        <p class="text-muted-foreground">Solicited, private-by-default feedback collected through survey campaigns.</p>
+    </div>
+    <div class="flex items-center gap-2">
+        <a href="{{ route('feedback.admin.summary') }}" class="px-3 py-2 text-sm rounded-md border border-border text-foreground hover:bg-accent transition-colors">
+            <i class="bi bi-bar-chart-line"></i> Summary
+        </a>
+        <a href="{{ route('feedback.admin.export', request()->query()) }}" class="px-3 py-2 text-sm rounded-md border border-border text-foreground hover:bg-accent transition-colors">
+            <i class="bi bi-download"></i> Export CSV
+        </a>
+    </div>
+</div>
+
+<div class="card-tw p-4 mb-6">
+    <form method="GET" action="{{ route('feedback.admin.index') }}" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        <div>
+            <label for="campaign" class="block text-sm text-muted-foreground mb-1">Campaign</label>
+            <select id="campaign" name="campaign" class="form-select-tw">
+                <option value="">All campaigns</option>
+                @foreach($campaigns as $campaign)
+                    <option value="{{ $campaign->slug }}" {{ ($filters['campaign'] ?? '') === $campaign->slug ? 'selected' : '' }}>{{ $campaign->name }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div>
+            <label for="user" class="block text-sm text-muted-foreground mb-1">User</label>
+            <input type="text" id="user" name="user" value="{{ $filters['user'] ?? '' }}" class="form-input-tw" placeholder="Name contains…">
+        </div>
+        <div>
+            <label for="event" class="block text-sm text-muted-foreground mb-1">Event</label>
+            <input type="text" id="event" name="event" value="{{ $filters['event'] ?? '' }}" class="form-input-tw" placeholder="Name or ID">
+        </div>
+        <div>
+            <label for="rating" class="block text-sm text-muted-foreground mb-1">Minimum rating</label>
+            <select id="rating" name="rating" class="form-select-tw">
+                <option value="">Any</option>
+                @foreach(range(1, 5) as $value)
+                    <option value="{{ $value }}" {{ (string) ($filters['rating'] ?? '') === (string) $value ? 'selected' : '' }}>{{ $value }}+</option>
+                @endforeach
+            </select>
+        </div>
+        <div>
+            <label for="visibility" class="block text-sm text-muted-foreground mb-1">Visibility</label>
+            <select id="visibility" name="visibility" class="form-select-tw">
+                <option value="">Any</option>
+                @foreach($visibilities as $visibility)
+                    <option value="{{ $visibility->id }}" {{ (string) ($filters['visibility'] ?? '') === (string) $visibility->id ? 'selected' : '' }}>{{ $visibility->name }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div>
+            <label for="submitted_after" class="block text-sm text-muted-foreground mb-1">Submitted after</label>
+            <input type="date" id="submitted_after" name="submitted_after" value="{{ $filters['submitted_after'] ?? '' }}" class="form-input-tw">
+        </div>
+        <div>
+            <label for="submitted_before" class="block text-sm text-muted-foreground mb-1">Submitted before</label>
+            <input type="date" id="submitted_before" name="submitted_before" value="{{ $filters['submitted_before'] ?? '' }}" class="form-input-tw">
+        </div>
+        <div class="flex items-end gap-2">
+            <x-ui.button type="submit">Filter</x-ui.button>
+            <a href="{{ route('feedback.admin.index') }}" class="px-4 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors">Reset</a>
+        </div>
+    </form>
+</div>
+
+<div class="card-tw p-4">
+    @if($responses->isEmpty())
+        <p class="text-muted-foreground py-8 text-center">No feedback responses match these filters yet.</p>
+    @else
+        <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+                <thead>
+                    <tr class="text-left text-muted-foreground border-b border-border">
+                        <th class="py-2 pr-4">Submitted</th>
+                        <th class="py-2 pr-4">Campaign</th>
+                        <th class="py-2 pr-4">User</th>
+                        <th class="py-2 pr-4">Subject</th>
+                        <th class="py-2 pr-4">Rating</th>
+                        <th class="py-2 pr-4">Visibility</th>
+                        <th class="py-2"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach($responses as $response)
+                        @php
+                            $ratingAnswer = $response->answers->firstWhere('value_int', '!=', null);
+                        @endphp
+                        <tr class="border-b border-border/50">
+                            <td class="py-2 pr-4 whitespace-nowrap">{{ $response->submitted_at?->format('M j, Y') ?? '—' }}</td>
+                            <td class="py-2 pr-4">{{ $response->campaign?->name ?? '—' }}</td>
+                            <td class="py-2 pr-4">
+                                @if($response->user)
+                                    <a href="{{ route('users.show', $response->user->id) }}" class="text-primary hover:underline">{{ $response->user->name }}</a>
+                                @else
+                                    <span class="text-muted-foreground">—</span>
+                                @endif
+                            </td>
+                            <td class="py-2 pr-4">{{ $response->subject->name ?? '—' }}</td>
+                            <td class="py-2 pr-4">
+                                @if($ratingAnswer)
+                                    <span class="text-yellow-400">{{ str_repeat('★', (int) $ratingAnswer->value_int) }}</span>
+                                @else
+                                    <span class="text-muted-foreground">—</span>
+                                @endif
+                            </td>
+                            <td class="py-2 pr-4">
+                                <x-ui.badge :variant="$response->isPublic() ? 'default' : 'secondary'">
+                                    {{ $response->isPublic() ? 'Public' : 'Private' }}
+                                </x-ui.badge>
+                            </td>
+                            <td class="py-2 text-right">
+                                <a href="{{ route('feedback.admin.show', $response->id) }}" class="text-primary hover:underline">View</a>
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+
+        <div class="mt-4">
+            <x-ui.pagination :paginator="$responses" />
+        </div>
+    @endif
+</div>
+@endsection

--- a/resources/views/feedback/admin/show-tw.blade.php
+++ b/resources/views/feedback/admin/show-tw.blade.php
@@ -1,0 +1,79 @@
+@extends('layouts.app-tw')
+
+@section('title', 'Feedback Response')
+
+@section('content')
+{{-- A single collected feedback response with every answer (issue #1998). --}}
+<div class="mb-6">
+    <a href="{{ route('feedback.admin.index') }}" class="text-sm text-muted-foreground hover:text-foreground transition-colors">
+        <i class="bi bi-arrow-left"></i> Back to responses
+    </a>
+    <h1 class="text-3xl font-bold text-primary mt-2 mb-2">{{ $response->campaign?->name ?? 'Feedback' }}</h1>
+    <p class="text-muted-foreground">
+        Submitted {{ $response->submitted_at?->format('M j, Y g:ia') ?? 'at an unknown time' }}
+        @if($response->user)
+            by <a href="{{ route('users.show', $response->user->id) }}" class="text-primary hover:underline">{{ $response->user->name }}</a>
+        @endif
+    </p>
+</div>
+
+<div class="card-tw p-4 mb-6">
+    <dl class="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
+        <div>
+            <dt class="text-muted-foreground">Subject</dt>
+            <dd class="text-foreground">
+                @if($response->subject && $response->subject_type === 'event')
+                    <a href="{{ route('events.show', $response->subject->slug ?: $response->subject->id) }}" class="text-primary hover:underline">
+                        {{ $response->subject->name }}
+                    </a>
+                @elseif($response->subject)
+                    {{ $response->subject->name ?? '—' }}
+                @else
+                    <span class="text-muted-foreground">None</span>
+                @endif
+            </dd>
+        </div>
+        <div>
+            <dt class="text-muted-foreground">Visibility</dt>
+            <dd>
+                <x-ui.badge :variant="$response->isPublic() ? 'default' : 'secondary'">
+                    {{ $response->isPublic() ? 'Public — shared by the user' : 'Private — admin only' }}
+                </x-ui.badge>
+            </dd>
+        </div>
+        <div>
+            <dt class="text-muted-foreground">Invitation</dt>
+            <dd class="text-foreground">
+                @if($response->invitation)
+                    {{ ucfirst($response->invitation->status) }}
+                    <span class="text-muted-foreground">({{ $response->invitation->source }})</span>
+                @else
+                    <span class="text-muted-foreground">Unsolicited</span>
+                @endif
+            </dd>
+        </div>
+    </dl>
+</div>
+
+<div class="card-tw p-4">
+    <h2 class="text-lg font-semibold text-foreground mb-4">Answers</h2>
+
+    @if($response->answers->isEmpty())
+        <p class="text-muted-foreground">No answers were recorded.</p>
+    @else
+        <div class="space-y-4">
+            {{-- Multi-choice stores one row per selected option, so group by
+                 question to render them as a single answer. --}}
+            @foreach($response->answers->groupBy('survey_question_id') as $answers)
+                @php $question = $answers->first()->question; @endphp
+                <div class="pb-4 border-b border-border/50 last:border-0 last:pb-0">
+                    <p class="text-sm font-semibold text-foreground">{{ $question?->prompt ?? 'Unknown question' }}</p>
+                    <p class="text-sm text-muted-foreground mt-1">
+                        {{ $answers->map(fn($answer) => $answer->displayValue())->filter()->implode(', ') ?: '—' }}
+                    </p>
+                </div>
+            @endforeach
+        </div>
+    @endif
+</div>
+@endsection

--- a/resources/views/feedback/admin/show-tw.blade.php
+++ b/resources/views/feedback/admin/show-tw.blade.php
@@ -18,7 +18,7 @@
 </div>
 
 <div class="card-tw p-4 mb-6">
-    <dl class="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
+    <dl class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 text-sm">
         <div>
             <dt class="text-muted-foreground">Subject</dt>
             <dd class="text-foreground">
@@ -42,6 +42,19 @@
             </dd>
         </div>
         <div>
+            <dt class="text-muted-foreground">Display</dt>
+            <dd>
+                <x-ui.badge :variant="$response->isApproved() ? 'default' : ($response->isRejected() ? 'destructive' : 'secondary')">
+                    {{ ucfirst($response->display_status) }}
+                </x-ui.badge>
+                @if($response->approved_at)
+                    <span class="text-muted-foreground block mt-1 text-xs">
+                        by {{ $response->approver?->name ?? 'an admin' }} on {{ $response->approved_at->format('M j, Y') }}
+                    </span>
+                @endif
+            </dd>
+        </div>
+        <div>
             <dt class="text-muted-foreground">Invitation</dt>
             <dd class="text-foreground">
                 @if($response->invitation)
@@ -53,6 +66,55 @@
             </dd>
         </div>
     </dl>
+</div>
+
+{{-- Admin moderation. Visibility is the submitter's consent, display status is
+     our decision; a response is only ever shown when both agree. Nothing on the
+     site renders feedback yet — this sets the gate for when it does. --}}
+<div class="card-tw p-4 mb-6">
+    <h2 class="text-lg font-semibold text-foreground mb-1">Moderation</h2>
+    <p class="text-sm text-muted-foreground mb-4">
+        Feedback is only ever shown publicly when the submitter shared it <em>and</em> an admin approved it.
+    </p>
+
+    <form method="POST" action="{{ route('feedback.admin.update', $response->id) }}" class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        @csrf
+        @method('PATCH')
+
+        <div>
+            <label for="visibility_id" class="block text-sm text-muted-foreground mb-1">Visibility</label>
+            <select id="visibility_id" name="visibility_id" class="form-select-tw">
+                @foreach($visibilities as $visibility)
+                    <option value="{{ $visibility->id }}" {{ $response->visibility_id === $visibility->id ? 'selected' : '' }}>{{ $visibility->name }}</option>
+                @endforeach
+            </select>
+        </div>
+
+        <div>
+            <label for="display_status" class="block text-sm text-muted-foreground mb-1">Display status</label>
+            <select id="display_status" name="display_status" class="form-select-tw">
+                @foreach(\App\Models\SurveyResponse::DISPLAY_STATUSES as $status)
+                    <option value="{{ $status }}" {{ $response->display_status === $status ? 'selected' : '' }}>{{ ucfirst($status) }}</option>
+                @endforeach
+            </select>
+        </div>
+
+        <div class="flex items-end">
+            <x-ui.button type="submit">Save</x-ui.button>
+        </div>
+    </form>
+
+    @if($response->isApprovedButNotShared())
+        <p class="text-sm text-muted-foreground mt-4">
+            <i class="bi bi-exclamation-triangle text-yellow-500"></i>
+            Approved, but the submitter kept this private — it will not be shown. Set visibility to public to allow it.
+        </p>
+    @elseif($response->isDisplayable())
+        <p class="text-sm text-muted-foreground mt-4">
+            <i class="bi bi-eye text-primary"></i>
+            Cleared for display. Nothing on the site renders feedback yet, so this is not visible to anyone but admins today.
+        </p>
+    @endif
 </div>
 
 <div class="card-tw p-4">

--- a/resources/views/feedback/admin/summary-tw.blade.php
+++ b/resources/views/feedback/admin/summary-tw.blade.php
@@ -1,0 +1,141 @@
+@extends('layouts.app-tw')
+
+@section('title', 'Feedback Summary')
+
+@section('content')
+{{-- Per-campaign (optionally per-event) rollup of collected feedback (#1998). --}}
+<div class="mb-6 flex flex-wrap items-start justify-between gap-3">
+    <div>
+        <h1 class="text-3xl font-bold text-primary mb-2">Feedback Summary</h1>
+        <p class="text-muted-foreground">
+            @if($event)
+                {{ $campaign?->name }} for <span class="text-foreground">{{ $event->name }}</span>
+            @else
+                Aggregate results across all responses to this campaign.
+            @endif
+        </p>
+    </div>
+    <a href="{{ route('feedback.admin.index') }}" class="px-3 py-2 text-sm rounded-md border border-border text-foreground hover:bg-accent transition-colors">
+        <i class="bi bi-list-ul"></i> All responses
+    </a>
+</div>
+
+<div class="card-tw p-4 mb-6">
+    <form method="GET" action="{{ route('feedback.admin.summary') }}" class="flex flex-wrap items-end gap-4">
+        <div>
+            <label for="campaign" class="block text-sm text-muted-foreground mb-1">Campaign</label>
+            <select id="campaign" name="campaign" class="form-select-tw">
+                @foreach($campaigns as $option)
+                    <option value="{{ $option->slug }}" {{ $campaign && $campaign->slug === $option->slug ? 'selected' : '' }}>{{ $option->name }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div>
+            <label for="event" class="block text-sm text-muted-foreground mb-1">Event ID (optional)</label>
+            <input type="text" id="event" name="event" value="{{ $event?->id }}" class="form-input-tw" placeholder="Leave blank for all">
+        </div>
+        <x-ui.button type="submit">Apply</x-ui.button>
+    </form>
+</div>
+
+@if(!$campaign)
+    <div class="card-tw p-4">
+        <p class="text-muted-foreground">That campaign could not be found.</p>
+    </div>
+@else
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+        <div class="card-tw p-4">
+            <p class="text-sm text-muted-foreground">Invitations</p>
+            <p class="text-2xl font-bold text-foreground">{{ $counts['invitations'] }}</p>
+        </div>
+        <div class="card-tw p-4">
+            <p class="text-sm text-muted-foreground">Responses</p>
+            <p class="text-2xl font-bold text-foreground">{{ $counts['responses'] }}</p>
+        </div>
+        <div class="card-tw p-4">
+            <p class="text-sm text-muted-foreground">Completion rate</p>
+            <p class="text-2xl font-bold text-foreground">{{ $counts['completion'] }}%</p>
+        </div>
+    </div>
+
+    <div class="card-tw p-4 mb-6">
+        <h2 class="text-lg font-semibold text-foreground mb-4">By question</h2>
+
+        @if(empty($stats))
+            <p class="text-muted-foreground">No quantitative questions in this campaign.</p>
+        @else
+            <div class="space-y-6">
+                @foreach($stats as $stat)
+                    <div>
+                        <div class="flex items-baseline justify-between gap-4 mb-2">
+                            <h3 class="text-sm font-semibold text-foreground">{{ $stat['question']->prompt }}</h3>
+                            <span class="text-xs text-muted-foreground whitespace-nowrap">{{ $stat['count'] }} answer(s)</span>
+                        </div>
+
+                        @if($stat['kind'] === 'rating')
+                            <p class="text-2xl font-bold text-foreground">
+                                {{ $stat['average'] }}
+                                <span class="text-sm font-normal text-muted-foreground">
+                                    / {{ $stat['question']->max_value ?? 5 }} average
+                                </span>
+                            </p>
+                        @elseif(empty($stat['histogram']))
+                            <p class="text-sm text-muted-foreground">No answers yet.</p>
+                        @else
+                            @php $max = max(array_column($stat['histogram'], 'total')); @endphp
+                            <div class="space-y-1">
+                                @foreach($stat['histogram'] as $bar)
+                                    <div class="flex items-center gap-3">
+                                        <span class="text-sm text-muted-foreground w-56 shrink-0 truncate">{{ $bar['label'] }}</span>
+                                        <div class="flex-1 bg-background rounded h-3 overflow-hidden">
+                                            <div class="bg-primary h-full" style="width: {{ $max > 0 ? round(($bar['total'] / $max) * 100) : 0 }}%"></div>
+                                        </div>
+                                        <span class="text-sm text-foreground tabular-nums w-10 text-right">{{ $bar['total'] }}</span>
+                                    </div>
+                                @endforeach
+                            </div>
+                        @endif
+                    </div>
+                @endforeach
+            </div>
+        @endif
+    </div>
+
+    <div class="card-tw p-4">
+        <h2 class="text-lg font-semibold text-foreground mb-4">Recent comments</h2>
+
+        @if($comments->isEmpty())
+            <p class="text-muted-foreground">No free-text comments yet.</p>
+        @else
+            <div class="space-y-4">
+                @foreach($comments as $comment)
+                    <div class="pb-4 border-b border-border/50 last:border-0 last:pb-0">
+                        <p class="text-sm text-foreground">{{ $comment->value_text }}</p>
+                        <p class="text-xs text-muted-foreground mt-1">
+                            {{ $comment->response?->user?->name ?? 'Unknown' }}
+                            @if($comment->response?->subject)
+                                &middot; {{ $comment->response->subject->name }}
+                            @endif
+                            @if($comment->response)
+                                &middot; <a href="{{ route('feedback.admin.show', $comment->response->id) }}" class="text-primary hover:underline">View response</a>
+                            @endif
+                        </p>
+                    </div>
+                @endforeach
+            </div>
+        @endif
+    </div>
+
+    @if($event)
+        {{-- Feedback is solicited and private; Event Reviews are unsolicited and
+             public. Different features on purpose — cross-link rather than merge. --}}
+        <div class="card-tw p-4 mt-6">
+            <h2 class="text-lg font-semibold text-foreground mb-2">Public reviews</h2>
+            <p class="text-sm text-muted-foreground">
+                This page covers solicited, private-by-default feedback. Unsolicited public reviews for this event live separately —
+                <a href="{{ route('reviews.index') }}" class="text-primary hover:underline">browse event reviews</a>.
+            </p>
+        </div>
+    @endif
+@endif
+@endsection

--- a/resources/views/feedback/show-tw.blade.php
+++ b/resources/views/feedback/show-tw.blade.php
@@ -1,0 +1,16 @@
+@extends('layouts.app-tw')
+
+@section('title', 'Share your feedback')
+
+@section('content')
+    {{--
+        Standalone feedback page (issue #1998). Renders the same Alpine
+        component as the in-app prompt, but inline and with the payload already
+        supplied so there is no round-trip to feedback.prompt.
+
+        This is also the target a future emailed feedback link will point at.
+    --}}
+    <div class="max-w-2xl mx-auto">
+        @include('partials.feedback-modal', ['standalone' => true, 'payload' => $payload])
+    </div>
+@endsection

--- a/resources/views/layouts/app-tw.blade.php
+++ b/resources/views/layouts/app-tw.blade.php
@@ -130,8 +130,11 @@
 	@include('flash')
 
 	@auth
+		{{-- Onboarding wins over the feedback prompt — never stack two modals. --}}
 		@if(auth()->user()->shouldSeeOnboarding() || session('show_onboarding'))
 			@include('partials.onboarding-modal')
+		@elseif(!empty($feedbackPrompt))
+			@include('partials.feedback-modal', ['payload' => $feedbackPrompt])
 		@endif
 	@endauth
 </body>

--- a/resources/views/partials/feedback-modal.blade.php
+++ b/resources/views/partials/feedback-modal.blade.php
@@ -61,7 +61,7 @@
 
             <template x-if="!loading">
                 <div class="space-y-6">
-                    <template x-for="question in questions" :key="question.key">
+                    <template x-for="question in visibleQuestions" :key="question.key">
                         <section>
                             <h3 class="text-sm font-semibold text-foreground mb-2">
                                 <span x-text="question.prompt"></span>
@@ -184,10 +184,24 @@
                 return Array.from({ length: max - min + 1 }, (_, i) => min + i);
             },
 
-            // Only the required questions gate the submit button; everything
-            // else is optional by design so the survey stays quick to finish.
+            // Whether a question's branch is currently taken. Mirrors
+            // SurveyQuestion::appliesGiven() on the server.
+            applies(question) {
+                if (!question.depends_on) return true;
+                const actual = this.answers[question.depends_on.key];
+                if (Array.isArray(actual)) return actual.includes(question.depends_on.value);
+                return actual !== undefined && actual !== null && String(actual) === String(question.depends_on.value);
+            },
+
+            get visibleQuestions() {
+                return this.questions.filter(q => this.applies(q));
+            },
+
+            // Only the required questions that are currently shown gate the
+            // submit button; everything else is optional by design so the
+            // survey stays quick to finish.
             get canSubmit() {
-                return this.questions
+                return this.visibleQuestions
                     .filter(q => q.required)
                     .every(q => {
                         const value = this.answers[q.key];

--- a/resources/views/partials/feedback-modal.blade.php
+++ b/resources/views/partials/feedback-modal.blade.php
@@ -31,7 +31,13 @@
         <!-- Header -->
         <div class="flex items-center justify-between p-4 border-b border-border">
             <div class="min-w-0">
-                <h2 id="feedback-title" class="text-lg font-semibold text-foreground" x-text="campaign.name || 'How was it?'"></h2>
+                <div class="flex items-center gap-2">
+                    <h2 id="feedback-title" class="text-lg font-semibold text-foreground" x-text="campaign.name || 'How was it?'"></h2>
+                    {{-- Only worth showing when there's actually a queue. --}}
+                    <span x-show="total > 1" x-cloak
+                          class="shrink-0 px-2 py-0.5 rounded-full text-xs font-semibold bg-background text-muted-foreground tabular-nums"
+                          x-text="index + ' of ' + total"></span>
+                </div>
                 <template x-if="subject && subject.name">
                     <p class="text-sm text-muted-foreground truncate">
                         <span x-text="subject.name"></span>
@@ -150,7 +156,7 @@
             </div>
             <button type="button" @click="submit()" :disabled="saving || !canSubmit"
                     class="px-4 py-2 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed">
-                <span x-show="!saving">Send feedback</span>
+                <span x-show="!saving" x-text="index < total ? 'Send & next' : 'Send feedback'"></span>
                 <span x-show="saving">Sending&hellip;</span>
             </button>
         </div>
@@ -173,6 +179,10 @@
             generalError: '',
             isPublic: false,
             visibilityPrompt: 'Share my feedback publicly',
+            // Queue position. `total` is fixed on first load so the counter
+            // reads 1 of 3, 2 of 3, 3 of 3 rather than counting itself down.
+            index: 1,
+            total: 1,
 
             csrf() {
                 return document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
@@ -209,11 +219,25 @@
                     });
             },
 
-            apply(data) {
+            apply(data, advancing = false) {
                 if (!data || !data.invitation) {
                     this.open = false;
                     return;
                 }
+
+                if (advancing) {
+                    this.index++;
+                } else {
+                    this.index = 1;
+                    this.total = (data.queue && data.queue.remaining) || 1;
+                }
+
+                // Fresh question state for each invitation in the queue.
+                this.answers = {};
+                this.errors = {};
+                this.generalError = '';
+                this.isPublic = false;
+
                 this.token = data.invitation.token;
                 this.campaign = data.campaign || {};
                 this.subject = data.subject || null;
@@ -271,9 +295,16 @@
                 this.post('/feedback/' + this.token, { answers: this.answers, public: this.isPublic })
                     .then(r => {
                         if (r.ok) {
-                            this.open = false;
-                            if (this.standalone) window.location = '/';
-                            return;
+                            return r.json().then(body => {
+                                // The server hands back the next invitation
+                                // inline, so advancing costs no extra request.
+                                if (body && body.next) {
+                                    this.apply(body.next, true);
+                                    return;
+                                }
+                                this.open = false;
+                                if (this.standalone) window.location = '/';
+                            });
                         }
                         return r.json().then(body => {
                             // Laravel returns answers.<key> keys; strip the prefix

--- a/resources/views/partials/feedback-modal.blade.php
+++ b/resources/views/partials/feedback-modal.blade.php
@@ -1,0 +1,302 @@
+{{--
+    Proactive feedback interview prompt (issue #1998).
+
+    Shown to a signed-in user who has an actionable survey invitation — today
+    that means they marked "Attending" on an event that has since finished.
+
+    Deliberately self-contained Alpine rather than <x-ui.modal>: that component
+    emits an inline script with a hardcoded element id and stacks a fresh
+    document-level keydown listener on every render.
+
+    Two modes:
+      - default: fixed overlay, fetches its payload from feedback.prompt
+      - $standalone: renders inline on the standalone page with $payload
+        already supplied, so there's no round-trip
+
+    Optional variables:
+      $standalone (bool)  render inline instead of as an overlay
+      $payload    (array) pre-seeded payload; skips the fetch
+--}}
+@php
+    $isStandalone = $standalone ?? false;
+    $seededPayload = $payload ?? null;
+@endphp
+<style>[x-cloak]{display:none!important}</style>
+<div x-data="feedbackPrompt({{ \Illuminate\Support\Js::from($seededPayload) }}, {{ $isStandalone ? 'true' : 'false' }})"
+     x-init="init()" x-show="open" x-cloak
+     class="{{ $isStandalone ? '' : 'fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4' }}"
+     role="dialog" aria-modal="{{ $isStandalone ? 'false' : 'true' }}" aria-labelledby="feedback-title">
+    <div class="bg-secondary rounded-lg shadow-2xl {{ $isStandalone ? 'w-full' : 'max-w-2xl w-full max-h-[90vh]' }} flex flex-col border border-border ring-1 ring-black/5"
+         @click.stop>
+        <!-- Header -->
+        <div class="flex items-center justify-between p-4 border-b border-border">
+            <div class="min-w-0">
+                <h2 id="feedback-title" class="text-lg font-semibold text-foreground" x-text="campaign.name || 'How was it?'"></h2>
+                <template x-if="subject && subject.name">
+                    <p class="text-sm text-muted-foreground truncate">
+                        <span x-text="subject.name"></span>
+                        <template x-if="subject.date">
+                            <span> &middot; <span x-text="subject.date"></span></span>
+                        </template>
+                    </p>
+                </template>
+            </div>
+            @unless($isStandalone)
+                <button type="button" @click="dismiss()" title="Not now"
+                        class="p-1 rounded-md hover:bg-background text-muted-foreground hover:text-foreground transition-colors">
+                    <i class="bi bi-x-lg"></i>
+                </button>
+            @endunless
+        </div>
+
+        <!-- Body -->
+        <div class="flex-1 overflow-y-auto px-6 pb-6 pt-3 space-y-6">
+            <p class="text-sm text-muted-foreground" x-show="campaign.intro" x-text="campaign.intro"></p>
+
+            <template x-if="loading">
+                <div class="text-center text-muted-foreground py-8">
+                    <i class="bi bi-arrow-repeat animate-spin text-2xl"></i>
+                </div>
+            </template>
+
+            <template x-if="!loading">
+                <div class="space-y-6">
+                    <template x-for="question in questions" :key="question.key">
+                        <section>
+                            <h3 class="text-sm font-semibold text-foreground mb-2">
+                                <span x-text="question.prompt"></span>
+                                <span x-show="question.required" class="text-destructive" aria-hidden="true">*</span>
+                            </h3>
+                            <p x-show="question.help" class="text-xs text-muted-foreground mb-2" x-text="question.help"></p>
+
+                            <!-- Rating -->
+                            <template x-if="question.type === 'rating'">
+                                <div class="flex items-center gap-1">
+                                    <template x-for="n in ratingRange(question)" :key="'r-' + question.key + '-' + n">
+                                        <button type="button" @click="answers[question.key] = n"
+                                                :aria-label="n + ' out of ' + question.max"
+                                                :aria-pressed="answers[question.key] === n"
+                                                class="p-1 text-2xl leading-none transition-colors"
+                                                :class="answers[question.key] >= n ? 'text-yellow-400' : 'text-muted-foreground hover:text-foreground'">
+                                            <i class="bi" :class="answers[question.key] >= n ? 'bi-star-fill' : 'bi-star'"></i>
+                                        </button>
+                                    </template>
+                                </div>
+                            </template>
+
+                            <!-- Single choice -->
+                            <template x-if="question.type === 'single_choice'">
+                                <div class="flex flex-wrap gap-2">
+                                    <template x-for="option in question.options" :key="question.key + '-' + option.value">
+                                        <label class="cursor-pointer">
+                                            <input type="radio" :name="question.key" :value="option.value"
+                                                   x-model="answers[question.key]" class="sr-only peer">
+                                            <span class="inline-block px-3 py-1 rounded-full text-sm border border-border text-muted-foreground peer-checked:bg-primary peer-checked:text-primary-foreground peer-checked:border-primary transition-colors"
+                                                  x-text="option.label"></span>
+                                        </label>
+                                    </template>
+                                </div>
+                            </template>
+
+                            <!-- Multi choice -->
+                            <template x-if="question.type === 'multi_choice'">
+                                <div class="flex flex-wrap gap-2">
+                                    <template x-for="option in question.options" :key="question.key + '-' + option.value">
+                                        <label class="cursor-pointer">
+                                            <input type="checkbox" :value="option.value"
+                                                   x-model="answers[question.key]" class="sr-only peer">
+                                            <span class="inline-block px-3 py-1 rounded-full text-sm border border-border text-muted-foreground peer-checked:bg-primary peer-checked:text-primary-foreground peer-checked:border-primary transition-colors"
+                                                  x-text="option.label"></span>
+                                        </label>
+                                    </template>
+                                </div>
+                            </template>
+
+                            <!-- Free text -->
+                            <template x-if="question.type === 'text'">
+                                <textarea x-model="answers[question.key]" rows="3"
+                                          :maxlength="question.maxlength"
+                                          class="form-input-tw w-full"
+                                          placeholder="Optional"></textarea>
+                            </template>
+
+                            <p x-show="errors[question.key]" class="text-xs text-destructive mt-1" x-text="errors[question.key]"></p>
+                        </section>
+                    </template>
+
+                    <label class="flex items-start gap-3 pt-2 border-t border-border cursor-pointer">
+                        <input type="checkbox" x-model="isPublic" class="mt-1 rounded border-border">
+                        <span class="text-sm text-muted-foreground" x-text="visibilityPrompt"></span>
+                    </label>
+
+                    <p x-show="generalError" class="text-sm text-destructive" x-text="generalError"></p>
+                </div>
+            </template>
+        </div>
+
+        <!-- Footer -->
+        <div class="p-4 border-t border-border flex flex-wrap justify-between items-center gap-2">
+            <div class="flex items-center gap-2">
+                @unless($isStandalone)
+                    <button type="button" @click="snooze()" :disabled="saving"
+                            class="px-3 py-2 text-sm rounded-md text-muted-foreground hover:text-foreground hover:bg-background transition-colors">
+                        Later
+                    </button>
+                @endunless
+                <button type="button" @click="optOut()" :disabled="saving"
+                        class="px-3 py-2 text-xs rounded-md text-muted-foreground hover:text-foreground hover:bg-background transition-colors">
+                    Don't ask me again
+                </button>
+            </div>
+            <button type="button" @click="submit()" :disabled="saving || !canSubmit"
+                    class="px-4 py-2 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed">
+                <span x-show="!saving">Send feedback</span>
+                <span x-show="saving">Sending&hellip;</span>
+            </button>
+        </div>
+    </div>
+</div>
+
+<script>
+    function feedbackPrompt(seeded, standalone) {
+        return {
+            open: false,
+            loading: true,
+            saving: false,
+            standalone: standalone,
+            token: null,
+            campaign: {},
+            subject: null,
+            questions: [],
+            answers: {},
+            errors: {},
+            generalError: '',
+            isPublic: false,
+            visibilityPrompt: 'Share my feedback publicly',
+
+            csrf() {
+                return document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
+            },
+
+            ratingRange(question) {
+                const min = question.min || 1;
+                const max = question.max || 5;
+                return Array.from({ length: max - min + 1 }, (_, i) => min + i);
+            },
+
+            // Only the required questions gate the submit button; everything
+            // else is optional by design so the survey stays quick to finish.
+            get canSubmit() {
+                return this.questions
+                    .filter(q => q.required)
+                    .every(q => {
+                        const value = this.answers[q.key];
+                        return Array.isArray(value) ? value.length > 0 : (value !== undefined && value !== '');
+                    });
+            },
+
+            apply(data) {
+                if (!data || !data.invitation) {
+                    this.open = false;
+                    return;
+                }
+                this.token = data.invitation.token;
+                this.campaign = data.campaign || {};
+                this.subject = data.subject || null;
+                this.questions = data.questions || [];
+                this.visibilityPrompt = (data.visibility && data.visibility.prompt) || this.visibilityPrompt;
+                this.isPublic = !!(data.visibility && data.visibility.default);
+
+                // Multi-choice needs an array to x-model into; everything else
+                // stays undefined until the user touches it.
+                this.questions.forEach(q => {
+                    if (q.type === 'multi_choice') this.answers[q.key] = [];
+                });
+
+                this.open = true;
+            },
+
+            init() {
+                if (seeded) {
+                    this.apply(seeded);
+                    this.loading = false;
+                    // The payload came from the layout composer, so the
+                    // prompt endpoint never ran — record the view here.
+                    if (this.token) {
+                        this.post('/feedback/' + this.token + '/shown').catch(() => {});
+                    }
+                    return;
+                }
+
+                this.open = true;
+                fetch('{{ route('feedback.prompt') }}', { headers: { 'Accept': 'application/json' } })
+                    .then(r => r.ok ? r.json() : { invitation: null })
+                    .then(data => this.apply(data))
+                    .catch(() => { this.open = false; })
+                    .finally(() => { this.loading = false; });
+            },
+
+            post(url, body) {
+                return fetch(url, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Accept': 'application/json',
+                        'X-CSRF-TOKEN': this.csrf(),
+                    },
+                    body: body ? JSON.stringify(body) : null,
+                });
+            },
+
+            submit() {
+                if (this.saving || !this.token) return;
+                this.saving = true;
+                this.errors = {};
+                this.generalError = '';
+
+                this.post('/feedback/' + this.token, { answers: this.answers, public: this.isPublic })
+                    .then(r => {
+                        if (r.ok) {
+                            this.open = false;
+                            if (this.standalone) window.location = '/';
+                            return;
+                        }
+                        return r.json().then(body => {
+                            // Laravel returns answers.<key> keys; strip the prefix
+                            // so each message lands next to its question.
+                            const errors = (body && body.errors) || {};
+                            Object.keys(errors).forEach(field => {
+                                this.errors[field.replace(/^answers\./, '')] = errors[field][0];
+                            });
+                            if (!Object.keys(errors).length) {
+                                this.generalError = 'Something went wrong. Please try again.';
+                            }
+                        });
+                    })
+                    .catch(() => { this.generalError = 'Something went wrong. Please try again.'; })
+                    .finally(() => { this.saving = false; });
+            },
+
+            snooze() {
+                if (this.saving || !this.token) return;
+                this.saving = true;
+                this.post('/feedback/' + this.token + '/snooze')
+                    .finally(() => { this.open = false; this.saving = false; });
+            },
+
+            dismiss() {
+                if (this.saving || !this.token) { this.open = false; return; }
+                this.saving = true;
+                this.post('/feedback/' + this.token + '/dismiss')
+                    .finally(() => { this.open = false; this.saving = false; });
+            },
+
+            optOut() {
+                if (this.saving) return;
+                this.saving = true;
+                this.post('{{ route('feedback.optOut') }}')
+                    .finally(() => { this.open = false; this.saving = false; });
+            },
+        };
+    }
+</script>

--- a/resources/views/partials/feedback-modal.blade.php
+++ b/resources/views/partials/feedback-modal.blade.php
@@ -29,30 +29,57 @@
     <div class="bg-secondary rounded-lg shadow-2xl {{ $isStandalone ? 'w-full' : 'max-w-2xl w-full max-h-[90vh]' }} flex flex-col border border-border ring-1 ring-black/5"
          @click.stop>
         <!-- Header -->
-        <div class="flex items-center justify-between p-4 border-b border-border">
-            <div class="min-w-0">
-                <div class="flex items-center gap-2">
-                    <h2 id="feedback-title" class="text-lg font-semibold text-foreground" x-text="campaign.name || 'How was it?'"></h2>
+        <div class="p-4 border-b border-border">
+            <div class="flex items-start justify-between gap-3">
+                <div class="flex items-center gap-2 min-w-0">
+                    <h2 id="feedback-title" class="text-sm font-medium text-muted-foreground truncate"
+                        x-text="campaign.name || 'How was it?'"></h2>
                     {{-- Only worth showing when there's actually a queue. --}}
                     <span x-show="total > 1" x-cloak
                           class="shrink-0 px-2 py-0.5 rounded-full text-xs font-semibold bg-background text-muted-foreground tabular-nums"
                           x-text="index + ' of ' + total"></span>
                 </div>
-                <template x-if="subject && subject.name">
-                    <p class="text-sm text-muted-foreground truncate">
-                        <span x-text="subject.name"></span>
-                        <template x-if="subject.date">
-                            <span> &middot; <span x-text="subject.date"></span></span>
-                        </template>
-                    </p>
-                </template>
+                @unless($isStandalone)
+                    <button type="button" @click="dismiss()" title="Not now"
+                            class="shrink-0 p-1 -mt-1 rounded-md hover:bg-background text-muted-foreground hover:text-foreground transition-colors">
+                        <i class="bi bi-x-lg"></i>
+                    </button>
+                @endunless
             </div>
-            @unless($isStandalone)
-                <button type="button" @click="dismiss()" title="Not now"
-                        class="p-1 rounded-md hover:bg-background text-muted-foreground hover:text-foreground transition-colors">
-                    <i class="bi bi-x-lg"></i>
-                </button>
-            @endunless
+
+            {{-- The event being reviewed: flyer thumbnail, prominent name,
+                 date and venue. This is what jogs the memory, so it leads. --}}
+            <template x-if="subject && subject.name">
+                <div class="flex items-start gap-3 mt-3">
+                    <template x-if="subject.image">
+                        <a :href="subject.url" target="_blank" rel="noopener" class="shrink-0">
+                            <img :src="subject.image" :alt="subject.name"
+                                 width="72" height="72" loading="lazy"
+                                 class="w-[4.5rem] h-[4.5rem] rounded-md object-cover border border-border">
+                        </a>
+                    </template>
+
+                    <div class="min-w-0">
+                        <a :href="subject.url" target="_blank" rel="noopener"
+                           class="block text-xl font-bold text-foreground leading-tight hover:text-primary transition-colors"
+                           x-text="subject.name"></a>
+
+                        <p class="mt-1 text-sm text-muted-foreground">
+                            <template x-if="subject.date">
+                                <span x-text="subject.date"></span>
+                            </template>
+                            <template x-if="subject.date && subject.venue">
+                                <span> &middot; </span>
+                            </template>
+                            <template x-if="subject.venue">
+                                <a :href="subject.venue_url" target="_blank" rel="noopener"
+                                   class="hover:text-foreground transition-colors"
+                                   x-text="subject.venue"></a>
+                            </template>
+                        </p>
+                    </div>
+                </div>
+            </template>
         </div>
 
         <!-- Body -->

--- a/resources/views/partials/sidebar-tw.blade.php
+++ b/resources/views/partials/sidebar-tw.blade.php
@@ -149,6 +149,10 @@
             <i class="bi bi-grid-3x3-gap text-lg"></i>
             <span>All Modules</span>
         </a>
+        <a href="{{ route('feedback.admin.index') }}" class="nav-item-tw mt-1 {{ Request::is('feedback/responses*') || Request::is('feedback/summary') ? 'nav-item-active-tw' : '' }}">
+            <i class="bi bi-chat-square-quote text-lg"></i>
+            <span>Feedback</span>
+        </a>
         @endcan
         <form action="{{ route('logout') }}" method="POST" class="w-full">
             @csrf
@@ -317,6 +321,10 @@
         <a href="{{ route('pages.allModules') }}" class="nav-item-tw mt-1 {{ Request::is('all-modules') ? 'nav-item-active-tw' : '' }}">
             <i class="bi bi-grid-3x3-gap text-lg"></i>
             <span>All Modules</span>
+        </a>
+        <a href="{{ route('feedback.admin.index') }}" class="nav-item-tw mt-1 {{ Request::is('feedback/responses*') || Request::is('feedback/summary') ? 'nav-item-active-tw' : '' }}">
+            <i class="bi bi-chat-square-quote text-lg"></i>
+            <span>Feedback</span>
         </a>
         @endcan
         @endif

--- a/resources/views/users/form-tw.blade.php
+++ b/resources/views/users/form-tw.blade.php
@@ -283,6 +283,21 @@
                 @endif
             </div>
         </div>
+
+        <div class="flex items-start gap-3">
+            <x-ui.checkbox
+                name="setting_feedback_requests"
+                id="setting_feedback_requests"
+                value="1"
+                :checked="old('setting_feedback_requests', isset($user->profile) ? $user->profile->setting_feedback_requests : false)"
+                :hasError="$errors->has('setting_feedback_requests')" />
+            <div class="flex-1">
+                <x-ui.label for="setting_feedback_requests">Ask me for feedback about events I attend</x-ui.label>
+                @if($errors->has('setting_feedback_requests'))
+                    <span class="text-xs text-destructive">{{ $errors->first('setting_feedback_requests') }}</span>
+                @endif
+            </div>
+        </div>
     </div>
 </div>
 

--- a/resources/views/users/show-tw.blade.php
+++ b/resources/views/users/show-tw.blade.php
@@ -242,6 +242,10 @@
                                     <i class="bi {{ $user->profile->setting_notify_threads_by_follow ? 'bi-check-circle text-green-500' : 'bi-x-circle text-muted-foreground' }}"></i>
                                     <span class="text-muted-foreground">Notify Discussions by Follow</span>
                                 </div>
+                                <div class="flex items-center gap-2">
+                                    <i class="bi {{ $user->profile->setting_feedback_requests ? 'bi-check-circle text-green-500' : 'bi-x-circle text-muted-foreground' }}"></i>
+                                    <span class="text-muted-foreground">Receive Feedback Requests</span>
+                                </div>
                             @endif
                             <div class="flex items-center gap-2">
                                 <i class="bi {{ $user->profile->setting_public_profile ? 'bi-check-circle text-green-500' : 'bi-x-circle text-muted-foreground' }}"></i>

--- a/routes/web.php
+++ b/routes/web.php
@@ -73,6 +73,30 @@ Route::middleware('auth')->group(function () {
     Route::post('onboarding/dismiss', [\App\Http\Controllers\OnboardingController::class, 'dismiss'])->name('onboarding.dismiss');
 });
 
+// Admin reporting over collected feedback (issue #1998).
+// Registered before the feedback/{invitation} wildcard below.
+Route::get('feedback/responses', [\App\Http\Controllers\FeedbackAdminController::class, 'index'])
+    ->name('feedback.admin.index')->middleware(['auth', 'can:admin']);
+Route::get('feedback/responses/export', [\App\Http\Controllers\FeedbackAdminController::class, 'export'])
+    ->name('feedback.admin.export')->middleware(['auth', 'can:admin']);
+Route::get('feedback/summary', [\App\Http\Controllers\FeedbackAdminController::class, 'summary'])
+    ->name('feedback.admin.summary')->middleware(['auth', 'can:admin']);
+Route::get('feedback/responses/{surveyResponse}', [\App\Http\Controllers\FeedbackAdminController::class, 'show'])
+    ->name('feedback.admin.show')->middleware(['auth', 'can:admin']);
+
+// Proactive feedback interview (issue #1998).
+// Invitations bind by token, not id — the literal paths must be registered
+// before feedback/{invitation} so they aren't swallowed by the wildcard.
+Route::middleware('auth')->group(function () {
+    Route::get('feedback/prompt', [\App\Http\Controllers\FeedbackController::class, 'prompt'])->name('feedback.prompt');
+    Route::post('feedback/opt-out', [\App\Http\Controllers\FeedbackController::class, 'optOut'])->name('feedback.optOut');
+    Route::post('feedback/{invitation}/shown', [\App\Http\Controllers\FeedbackController::class, 'shown'])->name('feedback.shown');
+    Route::post('feedback/{invitation}/snooze', [\App\Http\Controllers\FeedbackController::class, 'snooze'])->name('feedback.snooze');
+    Route::post('feedback/{invitation}/dismiss', [\App\Http\Controllers\FeedbackController::class, 'dismiss'])->name('feedback.dismiss');
+    Route::post('feedback/{invitation}', [\App\Http\Controllers\FeedbackController::class, 'store'])->name('feedback.store');
+    Route::get('feedback/{invitation}', [\App\Http\Controllers\FeedbackController::class, 'show'])->name('feedback.show');
+});
+
 Route::get('help', [\App\Http\Controllers\PagesController::class, 'help']);
 Route::get('all-modules', [\App\Http\Controllers\PagesController::class, 'allModules'])->name('pages.allModules');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -83,6 +83,8 @@ Route::get('feedback/summary', [\App\Http\Controllers\FeedbackAdminController::c
     ->name('feedback.admin.summary')->middleware(['auth', 'can:admin']);
 Route::get('feedback/responses/{surveyResponse}', [\App\Http\Controllers\FeedbackAdminController::class, 'show'])
     ->name('feedback.admin.show')->middleware(['auth', 'can:admin']);
+Route::patch('feedback/responses/{surveyResponse}', [\App\Http\Controllers\FeedbackAdminController::class, 'update'])
+    ->name('feedback.admin.update')->middleware(['auth', 'can:admin']);
 
 // Proactive feedback interview (issue #1998).
 // Invitations bind by token, not id — the literal paths must be registered

--- a/tests/Feature/FeedbackAdminTest.php
+++ b/tests/Feature/FeedbackAdminTest.php
@@ -1,0 +1,355 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\SurveyAnswer;
+use App\Models\SurveyCampaign;
+use App\Models\SurveyInvitation;
+use App\Models\SurveyResponse;
+use App\Models\User;
+use App\Models\UserStatus;
+use App\Models\Visibility;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Admin reporting over collected feedback (issue #1998).
+ *
+ * Responses are private by default, so the gating tests here matter as much as
+ * the aggregation ones.
+ */
+class FeedbackAdminTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private function makeAdmin(): User
+    {
+        $admin = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $admin->assignGroup('admin');
+
+        return $admin->fresh();
+    }
+
+    private function makeUser(): User
+    {
+        return User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+    }
+
+    private function makeEvent(string $name = 'Summer Showcase'): Event
+    {
+        return Event::factory()->create([
+            'name' => $name,
+            'start_at' => now()->subDays(3),
+            'end_at' => now()->subDays(3)->addHours(3),
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+    }
+
+    /**
+     * A full response: rating, two multi-choice options, and a comment.
+     */
+    private function makeResponse(User $user, Event $event, int $rating = 4, array $overrides = []): SurveyResponse
+    {
+        $campaign = SurveyCampaign::bySlug(SurveyCampaign::POST_EVENT_ATTENDEE);
+
+        $response = SurveyResponse::factory()->create(array_merge([
+            'survey_campaign_id' => $campaign->id,
+            'user_id' => $user->id,
+            'subject_type' => 'event',
+            'subject_id' => $event->id,
+        ], $overrides));
+
+        SurveyAnswer::factory()->rating($rating)->create([
+            'survey_response_id' => $response->id,
+            'survey_question_id' => $campaign->questions->firstWhere('key', 'overall_rating')->id,
+        ]);
+
+        foreach (['lineup', 'sound'] as $option) {
+            SurveyAnswer::factory()->option($option)->create([
+                'survey_response_id' => $response->id,
+                'survey_question_id' => $campaign->questions->firstWhere('key', 'liked_most')->id,
+            ]);
+        }
+
+        SurveyAnswer::factory()->create([
+            'survey_response_id' => $response->id,
+            'survey_question_id' => $campaign->questions->firstWhere('key', 'comments')->id,
+            'value_text' => 'The opener was excellent.',
+        ]);
+
+        return $response;
+    }
+
+    // ------------------------------------------------------------------ access
+
+    /** @test */
+    public function admin_can_view_the_response_index(): void
+    {
+        $this->makeResponse($this->makeUser(), $this->makeEvent());
+
+        $this->actingAs($this->makeAdmin())
+            ->get(route('feedback.admin.index'))
+            ->assertOk()
+            ->assertSee('Feedback Responses')
+            ->assertSee('Summer Showcase');
+    }
+
+    /** @test */
+    public function a_non_admin_cannot_view_the_response_index(): void
+    {
+        $this->withExceptionHandling();
+
+        $this->actingAs($this->makeUser())
+            ->get(route('feedback.admin.index'))
+            ->assertForbidden();
+    }
+
+    /** @test */
+    public function a_guest_is_redirected_from_the_response_index(): void
+    {
+        $this->withExceptionHandling();
+
+        $this->get(route('feedback.admin.index'))->assertRedirect();
+    }
+
+    /** @test */
+    public function the_summary_and_export_are_admin_only(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = $this->makeUser();
+
+        $this->actingAs($user)->get(route('feedback.admin.summary'))->assertForbidden();
+        $this->actingAs($user)->get(route('feedback.admin.export'))->assertForbidden();
+    }
+
+    /** @test */
+    public function the_response_detail_page_is_admin_only(): void
+    {
+        $this->withExceptionHandling();
+
+        $response = $this->makeResponse($this->makeUser(), $this->makeEvent());
+
+        $this->actingAs($this->makeUser())
+            ->get(route('feedback.admin.show', $response->id))
+            ->assertForbidden();
+    }
+
+    // ----------------------------------------------------------------- filters
+
+    /** @test */
+    public function filtering_by_event_narrows_the_list(): void
+    {
+        $wanted = $this->makeEvent('Wanted Event');
+        $other = $this->makeEvent('Other Event');
+
+        $this->makeResponse($this->makeUser(), $wanted);
+        $this->makeResponse($this->makeUser(), $other);
+
+        $this->actingAs($this->makeAdmin())
+            ->get(route('feedback.admin.index', ['event' => 'Wanted']))
+            ->assertOk()
+            ->assertSee('Wanted Event')
+            ->assertDontSee('Other Event');
+    }
+
+    /** @test */
+    public function filtering_by_user_narrows_the_list(): void
+    {
+        $wanted = User::factory()->create(['name' => 'Wanted Person', 'user_status_id' => UserStatus::ACTIVE]);
+        $other = User::factory()->create(['name' => 'Someone Else', 'user_status_id' => UserStatus::ACTIVE]);
+
+        $this->makeResponse($wanted, $this->makeEvent('Event A'));
+        $this->makeResponse($other, $this->makeEvent('Event B'));
+
+        $this->actingAs($this->makeAdmin())
+            ->get(route('feedback.admin.index', ['user' => 'Wanted Person']))
+            ->assertOk()
+            ->assertSee('Wanted Person')
+            ->assertDontSee('Someone Else');
+    }
+
+    /** @test */
+    public function filtering_by_visibility_narrows_the_list(): void
+    {
+        $this->makeResponse($this->makeUser(), $this->makeEvent('Private Event'));
+        $this->makeResponse($this->makeUser(), $this->makeEvent('Shared Event'), 5, [
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+
+        $this->actingAs($this->makeAdmin())
+            ->get(route('feedback.admin.index', ['visibility' => Visibility::VISIBILITY_PUBLIC]))
+            ->assertOk()
+            ->assertSee('Shared Event')
+            ->assertDontSee('Private Event');
+    }
+
+    /** @test */
+    public function filtering_by_minimum_rating_narrows_the_list(): void
+    {
+        $this->makeResponse($this->makeUser(), $this->makeEvent('High Rated'), 5);
+        $this->makeResponse($this->makeUser(), $this->makeEvent('Low Rated'), 1);
+
+        $this->actingAs($this->makeAdmin())
+            ->get(route('feedback.admin.index', ['rating' => 4]))
+            ->assertOk()
+            ->assertSee('High Rated')
+            ->assertDontSee('Low Rated');
+    }
+
+    /** @test */
+    public function filtering_by_campaign_narrows_the_list(): void
+    {
+        $this->makeResponse($this->makeUser(), $this->makeEvent('Kept Event'));
+
+        $otherCampaign = SurveyCampaign::factory()->create(['slug' => 'some-other-campaign']);
+        SurveyResponse::factory()->create([
+            'survey_campaign_id' => $otherCampaign->id,
+            'subject_type' => 'event',
+            'subject_id' => $this->makeEvent('Dropped Event')->id,
+        ]);
+
+        $this->actingAs($this->makeAdmin())
+            ->get(route('feedback.admin.index', ['campaign' => SurveyCampaign::POST_EVENT_ATTENDEE]))
+            ->assertOk()
+            ->assertSee('Kept Event')
+            ->assertDontSee('Dropped Event');
+    }
+
+    // ------------------------------------------------------------------ detail
+
+    /** @test */
+    public function the_detail_page_shows_every_answer(): void
+    {
+        $response = $this->makeResponse($this->makeUser(), $this->makeEvent());
+
+        $this->actingAs($this->makeAdmin())
+            ->get(route('feedback.admin.show', $response->id))
+            ->assertOk()
+            ->assertSee('Overall, how was it?')
+            ->assertSee('The lineup / music')
+            ->assertSee('Sound &amp; production', false)
+            ->assertSee('The opener was excellent.')
+            ->assertSee('Private');
+    }
+
+    // ----------------------------------------------------------------- summary
+
+    /** @test */
+    public function the_summary_reports_averages_and_histograms(): void
+    {
+        $event = $this->makeEvent();
+
+        $this->makeResponse($this->makeUser(), $event, 5);
+        $this->makeResponse($this->makeUser(), $event, 3);
+
+        $view = $this->actingAs($this->makeAdmin())
+            ->get(route('feedback.admin.summary', ['campaign' => SurveyCampaign::POST_EVENT_ATTENDEE]))
+            ->assertOk();
+
+        // (5 + 3) / 2
+        $view->assertSee('4');
+        $view->assertSee('The lineup / music');
+        $view->assertSee('The opener was excellent.');
+    }
+
+    /** @test */
+    public function the_summary_reports_the_completion_rate(): void
+    {
+        $campaign = SurveyCampaign::bySlug(SurveyCampaign::POST_EVENT_ATTENDEE);
+        $event = $this->makeEvent();
+
+        // Four invitations, one of which produced a response → 25%.
+        SurveyInvitation::factory()->count(4)->create([
+            'survey_campaign_id' => $campaign->id,
+            'subject_type' => 'event',
+            'subject_id' => $event->id,
+        ]);
+
+        $this->makeResponse($this->makeUser(), $event);
+
+        $this->actingAs($this->makeAdmin())
+            ->get(route('feedback.admin.summary', ['campaign' => SurveyCampaign::POST_EVENT_ATTENDEE]))
+            ->assertOk()
+            ->assertSee('25%');
+    }
+
+    /** @test */
+    public function the_summary_can_be_scoped_to_one_event(): void
+    {
+        $wanted = $this->makeEvent('Scoped Event');
+        $other = $this->makeEvent('Unscoped Event');
+
+        $this->makeResponse($this->makeUser(), $wanted, 5);
+        $this->makeResponse($this->makeUser(), $other, 1);
+
+        $this->actingAs($this->makeAdmin())
+            ->get(route('feedback.admin.summary', [
+                'campaign' => SurveyCampaign::POST_EVENT_ATTENDEE,
+                'event' => $wanted->id,
+            ]))
+            ->assertOk()
+            ->assertSee('Scoped Event')
+            // Only the 5-star response is in scope.
+            ->assertSee('5');
+    }
+
+    /** @test */
+    public function the_summary_handles_an_unknown_campaign(): void
+    {
+        $this->actingAs($this->makeAdmin())
+            ->get(route('feedback.admin.summary', ['campaign' => 'does-not-exist']))
+            ->assertOk()
+            ->assertSee('could not be found');
+    }
+
+    // ------------------------------------------------------------------ export
+
+    /** @test */
+    public function the_export_returns_csv_with_a_row_per_response(): void
+    {
+        $this->makeResponse($this->makeUser(), $this->makeEvent('Exported Event'), 4);
+
+        $response = $this->actingAs($this->makeAdmin())->get(route('feedback.admin.export'));
+
+        $response->assertOk();
+        $this->assertStringContainsString('text/csv', $response->headers->get('Content-Type'));
+
+        $csv = $response->streamedContent();
+        $lines = array_values(array_filter(explode("\n", trim($csv))));
+
+        $this->assertStringContainsString('Response ID', $lines[0]);
+        $this->assertStringContainsString('overall_rating', $lines[0]);
+        $this->assertCount(2, $lines, 'Expected a header row and one data row.');
+        $this->assertStringContainsString('Exported Event', $lines[1]);
+    }
+
+    /** @test */
+    public function the_export_pipe_joins_multi_choice_values(): void
+    {
+        $this->makeResponse($this->makeUser(), $this->makeEvent(), 4);
+
+        $csv = $this->actingAs($this->makeAdmin())
+            ->get(route('feedback.admin.export'))
+            ->streamedContent();
+
+        $this->assertStringContainsString('The lineup / music|Sound & production', $csv);
+    }
+
+    /** @test */
+    public function the_export_respects_filters(): void
+    {
+        $this->makeResponse($this->makeUser(), $this->makeEvent('Kept Event'), 5);
+        $this->makeResponse($this->makeUser(), $this->makeEvent('Dropped Event'), 1);
+
+        $csv = $this->actingAs($this->makeAdmin())
+            ->get(route('feedback.admin.export', ['rating' => 4]))
+            ->streamedContent();
+
+        $this->assertStringContainsString('Kept Event', $csv);
+        $this->assertStringNotContainsString('Dropped Event', $csv);
+    }
+}

--- a/tests/Feature/FeedbackAdminTest.php
+++ b/tests/Feature/FeedbackAdminTest.php
@@ -352,4 +352,179 @@ class FeedbackAdminTest extends TestCase
         $this->assertStringContainsString('Kept Event', $csv);
         $this->assertStringNotContainsString('Dropped Event', $csv);
     }
+
+    /** @test */
+    public function a_new_response_starts_pending_and_is_not_displayable(): void
+    {
+        $response = $this->makeResponse($this->makeUser(), $this->makeEvent());
+
+        $this->assertSame(SurveyResponse::DISPLAY_PENDING, $response->display_status);
+        $this->assertFalse($response->isDisplayable());
+        $this->assertSame(0, SurveyResponse::displayable()->count());
+    }
+
+    /** @test */
+    public function admin_can_approve_a_response_for_display(): void
+    {
+        $admin = $this->makeAdmin();
+        $response = $this->makeResponse($this->makeUser(), $this->makeEvent(), 5, [
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+
+        $this->actingAs($admin)
+            ->patch(route('feedback.admin.update', $response->id), [
+                'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+                'display_status' => SurveyResponse::DISPLAY_APPROVED,
+            ])
+            ->assertRedirect(route('feedback.admin.show', $response->id));
+
+        $response->refresh();
+
+        $this->assertTrue($response->isApproved());
+        $this->assertTrue($response->isDisplayable());
+        $this->assertSame($admin->id, $response->approved_by);
+        $this->assertNotNull($response->approved_at);
+        $this->assertSame(1, SurveyResponse::displayable()->count());
+    }
+
+    /** @test */
+    public function admin_can_flip_a_response_between_private_and_public(): void
+    {
+        $admin = $this->makeAdmin();
+        $response = $this->makeResponse($this->makeUser(), $this->makeEvent());
+
+        $this->assertFalse($response->isPublic());
+
+        $this->actingAs($admin)
+            ->patch(route('feedback.admin.update', $response->id), [
+                'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+                'display_status' => SurveyResponse::DISPLAY_PENDING,
+            ])->assertRedirect();
+
+        $this->assertTrue($response->fresh()->isPublic());
+
+        $this->actingAs($admin)
+            ->patch(route('feedback.admin.update', $response->id), [
+                'visibility_id' => Visibility::VISIBILITY_PRIVATE,
+                'display_status' => SurveyResponse::DISPLAY_PENDING,
+            ])->assertRedirect();
+
+        $this->assertFalse($response->fresh()->isPublic());
+    }
+
+    /** @test */
+    public function approval_alone_does_not_make_a_private_response_displayable(): void
+    {
+        $response = $this->makeResponse($this->makeUser(), $this->makeEvent());
+
+        $this->actingAs($this->makeAdmin())
+            ->patch(route('feedback.admin.update', $response->id), [
+                'visibility_id' => Visibility::VISIBILITY_PRIVATE,
+                'display_status' => SurveyResponse::DISPLAY_APPROVED,
+            ])->assertRedirect();
+
+        $response->refresh();
+
+        $this->assertTrue($response->isApproved());
+        $this->assertFalse($response->isDisplayable());
+        $this->assertTrue($response->isApprovedButNotShared());
+        $this->assertSame(0, SurveyResponse::displayable()->count());
+    }
+
+    /** @test */
+    public function a_public_response_is_not_displayable_until_approved(): void
+    {
+        SurveyResponse::factory()->shared()->create();
+
+        $this->assertSame(1, SurveyResponse::public()->count());
+        $this->assertSame(0, SurveyResponse::displayable()->count());
+    }
+
+    /** @test */
+    public function rejecting_a_response_clears_the_approval_audit_trail(): void
+    {
+        $admin = $this->makeAdmin();
+        $response = SurveyResponse::factory()->shared()->approved()->create();
+
+        $this->assertNotNull($response->approved_at);
+
+        $this->actingAs($admin)
+            ->patch(route('feedback.admin.update', $response->id), [
+                'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+                'display_status' => SurveyResponse::DISPLAY_REJECTED,
+            ])->assertRedirect();
+
+        $response->refresh();
+
+        $this->assertTrue($response->isRejected());
+        $this->assertFalse($response->isDisplayable());
+        $this->assertNull($response->approved_at);
+        $this->assertNull($response->approved_by);
+    }
+
+    /** @test */
+    public function an_invalid_display_status_is_rejected(): void
+    {
+        $this->withExceptionHandling();
+
+        $response = $this->makeResponse($this->makeUser(), $this->makeEvent());
+
+        $this->actingAs($this->makeAdmin())
+            ->patch(route('feedback.admin.update', $response->id), [
+                'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+                'display_status' => 'published',
+            ])
+            ->assertSessionHasErrors('display_status');
+
+        $this->assertSame(SurveyResponse::DISPLAY_PENDING, $response->fresh()->display_status);
+    }
+
+    /** @test */
+    public function moderating_a_response_is_admin_only(): void
+    {
+        $this->withExceptionHandling();
+
+        $response = $this->makeResponse($this->makeUser(), $this->makeEvent());
+
+        $payload = [
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'display_status' => SurveyResponse::DISPLAY_APPROVED,
+        ];
+
+        $this->actingAs($this->makeUser())
+            ->patch(route('feedback.admin.update', $response->id), $payload)
+            ->assertForbidden();
+
+        $this->assertSame(SurveyResponse::DISPLAY_PENDING, $response->fresh()->display_status);
+    }
+
+    /** @test */
+    public function a_guest_cannot_moderate_a_response(): void
+    {
+        $this->withExceptionHandling();
+
+        $response = $this->makeResponse($this->makeUser(), $this->makeEvent());
+
+        $this->patch(route('feedback.admin.update', $response->id), [
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'display_status' => SurveyResponse::DISPLAY_APPROVED,
+        ])->assertRedirect(route('login'));
+
+        $this->assertSame(SurveyResponse::DISPLAY_PENDING, $response->fresh()->display_status);
+    }
+
+    /** @test */
+    public function filtering_by_display_status_narrows_the_list(): void
+    {
+        $this->makeResponse($this->makeUser(), $this->makeEvent('Pending Event'));
+        $this->makeResponse($this->makeUser(), $this->makeEvent('Approved Event'), 5, [
+            'display_status' => SurveyResponse::DISPLAY_APPROVED,
+        ]);
+
+        $this->actingAs($this->makeAdmin())
+            ->get(route('feedback.admin.index', ['display_status' => SurveyResponse::DISPLAY_APPROVED]))
+            ->assertOk()
+            ->assertSee('Approved Event')
+            ->assertDontSee('Pending Event');
+    }
 }

--- a/tests/Feature/FeedbackInvitationGenerationTest.php
+++ b/tests/Feature/FeedbackInvitationGenerationTest.php
@@ -309,13 +309,13 @@ class FeedbackInvitationGenerationTest extends TestCase
     }
 
     /** @test */
-    public function it_does_not_skip_candidates_across_chunk_boundaries(): void
+    public function it_does_not_silently_drop_candidates_while_inserting(): void
     {
         // The candidate query filters on `survey_invitations.id is null` and the
-        // run inserts exactly those rows, so OFFSET-based chunking would skip
-        // roughly a full page per boundary. Keyset chunking must not.
+        // run inserts exactly those rows, so any OFFSET-based paging would walk
+        // off a shrinking result set and skip candidates. Iteration must be
+        // stable under its own writes.
         config([
-            'feedback.generation_chunk_size' => 2,
             'feedback.max_pending_per_user' => 0,
             'feedback.min_days_between_prompts' => 0,
         ]);
@@ -384,18 +384,18 @@ class FeedbackInvitationGenerationTest extends TestCase
     }
 
     /** @test */
-    public function it_respects_the_min_days_between_prompts_cap(): void
+    public function dismissing_a_prompt_starts_a_cooldown(): void
     {
         config(['feedback.max_pending_per_user' => 0, 'feedback.min_days_between_prompts' => 7]);
 
         $user = $this->makeAttendee();
         $campaign = SurveyCampaign::bySlug(SurveyCampaign::POST_EVENT_ATTENDEE);
 
-        // Answered something two days ago — too soon to ask again.
-        SurveyInvitation::factory()->completed()->create([
+        // Dismissed two days ago — they told us to back off, so we do.
+        SurveyInvitation::factory()->dismissed()->create([
             'survey_campaign_id' => $campaign->id,
             'user_id' => $user->id,
-            'completed_at' => now()->subDays(2),
+            'dismissed_at' => now()->subDays(2),
         ]);
 
         $event = $this->makeEvent(now()->subDays(2)->toDateTimeString(), now()->subDays(2)->addHours(3)->toDateTimeString());
@@ -404,6 +404,90 @@ class FeedbackInvitationGenerationTest extends TestCase
         $this->artisan('feedback:generate')->assertSuccessful();
 
         $this->assertSame(1, SurveyInvitation::where('user_id', $user->id)->count());
+    }
+
+    /** @test */
+    public function completing_a_prompt_does_not_start_a_cooldown(): void
+    {
+        // Someone who just answered is engaged. Making them wait a week is how
+        // their other events used to age out of the lookback window unasked.
+        config(['feedback.max_pending_per_user' => 0, 'feedback.min_days_between_prompts' => 7]);
+
+        $user = $this->makeAttendee();
+        $campaign = SurveyCampaign::bySlug(SurveyCampaign::POST_EVENT_ATTENDEE);
+
+        SurveyInvitation::factory()->completed()->create([
+            'survey_campaign_id' => $campaign->id,
+            'user_id' => $user->id,
+            'completed_at' => now()->subMinutes(5),
+        ]);
+
+        $event = $this->makeEvent(now()->subDays(2)->toDateTimeString(), now()->subDays(2)->addHours(3)->toDateTimeString());
+        $this->attend($user, $event);
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $this->assertSame(2, SurveyInvitation::where('user_id', $user->id)->count());
+    }
+
+    /** @test */
+    public function the_freshest_event_is_queued_first(): void
+    {
+        config(['feedback.max_pending_per_user' => 1]);
+
+        $user = $this->makeAttendee();
+
+        // Attended in a deliberately unhelpful RSVP order: the oldest event was
+        // RSVP'd to first, so ordering by event_responses.id would pick it.
+        $oldest = $this->makeEvent(now()->subDays(9)->toDateTimeString(), now()->subDays(9)->addHours(3)->toDateTimeString());
+        $newest = $this->makeEvent(now()->subDays(2)->toDateTimeString(), now()->subDays(2)->addHours(3)->toDateTimeString());
+        $middle = $this->makeEvent(now()->subDays(5)->toDateTimeString(), now()->subDays(5)->addHours(3)->toDateTimeString());
+
+        $this->attend($user, $oldest);
+        $this->attend($user, $newest);
+        $this->attend($user, $middle);
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $invitation = SurveyInvitation::where('user_id', $user->id)->first();
+
+        $this->assertSame($newest->id, $invitation->subject_id, 'Ask while the memory is sharp.');
+    }
+
+    /** @test */
+    public function a_busy_week_of_events_all_get_asked_about(): void
+    {
+        // The regression this whole change exists for: with a queue depth of 1
+        // and a cooldown on completion, the third event aged out of the
+        // 14-day lookback window before the user was ever asked.
+        $user = $this->makeAttendee();
+
+        $events = [];
+        foreach ([2, 5, 9] as $daysAgo) {
+            $event = $this->makeEvent(
+                now()->subDays($daysAgo)->toDateTimeString(),
+                now()->subDays($daysAgo)->addHours(3)->toDateTimeString()
+            );
+            $this->attend($user, $event);
+            $events[] = $event;
+        }
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $invitations = SurveyInvitation::where('user_id', $user->id)->orderBy('id')->get();
+
+        $this->assertCount(3, $invitations, 'All three events should be queued while still in the window.');
+        $this->assertSame(
+            [$events[0]->id, $events[1]->id, $events[2]->id],
+            $invitations->pluck('subject_id')->all(),
+            'Queued freshest first.'
+        );
+
+        // Every one of them outlives the lookback window, because expiry is
+        // driven by expires_at (30 days), not by the creation window.
+        foreach ($invitations as $invitation) {
+            $this->assertTrue($invitation->expires_at->isAfter(now()->addDays(14)));
+        }
     }
 
     /** @test */

--- a/tests/Feature/FeedbackInvitationGenerationTest.php
+++ b/tests/Feature/FeedbackInvitationGenerationTest.php
@@ -1,0 +1,511 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\EventResponse;
+use App\Models\EventStatus;
+use App\Models\ResponseType;
+use App\Models\SurveyCampaign;
+use App\Models\SurveyInvitation;
+use App\Models\User;
+use App\Models\UserStatus;
+use App\Models\Visibility;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Covers `feedback:generate` — who gets asked for post-event feedback, and
+ * just as importantly who does not (issue #1998).
+ */
+class FeedbackInvitationGenerationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['feedback.enabled' => true]);
+    }
+
+    /**
+     * An active, verified user who is opted in to feedback requests.
+     */
+    private function makeAttendee(array $profileOverrides = []): User
+    {
+        $user = User::factory()->create([
+            'user_status_id' => UserStatus::ACTIVE,
+            'email_verified_at' => now(),
+        ]);
+
+        $user->profile()->create(array_merge([
+            'setting_feedback_requests' => 1,
+        ], $profileOverrides));
+
+        return $user->fresh();
+    }
+
+    /**
+     * EventFactory randomizes visibility_id and pins start_at to now(), so every
+     * event used here has to set its own window and visibility explicitly.
+     */
+    private function makeEvent(string $start, string $end = null, array $overrides = []): Event
+    {
+        return Event::factory()->create(array_merge([
+            'start_at' => $start,
+            'end_at' => $end,
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'event_status_id' => EventStatus::APPROVED,
+        ], $overrides));
+    }
+
+    private function attend(User $user, Event $event): EventResponse
+    {
+        return EventResponse::create([
+            'event_id' => $event->id,
+            'user_id' => $user->id,
+            'response_type_id' => ResponseType::ATTENDING,
+        ]);
+    }
+
+    /** @test */
+    public function it_creates_an_invitation_for_an_attendee_of_a_recently_finished_event(): void
+    {
+        $user = $this->makeAttendee();
+        $event = $this->makeEvent(now()->subDays(2)->toDateTimeString(), now()->subDays(2)->addHours(3)->toDateTimeString());
+        $this->attend($user, $event);
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $invitation = SurveyInvitation::where('user_id', $user->id)->first();
+
+        $this->assertNotNull($invitation);
+        $this->assertSame(SurveyInvitation::STATUS_PENDING, $invitation->status);
+        $this->assertSame('event', $invitation->subject_type);
+        $this->assertSame($event->id, $invitation->subject_id);
+        $this->assertNotNull($invitation->expires_at);
+        $this->assertNotEmpty($invitation->token);
+        $this->assertSame(
+            SurveyCampaign::bySlug(SurveyCampaign::POST_EVENT_ATTENDEE)->id,
+            $invitation->survey_campaign_id
+        );
+    }
+
+    /** @test */
+    public function it_resolves_the_event_subject_through_the_morph_map(): void
+    {
+        $user = $this->makeAttendee();
+        $event = $this->makeEvent(now()->subDays(2)->toDateTimeString(), now()->subDays(2)->addHours(3)->toDateTimeString());
+        $this->attend($user, $event);
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $invitation = SurveyInvitation::where('user_id', $user->id)->first();
+
+        $this->assertTrue($invitation->hasSubject());
+        $this->assertInstanceOf(Event::class, $invitation->subject);
+        $this->assertSame($event->id, $invitation->subject->id);
+    }
+
+    /** @test */
+    public function it_waits_for_the_configured_delay_after_the_event_ends(): void
+    {
+        $user = $this->makeAttendee();
+        // Ended 3 hours ago; delay_hours is 12.
+        $event = $this->makeEvent(now()->subHours(6)->toDateTimeString(), now()->subHours(3)->toDateTimeString());
+        $this->attend($user, $event);
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $this->assertSame(0, SurveyInvitation::count());
+    }
+
+    /** @test */
+    public function it_ignores_events_older_than_the_lookback_window(): void
+    {
+        $user = $this->makeAttendee();
+        $event = $this->makeEvent(now()->subDays(40)->toDateTimeString(), now()->subDays(40)->addHours(3)->toDateTimeString());
+        $this->attend($user, $event);
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $this->assertSame(0, SurveyInvitation::count());
+    }
+
+    /** @test */
+    public function it_ignores_future_events(): void
+    {
+        $user = $this->makeAttendee();
+        $event = $this->makeEvent(now()->addDays(5)->toDateTimeString(), now()->addDays(5)->addHours(3)->toDateTimeString());
+        $this->attend($user, $event);
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $this->assertSame(0, SurveyInvitation::count());
+    }
+
+    /** @test */
+    public function it_falls_back_to_start_at_when_end_at_is_null(): void
+    {
+        $user = $this->makeAttendee();
+        $event = $this->makeEvent(now()->subDays(2)->toDateTimeString(), null);
+        $this->attend($user, $event);
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $this->assertSame(1, SurveyInvitation::count());
+    }
+
+    /** @test */
+    public function it_ignores_non_attending_responses(): void
+    {
+        $user = $this->makeAttendee();
+        $event = $this->makeEvent(now()->subDays(2)->toDateTimeString(), now()->subDays(2)->addHours(3)->toDateTimeString());
+
+        EventResponse::create([
+            'event_id' => $event->id,
+            'user_id' => $user->id,
+            'response_type_id' => ResponseType::INTERESTED,
+        ]);
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $this->assertSame(0, SurveyInvitation::count());
+    }
+
+    /** @test */
+    public function it_ignores_cancelled_events(): void
+    {
+        $user = $this->makeAttendee();
+        $event = $this->makeEvent(
+            now()->subDays(2)->toDateTimeString(),
+            now()->subDays(2)->addHours(3)->toDateTimeString(),
+            ['event_status_id' => EventStatus::CANCELLED]
+        );
+        $this->attend($user, $event);
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $this->assertSame(0, SurveyInvitation::count());
+    }
+
+    /** @test */
+    public function it_ignores_events_with_cancelled_visibility(): void
+    {
+        $user = $this->makeAttendee();
+        $event = $this->makeEvent(
+            now()->subDays(2)->toDateTimeString(),
+            now()->subDays(2)->addHours(3)->toDateTimeString(),
+            ['visibility_id' => Visibility::VISIBILITY_CANCELLED]
+        );
+        $this->attend($user, $event);
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $this->assertSame(0, SurveyInvitation::count());
+    }
+
+    /** @test */
+    public function running_twice_creates_exactly_one_invitation(): void
+    {
+        $user = $this->makeAttendee();
+        $event = $this->makeEvent(now()->subDays(2)->toDateTimeString(), now()->subDays(2)->addHours(3)->toDateTimeString());
+        $this->attend($user, $event);
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $this->assertSame(1, SurveyInvitation::count());
+    }
+
+    /** @test */
+    public function it_skips_users_who_opted_out(): void
+    {
+        $user = $this->makeAttendee(['setting_feedback_requests' => 0]);
+        $event = $this->makeEvent(now()->subDays(2)->toDateTimeString(), now()->subDays(2)->addHours(3)->toDateTimeString());
+        $this->attend($user, $event);
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $this->assertSame(0, SurveyInvitation::count());
+    }
+
+    /** @test */
+    public function it_skips_users_with_no_profile_row(): void
+    {
+        // Legacy users without a profile row are excluded by design — the whole
+        // app treats a missing profile as "not opted in".
+        $user = User::factory()->create([
+            'user_status_id' => UserStatus::ACTIVE,
+            'email_verified_at' => now(),
+        ]);
+        $user->profile()->delete();
+
+        $event = $this->makeEvent(now()->subDays(2)->toDateTimeString(), now()->subDays(2)->addHours(3)->toDateTimeString());
+        $this->attend($user, $event);
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $this->assertSame(0, SurveyInvitation::count());
+    }
+
+    /** @test */
+    public function it_skips_users_who_cannot_log_in(): void
+    {
+        $user = $this->makeAttendee();
+        $user->update(['user_status_id' => UserStatus::SUSPENDED]);
+
+        $event = $this->makeEvent(now()->subDays(2)->toDateTimeString(), now()->subDays(2)->addHours(3)->toDateTimeString());
+        $this->attend($user, $event);
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $this->assertSame(0, SurveyInvitation::count());
+    }
+
+    /** @test */
+    public function it_skips_users_with_unverified_email(): void
+    {
+        $user = $this->makeAttendee();
+        $user->forceFill(['email_verified_at' => null])->save();
+
+        $event = $this->makeEvent(now()->subDays(2)->toDateTimeString(), now()->subDays(2)->addHours(3)->toDateTimeString());
+        $this->attend($user, $event);
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $this->assertSame(0, SurveyInvitation::count());
+    }
+
+    /** @test */
+    public function it_does_nothing_when_the_feature_flag_is_off(): void
+    {
+        config(['feedback.enabled' => false]);
+
+        $user = $this->makeAttendee();
+        $event = $this->makeEvent(now()->subDays(2)->toDateTimeString(), now()->subDays(2)->addHours(3)->toDateTimeString());
+        $this->attend($user, $event);
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $this->assertSame(0, SurveyInvitation::count());
+    }
+
+    /** @test */
+    public function dry_run_reports_candidates_without_writing(): void
+    {
+        $user = $this->makeAttendee();
+        $event = $this->makeEvent(now()->subDays(2)->toDateTimeString(), now()->subDays(2)->addHours(3)->toDateTimeString());
+        $this->attend($user, $event);
+
+        $this->artisan('feedback:generate --dry-run')
+            ->expectsOutputToContain('1 invitation(s) would be created')
+            ->assertSuccessful();
+
+        $this->assertSame(0, SurveyInvitation::count());
+    }
+
+    /** @test */
+    public function it_does_not_skip_candidates_across_chunk_boundaries(): void
+    {
+        // The candidate query filters on `survey_invitations.id is null` and the
+        // run inserts exactly those rows, so OFFSET-based chunking would skip
+        // roughly a full page per boundary. Keyset chunking must not.
+        config([
+            'feedback.generation_chunk_size' => 2,
+            'feedback.max_pending_per_user' => 0,
+            'feedback.min_days_between_prompts' => 0,
+        ]);
+
+        $event = $this->makeEvent(
+            now()->subDays(2)->toDateTimeString(),
+            now()->subDays(2)->addHours(3)->toDateTimeString()
+        );
+
+        foreach (range(1, 7) as $i) {
+            $this->attend($this->makeAttendee(), $event);
+        }
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $this->assertSame(7, SurveyInvitation::count(), 'Every candidate should get an invitation.');
+    }
+
+    /** @test */
+    public function dry_run_predicts_the_same_count_the_real_run_creates(): void
+    {
+        // The point of --dry-run is to predict the real run. Because a dry run
+        // writes nothing, the per-user volume caps have to be tracked in memory
+        // or it reports every candidate as creatable.
+        config(['feedback.max_pending_per_user' => 1]);
+
+        $user = $this->makeAttendee();
+
+        foreach (range(1, 4) as $offset) {
+            $event = $this->makeEvent(
+                now()->subDays(1 + $offset)->toDateTimeString(),
+                now()->subDays(1 + $offset)->addHours(3)->toDateTimeString()
+            );
+            $this->attend($user, $event);
+        }
+
+        $this->artisan('feedback:generate --dry-run')
+            ->expectsOutputToContain('1 invitation(s) would be created')
+            ->assertSuccessful();
+
+        $this->assertSame(0, SurveyInvitation::count());
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $this->assertSame(1, SurveyInvitation::count());
+    }
+
+    /** @test */
+    public function it_respects_the_max_pending_per_user_cap(): void
+    {
+        config(['feedback.max_pending_per_user' => 1]);
+
+        $user = $this->makeAttendee();
+
+        foreach (range(1, 3) as $offset) {
+            $event = $this->makeEvent(
+                now()->subDays(1 + $offset)->toDateTimeString(),
+                now()->subDays(1 + $offset)->addHours(3)->toDateTimeString()
+            );
+            $this->attend($user, $event);
+        }
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $this->assertSame(1, SurveyInvitation::where('user_id', $user->id)->count());
+    }
+
+    /** @test */
+    public function it_respects_the_min_days_between_prompts_cap(): void
+    {
+        config(['feedback.max_pending_per_user' => 0, 'feedback.min_days_between_prompts' => 7]);
+
+        $user = $this->makeAttendee();
+        $campaign = SurveyCampaign::bySlug(SurveyCampaign::POST_EVENT_ATTENDEE);
+
+        // Answered something two days ago — too soon to ask again.
+        SurveyInvitation::factory()->completed()->create([
+            'survey_campaign_id' => $campaign->id,
+            'user_id' => $user->id,
+            'completed_at' => now()->subDays(2),
+        ]);
+
+        $event = $this->makeEvent(now()->subDays(2)->toDateTimeString(), now()->subDays(2)->addHours(3)->toDateTimeString());
+        $this->attend($user, $event);
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $this->assertSame(1, SurveyInvitation::where('user_id', $user->id)->count());
+    }
+
+    /** @test */
+    public function the_limit_option_caps_how_many_are_created(): void
+    {
+        config(['feedback.max_pending_per_user' => 0, 'feedback.min_days_between_prompts' => 0]);
+
+        $event = $this->makeEvent(now()->subDays(2)->toDateTimeString(), now()->subDays(2)->addHours(3)->toDateTimeString());
+
+        foreach (range(1, 3) as $i) {
+            $this->attend($this->makeAttendee(), $event);
+        }
+
+        $this->artisan('feedback:generate --limit=2')->assertSuccessful();
+
+        $this->assertSame(2, SurveyInvitation::count());
+    }
+
+    /** @test */
+    public function single_event_mode_only_considers_that_event(): void
+    {
+        config(['feedback.max_pending_per_user' => 0, 'feedback.min_days_between_prompts' => 0]);
+
+        $user = $this->makeAttendee();
+
+        $wanted = $this->makeEvent(now()->subDays(2)->toDateTimeString(), now()->subDays(2)->addHours(3)->toDateTimeString());
+        $other = $this->makeEvent(now()->subDays(3)->toDateTimeString(), now()->subDays(3)->addHours(3)->toDateTimeString());
+
+        $this->attend($user, $wanted);
+        $this->attend($user, $other);
+
+        $this->artisan('feedback:generate --single-event='.$wanted->slug)->assertSuccessful();
+
+        $this->assertSame(1, SurveyInvitation::count());
+        $this->assertSame($wanted->id, SurveyInvitation::first()->subject_id);
+    }
+
+    /** @test */
+    public function the_expiry_sweep_marks_overdue_invitations_expired(): void
+    {
+        $invitation = SurveyInvitation::factory()->create([
+            'status' => SurveyInvitation::STATUS_PENDING,
+            'expires_at' => now()->subDay(),
+        ]);
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $this->assertSame(SurveyInvitation::STATUS_EXPIRED, $invitation->fresh()->status);
+    }
+
+    /** @test */
+    public function the_expiry_sweep_leaves_current_invitations_alone(): void
+    {
+        $invitation = SurveyInvitation::factory()->create([
+            'status' => SurveyInvitation::STATUS_PENDING,
+            'expires_at' => now()->addDays(5),
+        ]);
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $this->assertSame(SurveyInvitation::STATUS_PENDING, $invitation->fresh()->status);
+    }
+
+    /** @test */
+    public function it_removes_invitations_whose_event_was_deleted(): void
+    {
+        // Nothing soft-deletes in this app and there's no FK on the polymorphic
+        // subject columns, so hard-deleted events leave invitations dangling.
+        $invitation = SurveyInvitation::factory()->create(['subject_type' => 'event']);
+
+        Event::where('id', $invitation->subject_id)->delete();
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $this->assertDatabaseMissing('survey_invitations', ['id' => $invitation->id]);
+    }
+
+    /** @test */
+    public function campaign_filter_can_skip_the_post_event_campaign(): void
+    {
+        $user = $this->makeAttendee();
+        $event = $this->makeEvent(now()->subDays(2)->toDateTimeString(), now()->subDays(2)->addHours(3)->toDateTimeString());
+        $this->attend($user, $event);
+
+        $this->artisan('feedback:generate --campaign=some-other-campaign')->assertSuccessful();
+
+        $this->assertSame(0, SurveyInvitation::count());
+    }
+
+    /** @test */
+    public function an_inactive_campaign_generates_nothing(): void
+    {
+        $campaign = SurveyCampaign::where('slug', SurveyCampaign::POST_EVENT_ATTENDEE)->first();
+        $campaign->update(['is_active' => false]);
+        SurveyCampaign::forgetCached(SurveyCampaign::POST_EVENT_ATTENDEE);
+
+        $user = $this->makeAttendee();
+        $event = $this->makeEvent(now()->subDays(2)->toDateTimeString(), now()->subDays(2)->addHours(3)->toDateTimeString());
+        $this->attend($user, $event);
+
+        $this->artisan('feedback:generate')->assertSuccessful();
+
+        $this->assertSame(0, SurveyInvitation::count());
+    }
+}

--- a/tests/Feature/FeedbackPromptTest.php
+++ b/tests/Feature/FeedbackPromptTest.php
@@ -338,6 +338,111 @@ class FeedbackPromptTest extends TestCase
         $this->assertSame(1, SurveyResponse::public()->count());
     }
 
+    // ---------------------------------------------------------------- queue
+
+    /** @test */
+    public function the_payload_reports_how_many_invitations_are_queued(): void
+    {
+        $user = $this->makeUser();
+        $this->makeInvitation($user);
+        $this->makeInvitation($user);
+        $this->makeInvitation($user);
+
+        $this->actingAs($user)->getJson(route('feedback.prompt'))
+            ->assertOk()
+            ->assertJsonPath('queue.remaining', 3);
+    }
+
+    /** @test */
+    public function a_single_invitation_reports_a_queue_of_one(): void
+    {
+        $user = $this->makeUser();
+        $this->makeInvitation($user);
+
+        $this->actingAs($user)->getJson(route('feedback.prompt'))
+            ->assertOk()
+            ->assertJsonPath('queue.remaining', 1);
+    }
+
+    /** @test */
+    public function submitting_hands_back_the_next_invitation_inline(): void
+    {
+        $user = $this->makeUser();
+        $first = $this->makeInvitation($user);
+        $second = $this->makeInvitation($user);
+
+        $response = $this->actingAs($user)->postJson(route('feedback.store', $first), [
+            'answers' => ['attended' => 'yes', 'overall_rating' => 4],
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('next.invitation.token', $second->token)
+            ->assertJsonPath('next.queue.remaining', 1);
+
+        // Handing it back counts as showing it.
+        $this->assertSame(SurveyInvitation::STATUS_SHOWN, $second->fresh()->status);
+    }
+
+    /** @test */
+    public function submitting_the_last_invitation_returns_a_null_next(): void
+    {
+        $user = $this->makeUser();
+        $only = $this->makeInvitation($user);
+
+        $this->actingAs($user)->postJson(route('feedback.store', $only), [
+            'answers' => ['attended' => 'yes', 'overall_rating' => 4],
+        ])->assertOk()->assertJsonPath('next', null);
+    }
+
+    /** @test */
+    public function the_queue_can_be_worked_through_end_to_end(): void
+    {
+        $user = $this->makeUser();
+        $this->makeInvitation($user);
+        $this->makeInvitation($user);
+        $this->makeInvitation($user);
+
+        $payload = $this->actingAs($user)->getJson(route('feedback.prompt'))->json();
+
+        $this->assertSame(3, $payload['queue']['remaining']);
+
+        $seen = 0;
+
+        while ($payload !== null && ($payload['invitation'] ?? null) !== null) {
+            $seen++;
+
+            $body = $this->actingAs($user)
+                ->postJson('/feedback/'.$payload['invitation']['token'], [
+                    'answers' => ['attended' => 'yes', 'overall_rating' => 5],
+                ])
+                ->assertOk()
+                ->json();
+
+            $payload = $body['next'];
+        }
+
+        $this->assertSame(3, $seen, 'All three should be answerable in one sitting.');
+        $this->assertSame(3, SurveyResponse::where('user_id', $user->id)->count());
+        $this->assertSame(0, SurveyInvitation::where('user_id', $user->id)->actionable()->count());
+    }
+
+    /** @test */
+    public function the_queue_does_not_leak_another_users_invitations(): void
+    {
+        $user = $this->makeUser();
+        $other = $this->makeUser();
+
+        $mine = $this->makeInvitation($user);
+        $this->makeInvitation($other);
+        $this->makeInvitation($other);
+
+        $this->actingAs($user)->getJson(route('feedback.prompt'))
+            ->assertOk()
+            ->assertJsonPath('queue.remaining', 1)
+            ->assertJsonPath('invitation.token', $mine->token);
+    }
+
     // --------------------------------------------------------- no-show branch
 
     /** @test */

--- a/tests/Feature/FeedbackPromptTest.php
+++ b/tests/Feature/FeedbackPromptTest.php
@@ -250,9 +250,13 @@ class FeedbackPromptTest extends TestCase
             ->assertJsonPath('campaign.slug', SurveyCampaign::POST_EVENT_ATTENDEE)
             ->assertJsonPath('subject.type', 'event')
             ->assertJsonPath('subject.name', 'Test Show')
-            ->assertJsonCount(6, 'questions')
-            ->assertJsonPath('questions.0.key', 'overall_rating')
+            ->assertJsonCount(9, 'questions')
+            ->assertJsonPath('questions.0.key', 'attended')
             ->assertJsonPath('questions.0.required', true)
+            ->assertJsonPath('questions.0.depends_on', null)
+            ->assertJsonPath('questions.3.key', 'overall_rating')
+            ->assertJsonPath('questions.3.depends_on.key', 'attended')
+            ->assertJsonPath('questions.3.depends_on.value', 'yes')
             ->assertJsonPath('visibility.default', false);
 
         $this->assertSame(SurveyInvitation::STATUS_SHOWN, $invitation->fresh()->status);
@@ -290,6 +294,7 @@ class FeedbackPromptTest extends TestCase
 
         $response = $this->actingAs($user)->postJson(route('feedback.store', $invitation), [
             'answers' => [
+                'attended' => 'yes',
                 'overall_rating' => 4,
                 'liked_most' => ['lineup', 'sound'],
                 'return_likelihood' => 'probably',
@@ -308,8 +313,8 @@ class FeedbackPromptTest extends TestCase
         $this->assertSame(Visibility::VISIBILITY_PRIVATE, $stored->visibility_id);
         $this->assertNotNull($stored->submitted_at);
 
-        // 1 rating + 2 multi-choice rows + 1 single choice + 1 text
-        $this->assertCount(5, $stored->answers);
+        // gate + rating + 2 multi-choice rows + 1 single choice + 1 text
+        $this->assertCount(6, $stored->answers);
 
         $this->assertSame(SurveyInvitation::STATUS_COMPLETED, $invitation->fresh()->status);
         $this->assertNotNull($invitation->fresh()->completed_at);
@@ -322,7 +327,7 @@ class FeedbackPromptTest extends TestCase
         $invitation = $this->makeInvitation($user);
 
         $this->actingAs($user)->postJson(route('feedback.store', $invitation), [
-            'answers' => ['overall_rating' => 5],
+            'answers' => ['attended' => 'yes', 'overall_rating' => 5],
             'public' => true,
         ])->assertOk();
 
@@ -333,6 +338,162 @@ class FeedbackPromptTest extends TestCase
         $this->assertSame(1, SurveyResponse::public()->count());
     }
 
+    // --------------------------------------------------------- no-show branch
+
+    /** @test */
+    public function a_user_can_report_that_they_did_not_attend_with_a_reason(): void
+    {
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user);
+
+        $this->actingAs($user)->postJson(route('feedback.store', $invitation), [
+            'answers' => [
+                'attended' => 'no',
+                'not_attended_reason' => ['cost', 'transport'],
+                'not_attended_detail' => 'Tickets went up and I could not get a ride.',
+            ],
+        ])->assertOk();
+
+        $stored = SurveyResponse::where('user_id', $user->id)->first();
+
+        $this->assertNotNull($stored);
+        $this->assertSame(SurveyInvitation::STATUS_COMPLETED, $invitation->fresh()->status);
+
+        $byKey = $stored->answers->groupBy(fn ($answer) => $answer->question->key);
+
+        $this->assertSame('no', $byKey['attended']->first()->value_option);
+        $this->assertSame(
+            ['cost', 'transport'],
+            $byKey['not_attended_reason']->pluck('value_option')->sort()->values()->all()
+        );
+        $this->assertSame(
+            'Tickets went up and I could not get a ride.',
+            $byKey['not_attended_detail']->first()->value_text
+        );
+    }
+
+    /** @test */
+    public function the_why_is_optional_for_a_no_show(): void
+    {
+        // We ask why; we don't demand it. Answering only the gate must succeed.
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user);
+
+        $this->actingAs($user)->postJson(route('feedback.store', $invitation), [
+            'answers' => ['attended' => 'no'],
+        ])->assertOk();
+
+        $stored = SurveyResponse::where('user_id', $user->id)->first();
+
+        $this->assertCount(1, $stored->answers);
+        $this->assertSame(SurveyInvitation::STATUS_COMPLETED, $invitation->fresh()->status);
+    }
+
+    /** @test */
+    public function the_rating_is_not_required_when_the_user_did_not_attend(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user);
+
+        $this->actingAs($user)->postJson(route('feedback.store', $invitation), [
+            'answers' => ['attended' => 'no'],
+        ])->assertOk();
+    }
+
+    /** @test */
+    public function attended_branch_answers_are_discarded_when_the_user_did_not_attend(): void
+    {
+        // A stale value left behind by switching the gate to "no" must not be
+        // stored against a branch the user isn't in.
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user);
+
+        $this->actingAs($user)->postJson(route('feedback.store', $invitation), [
+            'answers' => [
+                'attended' => 'no',
+                'overall_rating' => 5,
+                'liked_most' => ['lineup'],
+                'not_attended_reason' => ['forgot'],
+            ],
+        ])->assertOk();
+
+        $keys = SurveyResponse::where('user_id', $user->id)->first()
+            ->answers->map(fn ($answer) => $answer->question->key)->unique()->values()->all();
+
+        sort($keys);
+
+        $this->assertSame(['attended', 'not_attended_reason'], $keys);
+    }
+
+    /** @test */
+    public function no_show_answers_are_discarded_when_the_user_did_attend(): void
+    {
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user);
+
+        $this->actingAs($user)->postJson(route('feedback.store', $invitation), [
+            'answers' => [
+                'attended' => 'yes',
+                'overall_rating' => 4,
+                'not_attended_reason' => ['forgot'],
+                'not_attended_detail' => 'should be dropped',
+            ],
+        ])->assertOk();
+
+        $keys = SurveyResponse::where('user_id', $user->id)->first()
+            ->answers->map(fn ($answer) => $answer->question->key)->unique()->values()->all();
+
+        sort($keys);
+
+        $this->assertSame(['attended', 'overall_rating'], $keys);
+    }
+
+    /** @test */
+    public function the_attendance_gate_itself_is_required(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user);
+
+        $this->actingAs($user)->postJson(route('feedback.store', $invitation), [
+            'answers' => ['overall_rating' => 4],
+        ])->assertStatus(422)->assertJsonValidationErrors('answers.attended');
+
+        $this->assertSame(0, SurveyResponse::count());
+    }
+
+    /** @test */
+    public function an_unknown_attendance_value_is_rejected(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user);
+
+        $this->actingAs($user)->postJson(route('feedback.store', $invitation), [
+            'answers' => ['attended' => 'maybe'],
+        ])->assertStatus(422)->assertJsonValidationErrors('answers.attended');
+    }
+
+    /** @test */
+    public function an_unknown_no_show_reason_is_rejected(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user);
+
+        $this->actingAs($user)->postJson(route('feedback.store', $invitation), [
+            'answers' => [
+                'attended' => 'no',
+                'not_attended_reason' => ['not_an_option'],
+            ],
+        ])->assertStatus(422)->assertJsonValidationErrors('answers.not_attended_reason.0');
+    }
+
     /** @test */
     public function unknown_answer_keys_are_ignored(): void
     {
@@ -341,12 +502,13 @@ class FeedbackPromptTest extends TestCase
 
         $this->actingAs($user)->postJson(route('feedback.store', $invitation), [
             'answers' => [
+                'attended' => 'yes',
                 'overall_rating' => 3,
                 'not_a_real_question' => 'whatever',
             ],
         ])->assertOk();
 
-        $this->assertCount(1, SurveyResponse::where('user_id', $user->id)->first()->answers);
+        $this->assertCount(2, SurveyResponse::where('user_id', $user->id)->first()->answers);
     }
 
     /** @test */
@@ -358,7 +520,7 @@ class FeedbackPromptTest extends TestCase
         $invitation = $this->makeInvitation($user);
 
         $this->actingAs($user)->postJson(route('feedback.store', $invitation), [
-            'answers' => ['comments' => 'No rating given.'],
+            'answers' => ['attended' => 'yes', 'comments' => 'No rating given.'],
         ])->assertStatus(422)->assertJsonValidationErrors('answers.overall_rating');
 
         $this->assertSame(0, SurveyResponse::count());
@@ -373,7 +535,7 @@ class FeedbackPromptTest extends TestCase
         $invitation = $this->makeInvitation($user);
 
         $this->actingAs($user)->postJson(route('feedback.store', $invitation), [
-            'answers' => ['overall_rating' => 9],
+            'answers' => ['attended' => 'yes', 'overall_rating' => 9],
         ])->assertStatus(422)->assertJsonValidationErrors('answers.overall_rating');
     }
 
@@ -387,6 +549,7 @@ class FeedbackPromptTest extends TestCase
 
         $this->actingAs($user)->postJson(route('feedback.store', $invitation), [
             'answers' => [
+                'attended' => 'yes',
                 'overall_rating' => 4,
                 'liked_most' => ['not_an_option'],
             ],
@@ -403,7 +566,7 @@ class FeedbackPromptTest extends TestCase
         $invitation = $this->makeInvitation($owner);
 
         $this->actingAs($intruder)
-            ->postJson(route('feedback.store', $invitation), ['answers' => ['overall_rating' => 5]])
+            ->postJson(route('feedback.store', $invitation), ['answers' => ['attended' => 'yes', 'overall_rating' => 5]])
             ->assertForbidden();
 
         $this->assertSame(0, SurveyResponse::count());
@@ -418,7 +581,7 @@ class FeedbackPromptTest extends TestCase
         $invitation = $this->makeInvitation($user, ['status' => SurveyInvitation::STATUS_COMPLETED]);
 
         $this->actingAs($user)
-            ->postJson(route('feedback.store', $invitation), ['answers' => ['overall_rating' => 5]])
+            ->postJson(route('feedback.store', $invitation), ['answers' => ['attended' => 'yes', 'overall_rating' => 5]])
             ->assertStatus(410);
     }
 
@@ -428,7 +591,7 @@ class FeedbackPromptTest extends TestCase
         $this->withExceptionHandling();
 
         $this->actingAs($this->makeUser())
-            ->postJson('/feedback/'.str_repeat('z', 40), ['answers' => ['overall_rating' => 5]])
+            ->postJson('/feedback/'.str_repeat('z', 40), ['answers' => ['attended' => 'yes', 'overall_rating' => 5]])
             ->assertNotFound();
     }
 
@@ -443,7 +606,7 @@ class FeedbackPromptTest extends TestCase
         config(['feedback.enabled' => false]);
 
         $this->actingAs($user)
-            ->postJson(route('feedback.store', $invitation), ['answers' => ['overall_rating' => 5]])
+            ->postJson(route('feedback.store', $invitation), ['answers' => ['attended' => 'yes', 'overall_rating' => 5]])
             ->assertNotFound();
     }
 
@@ -489,7 +652,7 @@ class FeedbackPromptTest extends TestCase
         $invitation = $this->makeInvitation($user, ['status' => SurveyInvitation::STATUS_SHOWN]);
 
         $this->actingAs($user)->postJson(route('feedback.store', $invitation), [
-            'answers' => ['overall_rating' => 5],
+            'answers' => ['attended' => 'yes', 'overall_rating' => 5],
         ])->assertOk();
 
         $this->assertSame(SurveyInvitation::STATUS_COMPLETED, $invitation->fresh()->status);
@@ -549,7 +712,7 @@ class FeedbackPromptTest extends TestCase
         $user->profile->update(['setting_feedback_requests' => 0]);
 
         $this->actingAs($user->fresh())
-            ->postJson(route('feedback.store', $invitation), ['answers' => ['overall_rating' => 5]])
+            ->postJson(route('feedback.store', $invitation), ['answers' => ['attended' => 'yes', 'overall_rating' => 5]])
             ->assertForbidden();
     }
 

--- a/tests/Feature/FeedbackPromptTest.php
+++ b/tests/Feature/FeedbackPromptTest.php
@@ -1,0 +1,611 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Middleware\VerifyCsrfToken;
+use App\Models\Event;
+use App\Models\Follow;
+use App\Models\SurveyCampaign;
+use App\Models\SurveyInvitation;
+use App\Models\SurveyResponse;
+use App\Models\User;
+use App\Models\UserStatus;
+use App\Models\Visibility;
+use App\Services\FeedbackPromptService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+/**
+ * The user-facing half of the proactive feedback interview (issue #1998):
+ * prompt resolution, the modal payload, submission, and the ways out.
+ */
+class FeedbackPromptTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Web endpoints sit behind CSRF; bypass it for the JSON helpers.
+        $this->withoutMiddleware(VerifyCsrfToken::class);
+
+        config(['feedback.enabled' => true]);
+    }
+
+    /**
+     * A user who is eligible for prompts: verified, opted in, and — because
+     * onboarding outranks feedback — already following something.
+     */
+    private function makeUser(array $profileOverrides = []): User
+    {
+        $user = User::factory()->create([
+            'user_status_id' => UserStatus::ACTIVE,
+            'email_verified_at' => now(),
+        ]);
+
+        $user->profile()->create(array_merge([
+            'setting_feedback_requests' => 1,
+            'onboarding_completed_at' => now(),
+        ], $profileOverrides));
+
+        return $user->fresh();
+    }
+
+    private function makeInvitation(User $user, array $overrides = []): SurveyInvitation
+    {
+        $campaign = SurveyCampaign::bySlug(SurveyCampaign::POST_EVENT_ATTENDEE);
+
+        $event = Event::factory()->create([
+            'name' => 'Test Show',
+            'start_at' => now()->subDays(2),
+            'end_at' => now()->subDays(2)->addHours(3),
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+
+        return SurveyInvitation::factory()->create(array_merge([
+            'survey_campaign_id' => $campaign->id,
+            'user_id' => $user->id,
+            'subject_type' => 'event',
+            'subject_id' => $event->id,
+        ], $overrides));
+    }
+
+    private function service(): FeedbackPromptService
+    {
+        return app(FeedbackPromptService::class);
+    }
+
+    // ---------------------------------------------------------------- resolution
+
+    /** @test */
+    public function it_resolves_a_pending_invitation(): void
+    {
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user);
+
+        $this->assertSame($invitation->id, $this->service()->pendingFor($user)?->id);
+    }
+
+    /** @test */
+    public function it_resolves_nothing_when_the_feature_flag_is_off(): void
+    {
+        config(['feedback.enabled' => false]);
+
+        $user = $this->makeUser();
+        $this->makeInvitation($user);
+
+        $this->assertNull($this->service()->pendingFor($user));
+    }
+
+    /** @test */
+    public function it_resolves_nothing_when_the_user_opted_out(): void
+    {
+        $user = $this->makeUser(['setting_feedback_requests' => 0]);
+        $this->makeInvitation($user);
+
+        $this->assertNull($this->service()->pendingFor($user));
+    }
+
+    /** @test */
+    public function it_resolves_nothing_for_a_user_with_no_profile(): void
+    {
+        $user = User::factory()->create([
+            'user_status_id' => UserStatus::ACTIVE,
+            'email_verified_at' => now(),
+        ]);
+        $user->profile()->delete();
+
+        $this->makeInvitation($user->fresh());
+
+        $this->assertNull($this->service()->pendingFor($user->fresh()));
+    }
+
+    /** @test */
+    public function it_resolves_nothing_for_dismissed_completed_expired_or_snoozed_invitations(): void
+    {
+        foreach (['dismissed', 'completed', 'expired', 'snoozed'] as $state) {
+            $user = $this->makeUser();
+            $this->makeInvitation($user, match ($state) {
+                'dismissed' => ['status' => SurveyInvitation::STATUS_DISMISSED],
+                'completed' => ['status' => SurveyInvitation::STATUS_COMPLETED],
+                'expired' => ['expires_at' => now()->subDay()],
+                'snoozed' => ['snoozed_until' => now()->addWeek()],
+            });
+
+            $this->assertNull($this->service()->pendingFor($user), "State {$state} should not resolve.");
+        }
+    }
+
+    /** @test */
+    public function it_resolves_nothing_when_the_campaign_is_inactive(): void
+    {
+        $user = $this->makeUser();
+        $this->makeInvitation($user);
+
+        SurveyCampaign::where('slug', SurveyCampaign::POST_EVENT_ATTENDEE)->update(['is_active' => false]);
+
+        $this->assertNull($this->service()->pendingFor($user));
+    }
+
+    /** @test */
+    public function it_resolves_nothing_when_the_subject_event_was_deleted(): void
+    {
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user);
+
+        Event::where('id', $invitation->subject_id)->delete();
+        SurveyInvitation::forgetPendingCache($user->id);
+
+        $this->assertNull($this->service()->pendingFor($user));
+    }
+
+    /** @test */
+    public function onboarding_takes_precedence_over_the_feedback_prompt(): void
+    {
+        // shouldSeeOnboarding() is true for a verified user following nothing
+        // who has neither completed nor dismissed onboarding.
+        $user = User::factory()->create([
+            'user_status_id' => UserStatus::ACTIVE,
+            'email_verified_at' => now(),
+        ]);
+        $user->profile()->create(['setting_feedback_requests' => 1]);
+        $user = $user->fresh();
+
+        $this->makeInvitation($user);
+
+        $this->assertTrue($user->shouldSeeOnboarding());
+        $this->assertFalse($this->service()->mayDisplayFor($user));
+    }
+
+    // ------------------------------------------------------------------- layout
+
+    /** @test */
+    public function the_layout_renders_the_prompt_for_a_user_with_an_invitation(): void
+    {
+        $user = $this->makeUser();
+        Follow::create(['user_id' => $user->id, 'object_type' => 'tag', 'object_id' => 1]);
+        $this->makeInvitation($user);
+
+        $this->actingAs($user)->get(route('pages.allModules'))
+            ->assertOk()
+            ->assertSee('feedbackPrompt(', false);
+    }
+
+    /** @test */
+    public function the_layout_does_not_render_the_prompt_when_disabled(): void
+    {
+        config(['feedback.enabled' => false]);
+
+        $user = $this->makeUser();
+        $this->makeInvitation($user);
+
+        $this->actingAs($user)->get(route('pages.allModules'))
+            ->assertOk()
+            ->assertDontSee('feedbackPrompt(', false);
+    }
+
+    /** @test */
+    public function the_layout_does_not_render_the_prompt_for_an_opted_out_user(): void
+    {
+        $user = $this->makeUser(['setting_feedback_requests' => 0]);
+        $this->makeInvitation($user);
+
+        $this->actingAs($user)->get(route('pages.allModules'))
+            ->assertOk()
+            ->assertDontSee('feedbackPrompt(', false);
+    }
+
+    /** @test */
+    public function the_layout_shows_onboarding_instead_when_both_apply(): void
+    {
+        $user = User::factory()->create([
+            'user_status_id' => UserStatus::ACTIVE,
+            'email_verified_at' => now(),
+        ]);
+        $user->profile()->create(['setting_feedback_requests' => 1]);
+        $this->makeInvitation($user->fresh());
+
+        $this->actingAs($user->fresh())->get(route('pages.allModules'))
+            ->assertOk()
+            ->assertSee('onboarding(', false)
+            ->assertDontSee('feedbackPrompt(', false);
+    }
+
+    // ------------------------------------------------------------------- prompt
+
+    /** @test */
+    public function the_prompt_endpoint_returns_the_payload_and_marks_it_shown(): void
+    {
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user);
+
+        $response = $this->actingAs($user)->getJson(route('feedback.prompt'));
+
+        $response->assertOk()
+            ->assertJsonPath('invitation.token', $invitation->token)
+            ->assertJsonPath('campaign.slug', SurveyCampaign::POST_EVENT_ATTENDEE)
+            ->assertJsonPath('subject.type', 'event')
+            ->assertJsonPath('subject.name', 'Test Show')
+            ->assertJsonCount(6, 'questions')
+            ->assertJsonPath('questions.0.key', 'overall_rating')
+            ->assertJsonPath('questions.0.required', true)
+            ->assertJsonPath('visibility.default', false);
+
+        $this->assertSame(SurveyInvitation::STATUS_SHOWN, $invitation->fresh()->status);
+        $this->assertNotNull($invitation->fresh()->shown_at);
+    }
+
+    /** @test */
+    public function the_prompt_endpoint_returns_a_null_invitation_when_nothing_is_pending(): void
+    {
+        $user = $this->makeUser();
+
+        $this->actingAs($user)->getJson(route('feedback.prompt'))
+            ->assertOk()
+            ->assertJsonPath('invitation', null);
+    }
+
+    /** @test */
+    public function the_prompt_endpoint_404s_when_the_feature_is_off(): void
+    {
+        $this->withExceptionHandling();
+        config(['feedback.enabled' => false]);
+
+        $this->actingAs($this->makeUser())
+            ->getJson(route('feedback.prompt'))
+            ->assertNotFound();
+    }
+
+    // ------------------------------------------------------------------- submit
+
+    /** @test */
+    public function it_stores_a_response_with_answers_and_completes_the_invitation(): void
+    {
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user);
+
+        $response = $this->actingAs($user)->postJson(route('feedback.store', $invitation), [
+            'answers' => [
+                'overall_rating' => 4,
+                'liked_most' => ['lineup', 'sound'],
+                'return_likelihood' => 'probably',
+                'comments' => 'The opener was great.',
+            ],
+        ]);
+
+        $response->assertOk()->assertJsonPath('success', true);
+
+        $stored = SurveyResponse::where('user_id', $user->id)->first();
+
+        $this->assertNotNull($stored);
+        $this->assertSame($invitation->id, $stored->survey_invitation_id);
+        $this->assertSame('event', $stored->subject_type);
+        $this->assertSame($invitation->subject_id, $stored->subject_id);
+        $this->assertSame(Visibility::VISIBILITY_PRIVATE, $stored->visibility_id);
+        $this->assertNotNull($stored->submitted_at);
+
+        // 1 rating + 2 multi-choice rows + 1 single choice + 1 text
+        $this->assertCount(5, $stored->answers);
+
+        $this->assertSame(SurveyInvitation::STATUS_COMPLETED, $invitation->fresh()->status);
+        $this->assertNotNull($invitation->fresh()->completed_at);
+    }
+
+    /** @test */
+    public function opting_in_to_sharing_makes_the_response_public(): void
+    {
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user);
+
+        $this->actingAs($user)->postJson(route('feedback.store', $invitation), [
+            'answers' => ['overall_rating' => 5],
+            'public' => true,
+        ])->assertOk();
+
+        $stored = SurveyResponse::where('user_id', $user->id)->first();
+
+        $this->assertSame(Visibility::VISIBILITY_PUBLIC, $stored->visibility_id);
+        $this->assertTrue($stored->isPublic());
+        $this->assertSame(1, SurveyResponse::public()->count());
+    }
+
+    /** @test */
+    public function unknown_answer_keys_are_ignored(): void
+    {
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user);
+
+        $this->actingAs($user)->postJson(route('feedback.store', $invitation), [
+            'answers' => [
+                'overall_rating' => 3,
+                'not_a_real_question' => 'whatever',
+            ],
+        ])->assertOk();
+
+        $this->assertCount(1, SurveyResponse::where('user_id', $user->id)->first()->answers);
+    }
+
+    /** @test */
+    public function the_required_rating_is_enforced(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user);
+
+        $this->actingAs($user)->postJson(route('feedback.store', $invitation), [
+            'answers' => ['comments' => 'No rating given.'],
+        ])->assertStatus(422)->assertJsonValidationErrors('answers.overall_rating');
+
+        $this->assertSame(0, SurveyResponse::count());
+    }
+
+    /** @test */
+    public function an_out_of_range_rating_is_rejected(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user);
+
+        $this->actingAs($user)->postJson(route('feedback.store', $invitation), [
+            'answers' => ['overall_rating' => 9],
+        ])->assertStatus(422)->assertJsonValidationErrors('answers.overall_rating');
+    }
+
+    /** @test */
+    public function an_unknown_option_value_is_rejected(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user);
+
+        $this->actingAs($user)->postJson(route('feedback.store', $invitation), [
+            'answers' => [
+                'overall_rating' => 4,
+                'liked_most' => ['not_an_option'],
+            ],
+        ])->assertStatus(422)->assertJsonValidationErrors('answers.liked_most.0');
+    }
+
+    /** @test */
+    public function another_users_invitation_cannot_be_answered(): void
+    {
+        $this->withExceptionHandling();
+
+        $owner = $this->makeUser();
+        $intruder = $this->makeUser();
+        $invitation = $this->makeInvitation($owner);
+
+        $this->actingAs($intruder)
+            ->postJson(route('feedback.store', $invitation), ['answers' => ['overall_rating' => 5]])
+            ->assertForbidden();
+
+        $this->assertSame(0, SurveyResponse::count());
+    }
+
+    /** @test */
+    public function an_already_completed_invitation_returns_gone(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user, ['status' => SurveyInvitation::STATUS_COMPLETED]);
+
+        $this->actingAs($user)
+            ->postJson(route('feedback.store', $invitation), ['answers' => ['overall_rating' => 5]])
+            ->assertStatus(410);
+    }
+
+    /** @test */
+    public function an_unknown_token_returns_not_found(): void
+    {
+        $this->withExceptionHandling();
+
+        $this->actingAs($this->makeUser())
+            ->postJson('/feedback/'.str_repeat('z', 40), ['answers' => ['overall_rating' => 5]])
+            ->assertNotFound();
+    }
+
+    /** @test */
+    public function submitting_while_the_feature_is_off_returns_not_found(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user);
+
+        config(['feedback.enabled' => false]);
+
+        $this->actingAs($user)
+            ->postJson(route('feedback.store', $invitation), ['answers' => ['overall_rating' => 5]])
+            ->assertNotFound();
+    }
+
+    // --------------------------------------------------------------- ways out
+
+    /** @test */
+    public function dismissing_closes_the_invitation_and_clears_the_cache(): void
+    {
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user);
+
+        // Warm the cache so this genuinely exercises invalidation.
+        $this->assertNotNull($this->service()->pendingFor($user));
+        $this->assertTrue(Cache::has(SurveyInvitation::pendingCacheKey($user->id)));
+
+        $this->actingAs($user)->postJson(route('feedback.dismiss', $invitation))->assertOk();
+
+        $this->assertSame(SurveyInvitation::STATUS_DISMISSED, $invitation->fresh()->status);
+        $this->assertNotNull($invitation->fresh()->dismissed_at);
+        $this->assertNull($this->service()->pendingFor($user->fresh()));
+    }
+
+    /** @test */
+    public function the_shown_endpoint_records_the_view(): void
+    {
+        // The in-app modal is seeded by the layout composer rather than by the
+        // prompt endpoint, so this is what stamps shown_at for that path.
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user);
+
+        $this->actingAs($user)->postJson(route('feedback.shown', $invitation))->assertOk();
+
+        $fresh = $invitation->fresh();
+
+        $this->assertSame(SurveyInvitation::STATUS_SHOWN, $fresh->status);
+        $this->assertNotNull($fresh->shown_at);
+    }
+
+    /** @test */
+    public function a_shown_invitation_can_still_be_answered(): void
+    {
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user, ['status' => SurveyInvitation::STATUS_SHOWN]);
+
+        $this->actingAs($user)->postJson(route('feedback.store', $invitation), [
+            'answers' => ['overall_rating' => 5],
+        ])->assertOk();
+
+        $this->assertSame(SurveyInvitation::STATUS_COMPLETED, $invitation->fresh()->status);
+    }
+
+    /** @test */
+    public function snoozing_pushes_the_invitation_out_without_dismissing_it(): void
+    {
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user);
+
+        $this->actingAs($user)->postJson(route('feedback.snooze', $invitation))->assertOk();
+
+        $fresh = $invitation->fresh();
+
+        $this->assertNotNull($fresh->snoozed_until);
+        $this->assertTrue($fresh->snoozed_until->isFuture());
+        $this->assertNotSame(SurveyInvitation::STATUS_DISMISSED, $fresh->status);
+        $this->assertNull($this->service()->pendingFor($user->fresh()));
+    }
+
+    /** @test */
+    public function opting_out_sets_the_profile_flag_and_dismisses_outstanding_invitations(): void
+    {
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user);
+
+        $this->actingAs($user)->postJson(route('feedback.optOut'))->assertOk();
+
+        $this->assertSame(0, (int) $user->fresh()->profile->setting_feedback_requests);
+        $this->assertSame(SurveyInvitation::STATUS_DISMISSED, $invitation->fresh()->status);
+        $this->assertNull($this->service()->pendingFor($user->fresh()));
+    }
+
+    /** @test */
+    public function opting_out_works_for_a_user_with_no_profile_row(): void
+    {
+        $user = User::factory()->create([
+            'user_status_id' => UserStatus::ACTIVE,
+            'email_verified_at' => now(),
+        ]);
+        $user->profile()->delete();
+
+        $this->actingAs($user->fresh())->postJson(route('feedback.optOut'))->assertOk();
+
+        $this->assertSame(0, (int) $user->fresh()->profile->setting_feedback_requests);
+    }
+
+    /** @test */
+    public function an_opted_out_user_cannot_submit(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user);
+
+        $user->profile->update(['setting_feedback_requests' => 0]);
+
+        $this->actingAs($user->fresh())
+            ->postJson(route('feedback.store', $invitation), ['answers' => ['overall_rating' => 5]])
+            ->assertForbidden();
+    }
+
+    // --------------------------------------------------------- standalone page
+
+    /** @test */
+    public function the_standalone_page_renders_for_the_owner(): void
+    {
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user);
+
+        $this->actingAs($user)->get(route('feedback.show', $invitation))
+            ->assertOk()
+            ->assertSee('Test Show')
+            ->assertSee('feedbackPrompt(', false);
+    }
+
+    /** @test */
+    public function the_standalone_page_is_forbidden_for_another_user(): void
+    {
+        $this->withExceptionHandling();
+
+        $invitation = $this->makeInvitation($this->makeUser());
+
+        $this->actingAs($this->makeUser())
+            ->get(route('feedback.show', $invitation))
+            ->assertForbidden();
+    }
+
+    /** @test */
+    public function the_standalone_page_does_not_stack_a_second_modal(): void
+    {
+        $user = $this->makeUser();
+        $invitation = $this->makeInvitation($user);
+
+        $html = $this->actingAs($user)->get(route('feedback.show', $invitation))->getContent();
+
+        $this->assertSame(
+            1,
+            substr_count($html, 'x-data="feedbackPrompt('),
+            'The layout must not add its own prompt on top of the standalone page.'
+        );
+    }
+
+    // ------------------------------------------------------------------- auth
+
+    /** @test */
+    public function all_feedback_endpoints_require_authentication(): void
+    {
+        $this->withExceptionHandling();
+
+        $invitation = $this->makeInvitation($this->makeUser());
+
+        $this->getJson(route('feedback.prompt'))->assertUnauthorized();
+        $this->postJson(route('feedback.optOut'))->assertUnauthorized();
+        $this->postJson(route('feedback.dismiss', $invitation))->assertUnauthorized();
+        $this->postJson(route('feedback.store', $invitation), ['answers' => []])->assertUnauthorized();
+    }
+}

--- a/tests/Feature/FeedbackPromptTest.php
+++ b/tests/Feature/FeedbackPromptTest.php
@@ -3,8 +3,10 @@
 namespace Tests\Feature;
 
 use App\Http\Middleware\VerifyCsrfToken;
+use App\Models\Entity;
 use App\Models\Event;
 use App\Models\Follow;
+use App\Models\Photo;
 use App\Models\SurveyCampaign;
 use App\Models\SurveyInvitation;
 use App\Models\SurveyResponse;
@@ -336,6 +338,62 @@ class FeedbackPromptTest extends TestCase
         $this->assertSame(Visibility::VISIBILITY_PUBLIC, $stored->visibility_id);
         $this->assertTrue($stored->isPublic());
         $this->assertSame(1, SurveyResponse::public()->count());
+    }
+
+    // ------------------------------------------------------- subject details
+
+    /** @test */
+    public function the_payload_carries_the_venue_and_flyer_thumbnail(): void
+    {
+        $user = $this->makeUser();
+
+        $venue = Entity::factory()->venue()->create(['name' => 'The Rock Room']);
+        $event = Event::factory()->create([
+            'name' => 'Test Show',
+            'venue_id' => $venue->id,
+            'start_at' => now()->subDays(2),
+            'end_at' => now()->subDays(2)->addHours(3),
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ]);
+
+        $photo = Photo::factory()->create(['is_primary' => 1]);
+        $event->photos()->attach($photo->id);
+
+        $invitation = $this->makeInvitation($user, [
+            'subject_type' => 'event',
+            'subject_id' => $event->id,
+        ]);
+
+        $payload = $this->actingAs($user)->getJson(route('feedback.prompt'))
+            ->assertOk()
+            ->assertJsonPath('subject.name', 'Test Show')
+            ->assertJsonPath('subject.venue', 'The Rock Room')
+            ->json();
+
+        $this->assertNotNull($payload['subject']['image'], 'The flyer thumbnail should be resolved.');
+        $this->assertNotNull($payload['subject']['venue_url']);
+        $this->assertNotNull($payload['subject']['date']);
+        $this->assertSame($invitation->token, $payload['invitation']['token']);
+    }
+
+    /** @test */
+    public function the_payload_tolerates_an_event_with_no_venue_or_flyer(): void
+    {
+        $user = $this->makeUser();
+        $this->makeInvitation($user, ['subject_id' => Event::factory()->create([
+            'name' => 'Bare Show',
+            'venue_id' => null,
+            'start_at' => now()->subDays(2),
+            'end_at' => now()->subDays(2)->addHours(3),
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ])->id]);
+
+        $this->actingAs($user)->getJson(route('feedback.prompt'))
+            ->assertOk()
+            ->assertJsonPath('subject.name', 'Bare Show')
+            ->assertJsonPath('subject.venue', null)
+            ->assertJsonPath('subject.venue_url', null)
+            ->assertJsonPath('subject.image', null);
     }
 
     // ---------------------------------------------------------------- queue

--- a/tests/Feature/Services/DataExportUserDataTest.php
+++ b/tests/Feature/Services/DataExportUserDataTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Feature\Services;
+
+use App\Models\SurveyAnswer;
+use App\Models\SurveyCampaign;
+use App\Models\SurveyResponse;
+use App\Models\User;
+use App\Models\UserStatus;
+use App\Services\DataExportService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use ReflectionMethod;
+use Tests\TestCase;
+
+/**
+ * The GDPR export enumerates personal data explicitly, so anything new has to
+ * be added by hand. Feedback survey responses are private by default, which
+ * makes them exactly the kind of data the export must cover (issue #1998).
+ */
+class DataExportUserDataTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function aggregate(User $user): array
+    {
+        $method = new ReflectionMethod(DataExportService::class, 'aggregateUserData');
+        $method->setAccessible(true);
+
+        return $method->invoke(app(DataExportService::class), $user);
+    }
+
+    /** @test */
+    public function export_includes_the_feedback_request_setting(): void
+    {
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $user->profile()->create(['setting_feedback_requests' => 0]);
+
+        $data = $this->aggregate($user->fresh());
+
+        $this->assertArrayHasKey('setting_feedback_requests', $data['profile']['profile']);
+        $this->assertSame(0, (int) $data['profile']['profile']['setting_feedback_requests']);
+    }
+
+    /** @test */
+    public function export_includes_submitted_survey_responses_and_answers(): void
+    {
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $user->profile()->create([]);
+
+        $campaign = SurveyCampaign::bySlug(SurveyCampaign::POST_EVENT_ATTENDEE);
+        $question = $campaign->questions->firstWhere('key', 'overall_rating');
+
+        $response = SurveyResponse::factory()->create([
+            'survey_campaign_id' => $campaign->id,
+            'user_id' => $user->id,
+        ]);
+
+        SurveyAnswer::factory()->rating(4)->create([
+            'survey_response_id' => $response->id,
+            'survey_question_id' => $question->id,
+        ]);
+
+        $data = $this->aggregate($user->fresh());
+
+        $this->assertArrayHasKey('survey_responses', $data);
+        $this->assertCount(1, $data['survey_responses']);
+
+        $exported = $data['survey_responses']->first();
+
+        $this->assertSame($campaign->name, $exported['campaign']);
+        $this->assertSame('private', $exported['visibility']);
+        $this->assertCount(1, $exported['answers']);
+        $this->assertSame('overall_rating', $exported['answers'][0]['question_key']);
+        $this->assertSame('4', $exported['answers'][0]['value']);
+    }
+
+    /** @test */
+    public function export_does_not_leak_other_users_survey_responses(): void
+    {
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $user->profile()->create([]);
+
+        $other = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        SurveyResponse::factory()->create(['user_id' => $other->id]);
+
+        $data = $this->aggregate($user->fresh());
+
+        $this->assertCount(0, $data['survey_responses']);
+    }
+}

--- a/tests/Feature/SurveyCampaignSeedTest.php
+++ b/tests/Feature/SurveyCampaignSeedTest.php
@@ -48,15 +48,20 @@ class SurveyCampaignSeedTest extends TestCase
     }
 
     /** @test */
-    public function campaign_has_six_active_questions_in_sort_order(): void
+    public function campaign_has_the_expected_active_questions_in_sort_order(): void
     {
         $campaign = SurveyCampaign::bySlug(SurveyCampaign::POST_EVENT_ATTENDEE);
 
         $questions = $campaign->activeQuestions()->get();
 
-        $this->assertCount(6, $questions);
+        $this->assertCount(9, $questions);
         $this->assertSame(
-            ['overall_rating', 'liked_most', 'liked_least', 'want_more', 'return_likelihood', 'comments'],
+            [
+                'attended',
+                'not_attended_reason', 'not_attended_detail',
+                'overall_rating', 'liked_most', 'liked_least',
+                'want_more', 'return_likelihood', 'comments',
+            ],
             $questions->pluck('key')->all()
         );
 
@@ -67,17 +72,76 @@ class SurveyCampaignSeedTest extends TestCase
     }
 
     /** @test */
-    public function exactly_one_question_is_required_and_it_is_the_rating(): void
+    public function the_attendance_gate_is_first_unconditional_and_required(): void
     {
         $campaign = SurveyCampaign::bySlug(SurveyCampaign::POST_EVENT_ATTENDEE);
 
-        $required = $campaign->activeQuestions()->get()->where('is_required', true);
+        $gate = $campaign->activeQuestions()->get()->first();
 
-        $this->assertCount(1, $required);
-        $this->assertSame('overall_rating', $required->first()->key);
-        $this->assertSame(SurveyQuestion::TYPE_RATING, $required->first()->type);
-        $this->assertSame(1, $required->first()->min_value);
-        $this->assertSame(5, $required->first()->max_value);
+        $this->assertSame('attended', $gate->key);
+        $this->assertSame(SurveyQuestion::TYPE_SINGLE_CHOICE, $gate->type);
+        $this->assertTrue($gate->is_required);
+        $this->assertFalse($gate->isConditional(), 'The gate itself must never be conditional.');
+        $this->assertSame(['yes', 'no'], $gate->optionValues());
+    }
+
+    /** @test */
+    public function every_question_after_the_gate_belongs_to_exactly_one_branch(): void
+    {
+        $campaign = SurveyCampaign::bySlug(SurveyCampaign::POST_EVENT_ATTENDEE);
+
+        $branches = $campaign->activeQuestions()->get()
+            ->reject(fn (SurveyQuestion $q) => $q->key === 'attended')
+            ->groupBy('depends_on_value');
+
+        // Nothing may be left dangling without a branch, or the no-show path
+        // would be asked to rate an event they never saw.
+        $this->assertSame(['no', 'yes'], $branches->keys()->sort()->values()->all());
+        $this->assertCount(2, $branches['no']);
+        $this->assertCount(6, $branches['yes']);
+
+        foreach ($branches->flatten() as $question) {
+            $this->assertSame('attended', $question->depends_on_key);
+        }
+    }
+
+    /** @test */
+    public function the_rating_is_required_only_within_the_attended_branch(): void
+    {
+        $campaign = SurveyCampaign::bySlug(SurveyCampaign::POST_EVENT_ATTENDEE);
+
+        $rating = $campaign->activeQuestions()->get()->firstWhere('key', 'overall_rating');
+
+        $this->assertSame(SurveyQuestion::TYPE_RATING, $rating->type);
+        $this->assertTrue($rating->is_required);
+        $this->assertSame(1, $rating->min_value);
+        $this->assertSame(5, $rating->max_value);
+
+        $this->assertTrue($rating->appliesGiven(['attended' => 'yes']));
+        $this->assertFalse($rating->appliesGiven(['attended' => 'no']));
+        $this->assertFalse($rating->appliesGiven([]), 'An unanswered gate hides everything downstream.');
+    }
+
+    /** @test */
+    public function the_no_show_branch_asks_why(): void
+    {
+        $campaign = SurveyCampaign::bySlug(SurveyCampaign::POST_EVENT_ATTENDEE);
+        $questions = $campaign->activeQuestions()->get();
+
+        $reason = $questions->firstWhere('key', 'not_attended_reason');
+        $detail = $questions->firstWhere('key', 'not_attended_detail');
+
+        $this->assertNotNull($reason);
+        $this->assertNotNull($detail);
+
+        // Both optional — we ask why, we don't demand it.
+        $this->assertFalse($reason->is_required);
+        $this->assertFalse($detail->is_required);
+
+        $this->assertTrue($reason->appliesGiven(['attended' => 'no']));
+        $this->assertFalse($reason->appliesGiven(['attended' => 'yes']));
+        $this->assertContains('cost', $reason->optionValues());
+        $this->assertSame(SurveyQuestion::TYPE_TEXT, $detail->type);
     }
 
     /** @test */
@@ -145,7 +209,7 @@ class SurveyCampaignSeedTest extends TestCase
 
         $this->assertSame($originalId, $reseeded->id, 'Re-seeding must not replace the campaign row.');
         $this->assertSame(1, SurveyCampaign::where('slug', SurveyCampaign::POST_EVENT_ATTENDEE)->count());
-        $this->assertCount(6, $reseeded->questions);
+        $this->assertCount(9, $reseeded->questions);
         $this->assertSame(
             $originalQuestionIds,
             $reseeded->questions->pluck('id')->sort()->values()->all(),

--- a/tests/Feature/SurveyCampaignSeedTest.php
+++ b/tests/Feature/SurveyCampaignSeedTest.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\SurveyAnswer;
+use App\Models\SurveyCampaign;
+use App\Models\SurveyInvitation;
+use App\Models\SurveyQuestion;
+use App\Models\SurveyResponse;
+use App\Models\User;
+use App\Models\Visibility;
+use Database\Seeders\SurveyCampaignsTableSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Guards the seeded shape of the feedback campaigns (issue #1998).
+ *
+ * The idempotency tests here are the important ones: every other lookup seeder
+ * in this app opens with DB::table(...)->delete(), and copying that pattern
+ * would silently destroy collected feedback on the next seed run.
+ */
+class SurveyCampaignSeedTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    /** @test */
+    public function post_event_campaign_is_seeded_and_active(): void
+    {
+        $campaign = SurveyCampaign::where('slug', SurveyCampaign::POST_EVENT_ATTENDEE)->first();
+
+        $this->assertNotNull($campaign, 'The post-event-attendee campaign should be seeded.');
+        $this->assertTrue($campaign->is_active);
+        $this->assertSame('event', $campaign->subject_type);
+        $this->assertSame(30, $campaign->expires_after_days);
+        $this->assertSame(Visibility::VISIBILITY_PRIVATE, $campaign->default_visibility_id);
+    }
+
+    /** @test */
+    public function by_slug_resolves_the_campaign(): void
+    {
+        $campaign = SurveyCampaign::bySlug(SurveyCampaign::POST_EVENT_ATTENDEE);
+
+        $this->assertNotNull($campaign);
+        $this->assertSame(SurveyCampaign::POST_EVENT_ATTENDEE, $campaign->slug);
+    }
+
+    /** @test */
+    public function campaign_has_six_active_questions_in_sort_order(): void
+    {
+        $campaign = SurveyCampaign::bySlug(SurveyCampaign::POST_EVENT_ATTENDEE);
+
+        $questions = $campaign->activeQuestions()->get();
+
+        $this->assertCount(6, $questions);
+        $this->assertSame(
+            ['overall_rating', 'liked_most', 'liked_least', 'want_more', 'return_likelihood', 'comments'],
+            $questions->pluck('key')->all()
+        );
+
+        $sorts = $questions->pluck('sort')->all();
+        $sorted = $sorts;
+        sort($sorted);
+        $this->assertSame($sorted, $sorts, 'Questions should come back in sort order.');
+    }
+
+    /** @test */
+    public function exactly_one_question_is_required_and_it_is_the_rating(): void
+    {
+        $campaign = SurveyCampaign::bySlug(SurveyCampaign::POST_EVENT_ATTENDEE);
+
+        $required = $campaign->activeQuestions()->get()->where('is_required', true);
+
+        $this->assertCount(1, $required);
+        $this->assertSame('overall_rating', $required->first()->key);
+        $this->assertSame(SurveyQuestion::TYPE_RATING, $required->first()->type);
+        $this->assertSame(1, $required->first()->min_value);
+        $this->assertSame(5, $required->first()->max_value);
+    }
+
+    /** @test */
+    public function every_question_has_a_known_type(): void
+    {
+        $campaign = SurveyCampaign::bySlug(SurveyCampaign::POST_EVENT_ATTENDEE);
+
+        foreach ($campaign->questions as $question) {
+            $this->assertContains(
+                $question->type,
+                SurveyQuestion::TYPES,
+                "Question {$question->key} has an unknown type: {$question->type}"
+            );
+        }
+    }
+
+    /** @test */
+    public function choice_questions_have_non_empty_options_with_unique_values(): void
+    {
+        $campaign = SurveyCampaign::bySlug(SurveyCampaign::POST_EVENT_ATTENDEE);
+
+        $choiceQuestions = $campaign->questions->filter(fn (SurveyQuestion $q) => $q->isChoice());
+
+        $this->assertGreaterThan(0, $choiceQuestions->count());
+
+        foreach ($choiceQuestions as $question) {
+            $values = $question->optionValues();
+
+            $this->assertNotEmpty($values, "Question {$question->key} has no options.");
+            $this->assertSame(
+                array_values(array_unique($values)),
+                $values,
+                "Question {$question->key} has duplicate option values."
+            );
+
+            foreach ($question->options as $option) {
+                $this->assertArrayHasKey('label', $option);
+                $this->assertNotSame('', $option['label']);
+            }
+        }
+    }
+
+    /** @test */
+    public function non_choice_questions_have_no_options(): void
+    {
+        $campaign = SurveyCampaign::bySlug(SurveyCampaign::POST_EVENT_ATTENDEE);
+
+        $nonChoice = $campaign->questions->reject(fn (SurveyQuestion $q) => $q->isChoice());
+
+        foreach ($nonChoice as $question) {
+            $this->assertNull($question->options, "Question {$question->key} should not carry options.");
+        }
+    }
+
+    /** @test */
+    public function reseeding_is_idempotent(): void
+    {
+        $campaign = SurveyCampaign::bySlug(SurveyCampaign::POST_EVENT_ATTENDEE);
+        $originalId = $campaign->id;
+        $originalQuestionIds = $campaign->questions->pluck('id')->sort()->values()->all();
+
+        $this->seed(SurveyCampaignsTableSeeder::class);
+
+        $reseeded = SurveyCampaign::where('slug', SurveyCampaign::POST_EVENT_ATTENDEE)->first();
+
+        $this->assertSame($originalId, $reseeded->id, 'Re-seeding must not replace the campaign row.');
+        $this->assertSame(1, SurveyCampaign::where('slug', SurveyCampaign::POST_EVENT_ATTENDEE)->count());
+        $this->assertCount(6, $reseeded->questions);
+        $this->assertSame(
+            $originalQuestionIds,
+            $reseeded->questions->pluck('id')->sort()->values()->all(),
+            'Re-seeding must not replace question rows — answers FK to them.'
+        );
+    }
+
+    /** @test */
+    public function reseeding_preserves_collected_invitations_and_responses(): void
+    {
+        $campaign = SurveyCampaign::bySlug(SurveyCampaign::POST_EVENT_ATTENDEE);
+        $user = User::factory()->create(['user_status_id' => 1]);
+        $question = $campaign->questions->firstWhere('key', 'overall_rating');
+
+        $invitation = SurveyInvitation::factory()->create([
+            'survey_campaign_id' => $campaign->id,
+            'user_id' => $user->id,
+        ]);
+
+        $response = SurveyResponse::factory()->create([
+            'survey_invitation_id' => $invitation->id,
+            'survey_campaign_id' => $campaign->id,
+            'user_id' => $user->id,
+        ]);
+
+        $answer = SurveyAnswer::factory()->rating(4)->create([
+            'survey_response_id' => $response->id,
+            'survey_question_id' => $question->id,
+        ]);
+
+        $this->seed(SurveyCampaignsTableSeeder::class);
+
+        $this->assertDatabaseHas('survey_invitations', ['id' => $invitation->id]);
+        $this->assertDatabaseHas('survey_responses', ['id' => $response->id]);
+        $this->assertDatabaseHas('survey_answers', ['id' => $answer->id, 'value_int' => 4]);
+    }
+
+    /** @test */
+    public function invitations_get_a_token_and_are_actionable_by_default(): void
+    {
+        $invitation = SurveyInvitation::factory()->create(['token' => '']);
+
+        $this->assertNotEmpty($invitation->token);
+        $this->assertSame(40, strlen($invitation->token));
+        $this->assertTrue($invitation->isActionable());
+        $this->assertSame($invitation->id, SurveyInvitation::actionable()->first()?->id);
+    }
+
+    /** @test */
+    public function expired_dismissed_completed_and_snoozed_invitations_are_not_actionable(): void
+    {
+        $expired = SurveyInvitation::factory()->expired()->create();
+        $dismissed = SurveyInvitation::factory()->dismissed()->create();
+        $completed = SurveyInvitation::factory()->completed()->create();
+        $snoozed = SurveyInvitation::factory()->snoozed()->create();
+
+        $this->assertFalse($expired->isActionable());
+        $this->assertFalse($dismissed->isActionable());
+        $this->assertFalse($completed->isActionable());
+        $this->assertFalse($snoozed->isActionable());
+
+        $this->assertSame(0, SurveyInvitation::actionable()->count());
+    }
+
+    /** @test */
+    public function the_target_unique_index_prevents_duplicate_invitations(): void
+    {
+        $invitation = SurveyInvitation::factory()->create();
+
+        $duplicate = SurveyInvitation::firstOrCreate([
+            'survey_campaign_id' => $invitation->survey_campaign_id,
+            'user_id' => $invitation->user_id,
+            'subject_type' => $invitation->subject_type,
+            'subject_id' => $invitation->subject_id,
+        ]);
+
+        $this->assertSame($invitation->id, $duplicate->id);
+        $this->assertSame(1, SurveyInvitation::count());
+    }
+
+    /** @test */
+    public function subjectless_invitations_still_dedupe(): void
+    {
+        // NULL-in-unique-index trap: with nullable subject columns MySQL would
+        // treat every subject-less row as distinct and this would insert twice.
+        $invitation = SurveyInvitation::factory()->subjectless()->create();
+
+        $duplicate = SurveyInvitation::firstOrCreate([
+            'survey_campaign_id' => $invitation->survey_campaign_id,
+            'user_id' => $invitation->user_id,
+            'subject_type' => '',
+            'subject_id' => 0,
+        ]);
+
+        $this->assertSame($invitation->id, $duplicate->id);
+        $this->assertSame(1, SurveyInvitation::count());
+    }
+}

--- a/tests/Feature/TwPageRenderSmokeTest.php
+++ b/tests/Feature/TwPageRenderSmokeTest.php
@@ -56,6 +56,8 @@ class TwPageRenderSmokeTest extends TestCase
             'activity index'  => ['/activity'],
             'threads index'   => ['/threads'],
             'users index'     => ['/users'],
+            'feedback responses' => ['/feedback/responses'],
+            'feedback summary'   => ['/feedback/summary'],
         ];
     }
 

--- a/tests/Feature/UserEditUpdateTest.php
+++ b/tests/Feature/UserEditUpdateTest.php
@@ -119,6 +119,46 @@ class UserEditUpdateTest extends TestCase
     }
 
     /** @test */
+    public function unchecking_the_feedback_setting_persists_the_opt_out(): void
+    {
+        // Unchecked checkboxes are simply absent from the POST body, so the
+        // controller has to coerce them to 0 — without that, opting out of
+        // feedback requests silently never saves (issue #1998).
+        $this->withExceptionHandling();
+
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $user->profile()->create(['setting_feedback_requests' => 1]);
+
+        $this->actingAs($user)
+            ->patch(route('users.update', $user->id), [
+                'name' => $user->name,
+                'email' => $user->email,
+            ])
+            ->assertSessionHasNoErrors();
+
+        $this->assertSame(0, (int) $user->fresh()->profile->setting_feedback_requests);
+    }
+
+    /** @test */
+    public function checking_the_feedback_setting_persists_the_opt_in(): void
+    {
+        $this->withExceptionHandling();
+
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $user->profile()->create(['setting_feedback_requests' => 0]);
+
+        $this->actingAs($user)
+            ->patch(route('users.update', $user->id), [
+                'name' => $user->name,
+                'email' => $user->email,
+                'setting_feedback_requests' => 1,
+            ])
+            ->assertSessionHasNoErrors();
+
+        $this->assertSame(1, (int) $user->fresh()->profile->setting_feedback_requests);
+    }
+
+    /** @test */
     public function regular_user_cannot_view_edit_form_for_another_user(): void
     {
         $this->withExceptionHandling();


### PR DESCRIPTION
Closes #1998.

Adds a reusable survey engine plus one working campaign: post-event feedback for users who marked **Attending** on an event that has since finished.

Scoped per the agreed plan — the other campaign types in the issue ("why did you skip", periodic interest polls, promoter outreach) must be possible **without new schema**, but are not built here. Each is a seeder block.

## What's included

| Area | Detail |
|---|---|
| **Schema** | `survey_campaigns`, `survey_questions`, `survey_invitations`, `survey_responses`, `survey_answers`, plus `profiles.setting_feedback_requests` |
| **Generation** | `feedback:generate`, scheduled daily, with `--dry-run` / `--campaign` / `--single-event` / `--lookback-days` / `--limit` |
| **Display** | Alpine modal in `layouts/app-tw`, plus a standalone `/feedback/{token}` page |
| **Admin** | `/feedback/responses` with filters, `/feedback/summary` with averages and histograms, CSV export |
| **Controls** | `FEEDBACK_ENABLED` master flag (defaults **false**) and a per-user opt-out |

Feature flag and opt-out are enforced at **all three** layers the issue implies: generation, display, and submit.

## Design decisions worth reviewing

**Campaigns and questions are seeded DB rows, not config arrays.** `survey_answers` needs a stable FK to a question, and the admin summary is a `JOIN … GROUP BY`. Since every feature test runs `$seed = true`, this also means tests get the campaign for free.

**The seeder uses `updateOrCreate`, deliberately breaking with the other lookup seeders.** Every one of them opens with `DB::table(...)->delete()`; copying that here would cascade-delete all collected feedback on the next seed run. There's a dedicated regression test for this.

**Invitation status is a plain varchar with model constants, not a lookup table.** Every existing lookup table exists because it's admin-manageable and form-selectable. These are internal state-machine values. Conscious deviation — flagging it for review.

**Invitations route by `token`, not `id`.** Prevents enumeration, and it's the handle a future emailed link needs. Together with the `source` column that's the whole deferred-email seam.

**Subject columns are `NOT NULL` with `''`/`0` defaults.** MySQL treats NULLs as distinct in a unique index, so nullable columns would silently make the dedupe constraint a no-op for subject-less campaigns.

**Legacy types.** `users.id`, `events.id` and `visibilities.id` are `int unsigned`, not bigint — `foreignId()` emits `bigint unsigned` and the FK fails to create. References into legacy tables use `unsignedInteger()`.

**Performance.** The layout already calls `shouldSeeOnboarding()` on every authenticated page load. The prompt resolves through a view composer **scoped to `layouts.app-tw`** (not `'*'` — `AppServiceProvider` already registers one of those), guarded in four layers cheapest-first: feature flag → profile opt-out → onboarding mutual exclusion → a 5-minute cache holding an id or `0`. Only a non-zero id triggers hydration.

## Three bugs caught by running it, not by the tests

1. **Chunking silently dropped candidates.** The candidate query filters on `survey_invitations.id is null` and the run inserts exactly those rows, so OFFSET-based `chunk()` walked off a shrinking result set. Demonstrated concretely: 7 eligible attendees → only 4 invitations created. Fixed; the regression test fails against the old code. (Later replaced by `cursor()` — see post-review additions.)
2. **`--dry-run` overstated by ~6x.** Against real dev data it claimed 47 invitations where a real run creates 8, because with nothing written the per-user volume caps never engaged. Now tracks grants in-memory during a dry run.
3. **An unwritable cache took the whole feature down.** `Cache::remember` threw and killed the generator. These caches sit over single indexed reads and one runs on every authenticated page load, so they now log and fall back to a direct query.

## Verification

- **1340 tests pass**, full suite, no failures.
- **PHPStan (Larastan level 3) clean**, no baseline additions.
- `EXPLAIN` against dev data confirms the indexable pre-filter works — `events` resolves `type=range key=idx_start_at`, `event_responses` by `ref`, and the dedupe join uses `survey_invitations_target_unique`.
- `feedback:generate --dry-run` against the dev database reports `47 candidate(s), 8 invitation(s) would be created, 39 skipped by volume caps`.

New test files: `SurveyCampaignSeedTest`, `FeedbackInvitationGenerationTest`, `FeedbackPromptTest`, `FeedbackAdminTest`, `Services/DataExportUserDataTest`. Updated: `UserEditUpdateTest`, `TwPageRenderSmokeTest`.

## Deploy notes

`FEEDBACK_ENABLED` defaults to **false**, so this ships inert. To turn it on:

```bash
php artisan migrate
php artisan db:seed --class=SurveyCampaignsTableSeeder   # required — migrations create empty tables
php artisan route:clear
# then set FEEDBACK_ENABLED=true and php artisan config:clear
```

The dark-launch default is intentional, but it does mean the feature can ship and quietly never run — hence the `.env.example` entry.

## Out of scope, stated deliberately

- **The legacy `resources/views/app.blade.php` layout does not get the prompt.** It's used by 19 secondary views, has no Alpine loaded, and already omits the onboarding modal. The standalone `/feedback/{token}` page is the universal fallback.
- **Email delivery is deferred.** A later `feedback:notify` command targeting `source = 'email'` invitations needs no schema change — that's what `token` and `source` are for.
- **Relationship to Event Reviews.** Kept separate on purpose: reviews are unsolicited, public, editorial; feedback is solicited, private-by-default, structured, campaign-driven. The summary page cross-links to `/reviews`. Separately, that feature turns out to be substantially broken — see #2063.

## Post-review additions

Four rounds of changes after the branch was first opened, all driven by testing it in dev.

**"I did not attend" branch.** The form now opens with a required *"Did you make it to this one?"* gate — invitations go to everyone who marked Attending, but plenty won't have gone, and "how was the sound?" is meaningless if they weren't there. Answering **no** swaps the rating/liked/want-more questions for an optional reason list (cost, timing, lineup, venue, distance, transport, weather, illness, plans changed, forgot, other) plus an optional free-text why.

Built as a generic conditional-question mechanism rather than a special case — `survey_questions` gained `depends_on_key` / `depends_on_value` — because the deferred "why did you skip this event" campaign needs exactly the same thing. Validation uses `exclude_unless`, so a question whose branch isn't taken is dropped from the payload entirely: `is_required` reads as "required when shown", and a stale client value (a rating entered before switching the gate to "no") can't be stored against the wrong branch. Tested both directions.

**Multiple events per user.** Simulating a user who attended three events in one week showed only two ever got asked about — the third aged out of the 14-day lookback window while waiting on a 7-day cooldown. Three changes:

- `max_pending_per_user` 1 → 3. This is the actual fix: the lookback window governs invitation *creation*, while an invitation lives 30 days once it exists, so queueing up front decouples them from the window. It's a queue depth, not a display limit.
- The cooldown now keys off **dismissal only**, not completion. Someone who just answered is engaged and can clear their queue immediately; someone who dismissed still gets a full week of quiet.
- Candidates order by event recency, so the freshest event is asked about first. Previously the pick came out in `event_responses.id` order — whichever event they happened to RSVP to first, unrelated to when it happened.

The recency ordering meant dropping `chunkById` (it must order by its own cursor column). Iteration now uses `cursor()`: a single snapshot fixed at execute time, equally safe against the self-inserting-rows problem `chunkById` was solving. PDO MySQL is buffered by default here, so writes during iteration are fine.

**Queue UI.** The payload carries `queue.remaining`, and the modal shows a **"1 of 3"** badge when more than one is queued. The submit button reads **"Send & next"** until the last. Submitting returns the next invitation inline as `next`, so advancing costs no extra round trip and needs no page reload; `null` closes the modal as before. Confirmed working in a real browser — three invitations cleared in about 90 seconds, with the handed-back invitation marked shown in the same second the previous one completed.

**Modal now leads with the event.** Flyer thumbnail beside a bold event title, with date and venue beneath; the campaign name drops to a small muted label. Each element degrades independently when an event has no flyer or no venue. The morph subject is eager-loaded via `morphWith([Event::class => ['venue', 'photos']])` so reading them doesn't add two queries per authenticated page render.

**Verification after all of the above:** 1340 tests pass, PHPStan clean.

## Deploy note, updated

There are now **four** migrations. The seeded question set changed, so the seeder must be re-run on any environment that already had it — it is idempotent and preserves collected feedback.

One caveat for existing data: responses collected before the gate have no `attended` answer, so an admin summary spanning both shapes mixes them. Only affects rows collected during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
