### PR TITLE
Fix: coerce explicit-null boolean fields to false on API event PUT [EVENTREPO-XH]

### DIFF
--- a/app/Http/Controllers/Api/EventsController.php
+++ b/app/Http/Controllers/Api/EventsController.php
@@ -1080,11 +1080,19 @@ class EventsController extends Controller
 
         $nonNullableBooleans = $this->nonNullableBooleanEventFields();
         foreach ($this->optionalEventFields() as $field) {
+            $isNonNullableBoolean = in_array($field, $nonNullableBooleans, true);
+
             if (!array_key_exists($field, $input)) {
                 // Boolean fields are backed by NOT NULL columns, so an omitted
                 // field resets to false (0) rather than null to avoid an
                 // integrity constraint violation.
-                $input[$field] = in_array($field, $nonNullableBooleans, true) ? false : null;
+                $input[$field] = $isNonNullableBoolean ? false : null;
+            } elseif ($isNonNullableBoolean && null === $input[$field]) {
+                // These columns carry no validation rule, so a body that sends
+                // the key with an explicit null still reaches fill() as null and
+                // trips the same NOT NULL constraint. Coerce it to false too
+                // (EVENTREPO-XH).
+                $input[$field] = false;
             }
         }
 

--- a/tests/Feature/ApiEventsCrudTest.php
+++ b/tests/Feature/ApiEventsCrudTest.php
@@ -114,6 +114,33 @@ class ApiEventsCrudTest extends TestCase
         $this->assertFalse((bool) $fresh->do_not_repost);
     }
 
+    public function test_update_coerces_explicit_null_boolean_fields_to_false(): void
+    {
+        $event = Event::factory()->create([
+            'created_by' => $this->user->id,
+            'slug' => 'zz-benefit-null-target-'.uniqid(),
+            'is_benefit' => 1,
+            'do_not_repost' => 1,
+        ]);
+
+        // PUT payload sends the boolean keys with an explicit null. Those
+        // columns are NOT NULL and carry no validation rule, so without
+        // coercion fill() would set null and trip an integrity constraint
+        // violation (EVENTREPO-XH).
+        $payload = $this->validPayload([
+            'slug' => $event->slug,
+            'is_benefit' => null,
+            'do_not_repost' => null,
+        ]);
+
+        $response = $this->putJson('/api/events/'.$event->slug, $payload);
+
+        $response->assertOk();
+        $fresh = $event->fresh();
+        $this->assertSame(0, (int) $fresh->is_benefit);
+        $this->assertFalse((bool) $fresh->do_not_repost);
+    }
+
     public function test_update_refuses_when_not_creator(): void
     {
         $other = User::factory()->create();


### PR DESCRIPTION
Follow-up to the merged PR #2056, addressing a distinct, still-live path of the same Sentry issue.

**Sentry:** [EVENTREPO-XH](https://sentry.io/organizations/geoff-maddock/issues/7648438008/) — `Illuminate\Database\QueryException: SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'is_benefit' cannot be null` on `PUT /api/events/{event}`.

## Error

`App\Http\Controllers\Api\EventsController::update` (line ~1085) fills the model with request input and saves. `is_benefit` and `do_not_repost` are backed by **NOT NULL** columns, so a null value trips an integrity-constraint violation.

## Root cause (confirmed from the Sentry event body)

PR #2056 reset these booleans to `false` only when the key was **omitted** from the body:

```php
if (!array_key_exists($field, $input)) {
    $input[$field] = $isNonNullableBoolean ? false : null;
}
```

But the failing request sent the keys **present with an explicit null** (`"is_benefit": null`, `"do_not_repost": null`). `array_key_exists()` is then `true`, so the reset was skipped and `fill()` set the column to null. `EventRequest` has **no validation rule** for either field, so nothing rejected the null upstream. The issue's `lastSeen` (2026-08-04) is after the #2056 fix commit (2026-08-03), consistent with this uncovered path still firing.

## Change

Extend the existing coercion loop so an explicit `null` on a non-nullable boolean field is also coerced to `false`:

```php
} elseif ($isNonNullableBoolean && null === $input[$field]) {
    $input[$field] = false;
}
```

This is strictly safer — a NOT NULL boolean column can never legitimately take null — and completes the omit-case guard added in #2056.

## What changed

- `app/Http/Controllers/Api/EventsController.php` — coerce explicit-null non-nullable booleans to `false` in `update()`.
- `tests/Feature/ApiEventsCrudTest.php` — new regression test `test_update_coerces_explicit_null_boolean_fields_to_false` sending an explicit-null payload (companion to the existing omit-case test).

## Verification

Dependencies could not be installed in the triage sandbox (no MySQL, composer install timed out), so the full `composer tests` / PHPStan run is left to CI. `php -l` passes on both changed files. The change is a minimal, type-safe addition to an existing loop.

## Note

The `patch()` (PATCH) handler fills `is_benefit`/`do_not_repost` directly without this guard and shares the same latent exposure, but the reported Sentry issue is the PUT path only, so it is left unchanged to keep this diff minimal. Flagging for a possible separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nkroUxeLxvLtjMVY4NKge

---
_Generated by [Claude Code](https://claude.ai/code/session_013nkroUxeLxvLtjMVY4NKge)_