### PR TITLE
Fix event cards loading a full playlist of embeds on entity pages

### DIFF
--- a/public/js/custom.js
+++ b/public/js/custom.js
@@ -16,11 +16,15 @@ var App = (function () {
     // load embeded audio code with caching support
     var loadEmbeds = function () {
         $('body div.playlist-id').each(function (e) {
-            var url = $(this).attr('data-url');
-            var target = $(this).attr('id');
-            var slug = $(this).attr('data-slug');
-            var resourceType = $(this).attr('data-resource-type') || 'events';
-            var endpoint = $(this).attr('data-endpoint') || 'minimal-embeds';
+            // Hold onto the element itself rather than looking it back up by id:
+            // a page can carry more than one placeholder with the same id (e.g. an
+            // entity page whose event card and Audio section both key off the same
+            // record), and $('#id') would resolve every loader to the first match.
+            var $container = $(this);
+            var url = $container.attr('data-url');
+            var slug = $container.attr('data-slug');
+            var resourceType = $container.attr('data-resource-type') || 'events';
+            var endpoint = $container.attr('data-endpoint') || 'minimal-embeds';
 
             // Use EmbedLoader with caching if available and slug is provided
             if (typeof EmbedLoader !== 'undefined' && slug) {
@@ -28,13 +32,17 @@ var App = (function () {
                     endpoint: endpoint,
                     onSuccess: function (embeds) {
                         if (embeds && embeds.length > 0) {
-                            var html = embeds.map(function (embed) {
+                            // Cards render at most one player. The server caps this too,
+                            // but localStorage entries cached before that cap can still
+                            // hold several, so trim here as well.
+                            var list = endpoint === 'embeds' ? embeds : embeds.slice(0, 1);
+                            var html = list.map(function (embed) {
                                 return endpoint === 'embeds'
                                     ? '<div class="rounded-md overflow-hidden">' + embed + '</div>'
                                     : embed;
                             }).join('');
-                            $('#' + target).html(html);
-                            $('#' + target).removeClass('playlist-id hidden');
+                            $container.html(html);
+                            $container.removeClass('playlist-id hidden');
                         }
                     },
                     onError: function () {
@@ -48,8 +56,8 @@ var App = (function () {
                 }).done(function (data) {
                     // load results into the applicable position if data exists
                     if (data.Success && data.Success.trim() !== '') {
-                        $('#' + target).html(data.Success);
-                        $('#' + target).removeClass('playlist-id hidden');
+                        $container.html(data.Success);
+                        $container.removeClass('playlist-id hidden');
                     }
                 }).fail(function () {
                     console.log('No event embeds could be loaded')

--- a/resources/views/embeds/minimal-playlist.blade.php
+++ b/resources/views/embeds/minimal-playlist.blade.php
@@ -15,8 +15,11 @@
     @endforeach
 </div>
 @else
+    {{-- @elseif, not three independent @ifs: @include inherits the caller's scope, so a
+         stray $event/$entity from a surrounding @foreach must not render a second
+         placeholder alongside the subject the caller actually passed. --}}
     @if (isset($event) && is_object($event) && !($event instanceof \Illuminate\Pagination\LengthAwarePaginator))
-        <div id="playlist-{{ $event->id}}" class="playlist-id rounded-lg border bg-card shadow p-4 hidden" data-url="/events/{{ $event->id }}/load-minimal-embeds" data-slug="{{ $event->slug }}" data-resource-type="events">
+        <div id="playlist-events-{{ $event->id}}" class="playlist-id rounded-lg border bg-card shadow p-4 hidden" data-url="/events/{{ $event->id }}/load-minimal-embeds" data-slug="{{ $event->slug }}" data-resource-type="events">
             <div class="flex items-center justify-center py-4">
                 <div class="load-spinner">
                     <div class="double-bounce1"></div>
@@ -24,9 +27,8 @@
                 </div>
             </div>
         </div>
-    @endif
-    @if (isset($series) && is_object($series) && !($series instanceof \Illuminate\Pagination\LengthAwarePaginator))
-        <div id="playlist-{{ $series->id}}" class="playlist-id rounded-lg border bg-card shadow p-4 hidden" data-url="/series/{{ $series->id }}/load-minimal-embeds" data-slug="{{ $series->slug }}" data-resource-type="series">
+    @elseif (isset($series) && is_object($series) && !($series instanceof \Illuminate\Pagination\LengthAwarePaginator))
+        <div id="playlist-series-{{ $series->id}}" class="playlist-id rounded-lg border bg-card shadow p-4 hidden" data-url="/series/{{ $series->id }}/load-minimal-embeds" data-slug="{{ $series->slug }}" data-resource-type="series">
             <div class="flex items-center justify-center py-4">
                 <div class="load-spinner">
                     <div class="double-bounce1"></div>
@@ -34,9 +36,8 @@
                 </div>
             </div>
         </div>
-    @endif
-    @if (isset($entity) && is_object($entity) && !($entity instanceof \Illuminate\Pagination\LengthAwarePaginator))
-        <div id="playlist-{{ $entity->id}}" class="playlist-id rounded-lg border bg-card shadow p-4 hidden {{ $entity->name }}" data-url="/entities/{{ $entity->id }}/load-minimal-embeds" data-slug="{{ $entity->slug }}" data-resource-type="entities">
+    @elseif (isset($entity) && is_object($entity) && !($entity instanceof \Illuminate\Pagination\LengthAwarePaginator))
+        <div id="playlist-entities-{{ $entity->id}}" class="playlist-id rounded-lg border bg-card shadow p-4 hidden {{ $entity->name }}" data-url="/entities/{{ $entity->id }}/load-minimal-embeds" data-slug="{{ $entity->slug }}" data-resource-type="entities">
             <div class="flex items-center justify-center py-4">
                 <div class="load-spinner">
                     <div class="double-bounce1"></div>

--- a/resources/views/embeds/playlist-tw.blade.php
+++ b/resources/views/embeds/playlist-tw.blade.php
@@ -17,7 +17,11 @@
 
 @else
 
-    @if (isset($event))
+    {{-- Exactly one subject renders. The branches are @elseif rather than three
+         independent @ifs because @include inherits the caller's scope, so a stray
+         $event/$entity left over from a surrounding @foreach must not add a second
+         placeholder alongside the one the caller actually asked for. --}}
+    @if (isset($event) && is_object($event))
         @php
             // Estimate embed count from the event description URLs + related entity links.
             $expectedEmbedCount = 0;
@@ -41,7 +45,7 @@
             }
         @endphp
         @if ($expectedEmbedCount > 0)
-        <div id="playlist-{{ $event->id}}" class="playlist-id rounded-lg border bg-card shadow p-6" data-url="/events/{{ $event->id }}/load-embeds" data-slug="{{ $event->slug }}" data-resource-type="events" data-endpoint="embeds" style="min-height: {{ 80 + $expectedEmbedCount * 148 }}px;">
+        <div id="playlist-events-{{ $event->id}}" class="playlist-id rounded-lg border bg-card shadow p-6" data-url="/events/{{ $event->id }}/load-embeds" data-slug="{{ $event->slug }}" data-resource-type="events" data-endpoint="embeds" style="min-height: {{ 80 + $expectedEmbedCount * 148 }}px;">
             <div class="flex items-center gap-2 mb-4">
                 <i class="bi bi-music-note-beamed text-lg"></i>
                 <h2 class="text-xl font-semibold">Audio</h2>
@@ -54,8 +58,7 @@
             </div>
         </div>
         @endif
-    @endif
-    @if (isset($entity))
+    @elseif (isset($entity) && is_object($entity))
         @php
             // Estimate embed count to reserve space and avoid layout shift when the
             // deferred AJAX response replaces this placeholder. Medium-size iframes
@@ -71,7 +74,7 @@
             }
         @endphp
         @if ($expectedEmbedCount > 0)
-        <div id="playlist-{{ $entity->id}}" class="playlist-id rounded-lg border bg-card shadow p-6" data-url="/entities/{{ $entity->id }}/load-embeds" data-slug="{{ $entity->slug }}" data-resource-type="entities" data-endpoint="embeds" style="min-height: {{ 80 + $expectedEmbedCount * 148 }}px;">
+        <div id="playlist-entities-{{ $entity->id}}" class="playlist-id rounded-lg border bg-card shadow p-6" data-url="/entities/{{ $entity->id }}/load-embeds" data-slug="{{ $entity->slug }}" data-resource-type="entities" data-endpoint="embeds" style="min-height: {{ 80 + $expectedEmbedCount * 148 }}px;">
             <div class="flex items-center gap-2 mb-4">
                 <i class="bi bi-music-note-beamed text-lg"></i>
                 <h2 class="text-xl font-semibold">Audio</h2>
@@ -84,8 +87,7 @@
             </div>
         </div>
         @endif
-    @endif
-    @if (isset($series))
+    @elseif (isset($series) && is_object($series))
         @php
             $expectedEmbedCount = 0;
             $regex = "/\b(?:(?:https|ftp):\/\/|www\.)[-a-z0-9+&@#\/%?=~_|!:,.;]*[-a-z0-9+&@#\/%=~_|]/i";
@@ -108,7 +110,7 @@
             }
         @endphp
         @if ($expectedEmbedCount > 0)
-        <div id="playlist-{{ $series->id}}" class="playlist-id rounded-lg border bg-card shadow p-6" data-url="/series/{{ $series->id }}/load-embeds" data-slug="{{ $series->slug }}" data-resource-type="series" data-endpoint="embeds" style="min-height: {{ 80 + $expectedEmbedCount * 148 }}px;">
+        <div id="playlist-series-{{ $series->id}}" class="playlist-id rounded-lg border bg-card shadow p-6" data-url="/series/{{ $series->id }}/load-embeds" data-slug="{{ $series->slug }}" data-resource-type="series" data-endpoint="embeds" style="min-height: {{ 80 + $expectedEmbedCount * 148 }}px;">
             <div class="flex items-center gap-2 mb-4">
                 <i class="bi bi-music-note-beamed text-lg"></i>
                 <h2 class="text-xl font-semibold">Audio</h2>

--- a/resources/views/embeds/playlist.blade.php
+++ b/resources/views/embeds/playlist.blade.php
@@ -17,8 +17,11 @@
 
 @else
 
-    @if (isset($event))
-        <div id="playlist-{{ $event->id}}" class="playlist-id rounded-lg border bg-card shadow p-6" data-url="/events/{{ $event->id }}/load-embeds" data-slug="{{ $event->slug }}" data-resource-type="events" data-endpoint="embeds">
+    {{-- @elseif, not three independent @ifs: @include inherits the caller's scope, so a
+         stray $event/$entity from a surrounding @foreach must not render a second
+         placeholder alongside the subject the caller actually passed. --}}
+    @if (isset($event) && is_object($event))
+        <div id="playlist-events-{{ $event->id}}" class="playlist-id rounded-lg border bg-card shadow p-6" data-url="/events/{{ $event->id }}/load-embeds" data-slug="{{ $event->slug }}" data-resource-type="events" data-endpoint="embeds">
             <div class="flex items-center gap-2 mb-4">
                 <i class="bi bi-music-note-beamed text-lg"></i>
                 <h3 class="text-xl font-semibold">Audio</h3>
@@ -30,9 +33,8 @@
                 </div>
             </div>
         </div>
-    @endif
-    @if (isset($entity))
-        <div id="playlist-{{ $entity->id}}" class="playlist-id rounded-lg border bg-card shadow p-6" data-url="/entities/{{ $entity->id }}/load-embeds" data-slug="{{ $entity->slug }}" data-resource-type="entities" data-endpoint="embeds">
+    @elseif (isset($entity) && is_object($entity))
+        <div id="playlist-entities-{{ $entity->id}}" class="playlist-id rounded-lg border bg-card shadow p-6" data-url="/entities/{{ $entity->id }}/load-embeds" data-slug="{{ $entity->slug }}" data-resource-type="entities" data-endpoint="embeds">
             <div class="flex items-center gap-2 mb-4">
                 <i class="bi bi-music-note-beamed text-lg"></i>
                 <h3 class="text-xl font-semibold">Audio</h3>
@@ -44,9 +46,8 @@
                 </div>
             </div>
         </div>
-    @endif
-    @if (isset($series))
-        <div id="playlist-{{ $series->id}}" class="playlist-id rounded-lg border bg-card shadow p-6" data-url="/series/{{ $series->id }}/load-embeds" data-slug="{{ $series->slug }}" data-resource-type="series" data-endpoint="embeds">
+    @elseif (isset($series) && is_object($series))
+        <div id="playlist-series-{{ $series->id}}" class="playlist-id rounded-lg border bg-card shadow p-6" data-url="/series/{{ $series->id }}/load-embeds" data-slug="{{ $series->slug }}" data-resource-type="series" data-endpoint="embeds">
             <div class="flex items-center gap-2 mb-4">
                 <i class="bi bi-music-note-beamed text-lg"></i>
                 <h3 class="text-xl font-semibold">Audio</h3>

--- a/resources/views/entities/card-tw.blade.php
+++ b/resources/views/entities/card-tw.blade.php
@@ -113,7 +113,7 @@
 
 		<!-- Embeds (lazy-loaded) -->
 		<div id="card-entity-minimal-playlist">
-		@include('embeds.minimal-playlist', ['entity' => $entity])
+		@include('embeds.minimal-playlist', ['entity' => $entity, 'event' => null, 'series' => null])
 		</div>
 
 		<!-- Action Icons Footer -->

--- a/resources/views/entities/show-tw.blade.php
+++ b/resources/views/entities/show-tw.blade.php
@@ -185,7 +185,10 @@
 
 		<!-- Audio -->
 		@if ($entity->entityType && $entity->entityType->name !== 'Space')
-		@include('embeds.playlist-tw', ['entity' => $entity, 'embeds' => $embeds ?? []])
+		{{-- event/series are nulled explicitly: the Upcoming Events @foreach above leaves
+		     $event defined in this scope, and @include inherits it, so the partial would
+		     otherwise render the last card's full event playlist instead of the entity's. --}}
+		@include('embeds.playlist-tw', ['entity' => $entity, 'event' => null, 'series' => null, 'embeds' => $embeds ?? []])
 		@endif
 
 		<!-- Frequently Performs With / At -->

--- a/resources/views/entities/single.blade.php
+++ b/resources/views/entities/single.blade.php
@@ -119,5 +119,5 @@
 		@endif
 	</ul>
 	@php unset($series) @endphp
-	@include('embeds.minimal-playlist', ['entity' => $entity])
+	@include('embeds.minimal-playlist', ['entity' => $entity, 'event' => null, 'series' => null])
 </li>

--- a/resources/views/events/card-tw.blade.php
+++ b/resources/views/events/card-tw.blade.php
@@ -178,7 +178,7 @@
 
     <!-- Embeds (lazy-loaded) -->
     <div id="card-event-minimal-playlist">
-        @include('embeds.minimal-playlist', ['event' => $event, 'entity' => null])
+        @include('embeds.minimal-playlist', ['event' => $event, 'entity' => null, 'series' => null])
     </div>
 
     <!-- Card Footer Actions -->

--- a/resources/views/events/show-tw.blade.php
+++ b/resources/views/events/show-tw.blade.php
@@ -386,7 +386,7 @@
 					
 					
                     <!-- Audio Section -->
-					@include('embeds.playlist-tw', ['event' => $event, 'entity' => null])
+					@include('embeds.playlist-tw', ['event' => $event, 'entity' => null, 'series' => null])
 
 				</div>
 			</div>

--- a/resources/views/events/single.blade.php
+++ b/resources/views/events/single.blade.php
@@ -166,5 +166,5 @@
 	</div>
 
 	@php unset($series) @endphp
-	@include('embeds.minimal-playlist', ['event' => $event])
+	@include('embeds.minimal-playlist', ['event' => $event, 'entity' => null, 'series' => null])
 </li>

--- a/resources/views/series/show-tw.blade.php
+++ b/resources/views/series/show-tw.blade.php
@@ -326,7 +326,7 @@
 		@include('partials.photo-gallery-tw', ['series' => $series, 'entity' => null, 'event' => null, 'lightboxGroup' => 'series-gallery'])
 
 		<!-- Audio Section -->
-		@include('embeds.playlist', ['series' => $series])
+		@include('embeds.playlist', ['series' => $series, 'event' => null, 'entity' => null])
 	</div>
 </div>
 

--- a/resources/views/series/single.blade.php
+++ b/resources/views/series/single.blade.php
@@ -127,5 +127,5 @@
         @endunless
     </P>
 
-	@include('embeds.minimal-playlist', ['series' => $series])
+	@include('embeds.minimal-playlist', ['series' => $series, 'event' => null, 'entity' => null])
 </li>


### PR DESCRIPTION
## Problem

On entity show pages such as [/entities/steel-city-dungeon-synth](https://arcane.city/entities/steel-city-dungeon-synth), the event cards under **Upcoming Events** filled up with a stack of full-size music players, and the page's own **Audio** section never finished loading — it just spun.

The card itself was never the thing loading them. It was being written into by the Audio section's loader.

## Root cause

Two bugs compounding:

1. **Leaked loop variable.** `entities/show-tw.blade.php` renders Upcoming Events in `@foreach ($relatedEvents as $event)`. PHP leaves `$event` defined after the loop, and Blade's `@include` inherits the caller's scope. The Audio section below it included `embeds/playlist-tw` with only `entity` — but that partial checks `@if (isset($event))` **first**, so it matched the leaked loop variable and rendered the *event's* full-size playlist placeholder (`data-endpoint="embeds"`, `min-height: 672px` ≈ 4 players) instead of the entity's.

2. **Duplicate DOM ids.** Both placeholders then carried the same id, `playlist-8805`. `custom.js` wrote its results back with `$('#' + target)`, which resolves to the **first** match — the event card's minimal container. So all four full-size players landed inside the card, and the real Audio section kept its spinner.

The three `@if (isset($event)) / @if (isset($entity)) / @if (isset($series))` branches in the embed partials were also independent rather than mutually exclusive, so a stray loop variable could add a second placeholder alongside the one the caller actually asked for. `tags/show-tw.blade.php` was already passing explicit nulls to work around this, which is a decent sign it had bitten before.

## Changes

- **`public/js/custom.js`** — hold the element reference (`$container = $(this)`) rather than re-looking it up by id, so duplicate ids can never cross-write. Also slice `minimal-embeds` results to one client-side: the server already caps this, but `localStorage` entries cached before that cap (7-day TTL) can still hold several.
- **`embeds/playlist-tw`, `embeds/playlist`, `embeds/minimal-playlist`** — branches are now `@if/@elseif` with `is_object()` guards, so exactly one subject renders.
- **Placeholder ids namespaced by resource type** — `playlist-events-<id>`, `playlist-entities-<id>`, `playlist-series-<id>`.
- **Every `@include` of these partials names its subject and nulls the other two**, so an inherited variable can't win.

## Verification

Rendered against dev:

- `/entities/keebs` (an entity with upcoming events *and* audio links) now renders two per-card minimal placeholders plus one `playlist-entities-17` for its own Audio section, sized for its single embed.
- Ids are unique across `/events`, `/entities`, `/series/lazercrunk`, `/popular`, and `/search`; one placeholder per card, correct resource type per subject.
- `/events/{slug}/minimal-embeds` and `/events/{slug}/embeds` return the expected counts.

Tests: 34 passing across `EventEmbedsTest`, `EntitiesTest`, `VenueEntityPageTest`, `UserAttendingEventsCardTest`.

## Deploy note

Guest event cards are fragment-cached for 6 hours, so some cards will keep the old un-namespaced ids until those expire. Harmless — the JS change means the loader targets its own element rather than resolving by id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)