### PR TITLE
Fix silent sitemap write failures; expand page and thread coverage

### DIFF
--- a/app/Console/Commands/GenerateSitemap.php
+++ b/app/Console/Commands/GenerateSitemap.php
@@ -7,10 +7,12 @@ use App\Models\Entity;
 use App\Models\Event;
 use App\Models\Series;
 use App\Models\Tag;
+use App\Models\Thread;
 use App\Models\Visibility;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Model;
+use RuntimeException;
 use Spatie\Sitemap\Sitemap;
 use Spatie\Sitemap\SitemapIndex;
 use Spatie\Sitemap\Tags\Sitemap as SitemapTag;
@@ -39,6 +41,20 @@ class GenerateSitemap extends Command
 
     /**
      * Static landing pages worth indexing. Keep in sync with routes/web.php.
+     *
+     * A page belongs here only if it is reachable by a guest, self-canonical,
+     * not noindexed, and not covered by a robots.txt Disallow rule. Notable
+     * deliberate omissions:
+     *  - /events/future — same listing as /events under a second URL
+     *  - /tools, /radar, /job-status — redirect guests to /login
+     *  - /search — Disallow'd in robots.txt
+     *  - /activity, /all-modules — churn/internal nav, nothing to rank
+     *
+     * The four time-window pages stay despite overlapping: each is a distinct
+     * range with its own title targeting a distinct query. Note that today and
+     * tonight return the same events on roughly 2/3 of the days that have any,
+     * because almost everything here starts after 17:00 — differentiating them
+     * is a content problem, not a reason to drop one from the sitemap.
      */
     protected const PAGES = [
         '/',
@@ -47,24 +63,40 @@ class GenerateSitemap extends Command
         '/events/today',
         '/events/this-weekend',
         '/events/this-week',
+        '/events/week',
+        '/events/past',
         '/entities',
         '/series',
+        '/series/week',
         '/tags',
         '/blogs',
+        '/threads',
         '/calendar',
+        '/calendar/free',
+        '/popular',
+        '/about',
+        '/help',
+        '/privacy',
+        '/tos',
     ];
 
     protected string $baseUrl;
+
+    /**
+     * Ids dropped by slugUrls(), keyed by section. Reported at the end so bad
+     * slug data surfaces instead of silently shrinking the sitemap.
+     *
+     * @var array<string, array<int|string>>
+     */
+    protected array $skipped = [];
 
     public function handle(): int
     {
         $path = rtrim($this->option('path') ?: public_path(), '/');
         $this->baseUrl = rtrim(config('app.url'), '/');
 
-        $this->info('Generating sitemaps for '.$this->baseUrl.' into '.$path);
-
-        $index = SitemapIndex::create();
-
+        // All seven are generators, so building the map runs no queries — the
+        // writability check below still happens before any real work.
         $sections = [
             'pages' => $this->pageUrls(),
             'events' => $this->eventUrls(),
@@ -72,10 +104,33 @@ class GenerateSitemap extends Command
             'series' => $this->seriesUrls(),
             'tags' => $this->tagUrls(),
             'blogs' => $this->blogUrls(),
+            'threads' => $this->threadUrls(),
         ];
 
+        if ($problem = $this->writabilityProblem($path, array_keys($sections))) {
+            $this->error($problem);
+
+            return self::FAILURE;
+        }
+
+        $this->info('Generating sitemaps for '.$this->baseUrl.' into '.$path);
+
+        $index = SitemapIndex::create();
+
         foreach ($sections as $name => $urls) {
-            foreach ($this->writeChunked($name, $urls, $path) as [$file, $count, $lastmod]) {
+            $written = $this->writeChunked($name, $urls, $path);
+
+            if ($skipped = $this->skipped[$name] ?? []) {
+                $this->warn(sprintf(
+                    '  %s: skipped %d row(s) with an unusable slug (ids: %s%s)',
+                    $name,
+                    count($skipped),
+                    implode(', ', array_slice($skipped, 0, 5)),
+                    count($skipped) > 5 ? ', …' : ''
+                ));
+            }
+
+            foreach ($written as [$file, $count, $lastmod]) {
                 $entry = SitemapTag::create($this->baseUrl.'/'.$file);
                 if ($lastmod) {
                     $entry->setLastModificationDate($lastmod);
@@ -86,9 +141,81 @@ class GenerateSitemap extends Command
         }
 
         $index->writeToFile($path.'/sitemap.xml');
+        $this->assertWritten($path.'/sitemap.xml');
         $this->info('Wrote sitemap index to '.$path.'/sitemap.xml');
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Spatie's writeToFile() is a bare file_put_contents(): on a permission
+     * problem it only raises a warning, so the command would otherwise leave a
+     * partial (or entirely stale) set of sitemaps behind and still exit 0.
+     * Check the directory and any files we are about to overwrite up front —
+     * before spending the query budget — and fail properly instead.
+     *
+     * Returns a human-readable problem description, or null if all is well.
+     *
+     * @param array<string> $sections
+     */
+    protected function writabilityProblem(string $path, array $sections): ?string
+    {
+        if (! is_dir($path)) {
+            return 'Sitemap directory does not exist: '.$path;
+        }
+
+        $stale = array_filter(
+            (array) glob($path.'/sitemap*.xml'),
+            fn ($file) => ! is_writable($file)
+        );
+
+        if ($stale !== []) {
+            return sprintf(
+                'Existing sitemap files are not writable by %s: %s — see docs/deployment_notes.md',
+                get_current_user(),
+                implode(', ', array_map('basename', $stale))
+            );
+        }
+
+        // Replacing a file needs write permission on the file itself; only
+        // *creating* one needs it on the directory. So an unwritable directory
+        // is fatal just when something we are about to write does not exist.
+        if (! is_writable($path)) {
+            $expected = array_map(fn ($name) => 'sitemap-'.$name.'.xml', $sections);
+            $expected[] = 'sitemap.xml';
+
+            $missing = array_values(array_filter(
+                $expected,
+                fn ($file) => ! file_exists($path.'/'.$file)
+            ));
+
+            if ($missing !== []) {
+                return sprintf(
+                    'Sitemap directory %s is not writable by %s and these files must be created: %s — see docs/deployment_notes.md',
+                    $path,
+                    get_current_user(),
+                    implode(', ', $missing)
+                );
+            }
+
+            $this->warn('Directory is not writable: existing sitemaps can be replaced, but additional chunk files could not be created if a section outgrows one file.');
+        }
+
+        return null;
+    }
+
+    /**
+     * writeToFile() swallows failures, so confirm something actually landed on
+     * disk. Covers what the up-front check cannot predict — a chunk file that
+     * did not exist yet, a full disk, a read-only remount mid-run.
+     */
+    protected function assertWritten(string $file): void
+    {
+        clearstatcache(true, $file);
+
+        if (! is_file($file) || filesize($file) === 0) {
+            throw new RuntimeException('Failed to write '.$file.' — check permissions and free disk space.');
+        }
     }
 
     /**
@@ -112,6 +239,7 @@ class GenerateSitemap extends Command
             }
             $file = 'sitemap-'.$name.($chunk > 1 ? '-'.$chunk : '').'.xml';
             $sitemap->writeToFile($path.'/'.$file);
+            $this->assertWritten($path.'/'.$file);
             $files[] = [$file, $count, $lastmod];
             $sitemap = Sitemap::create();
             $count = 0;
@@ -222,6 +350,48 @@ class GenerateSitemap extends Command
     }
 
     /**
+     * Threads are id-routed: unlike Event and Entity, Thread has no
+     * getRouteKeyName() override, so /threads/{slug} 404s and the canonical
+     * URL is /threads/{id} — which is what the thread index links to.
+     *
+     * @return iterable<Url>
+     */
+    protected function threadUrls(): iterable
+    {
+        $query = Thread::query()
+            ->where('visibility_id', Visibility::VISIBILITY_PUBLIC)
+            ->select(['id', 'updated_at']);
+
+        foreach ($this->idUrls($query, 'threads') as $url) {
+            yield $url;
+        }
+    }
+
+    /**
+     * Yield canonical URLs for a model query routed by primary key.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder<covariant Model> $query
+     * @return iterable<Url>
+     */
+    protected function idUrls($query, string $prefix): iterable
+    {
+        $urls = [];
+
+        $query->chunkById(1000, function ($models) use (&$urls, $prefix) {
+            foreach ($models as $model) {
+                $url = Url::create($this->baseUrl.'/'.$prefix.'/'.$model->getKey());
+                $updatedAt = $model->getAttribute('updated_at');
+                if ($updatedAt) {
+                    $url->setLastModificationDate($updatedAt);
+                }
+                $urls[] = $url;
+            }
+        });
+
+        return $urls;
+    }
+
+    /**
      * Yield canonical slug URLs for a model query, chunked to keep memory flat.
      * Skips rows whose slug is empty, purely numeric (route binding treats
      * those as ids), or not a clean lowercase slug (junk data like URLs or
@@ -238,6 +408,8 @@ class GenerateSitemap extends Command
             foreach ($models as $model) {
                 $slug = strtolower((string) $model->getAttribute('slug'));
                 if ($slug === '' || ctype_digit($slug) || !preg_match('/^[a-z0-9-]+$/', $slug)) {
+                    $this->skipped[$prefix][] = $model->getKey();
+
                     continue;
                 }
                 $url = Url::create($this->baseUrl.'/'.$prefix.'/'.$slug);

--- a/docs/deployment_notes.md
+++ b/docs/deployment_notes.md
@@ -152,6 +152,38 @@ $ npm install
 	sudo chmod -R ug+rwx storage bootstrap/cache
 ```
 
+The scheduled `sitemap:generate` command writes `sitemap*.xml` straight into
+`public/`, so the **sitemap files must be writable by the user that runs
+`schedule:run`** (`www-data` — check with `sudo grep -rn 'schedule:run'
+/var/spool/cron/crontabs/ /etc/cron.d/ /etc/crontab`). A manual run as the
+deploying user leaves them owned by that user, and every subsequent cron run
+then fails:
+
+```bash
+	sudo chgrp www-data public/sitemap*.xml
+	sudo chmod 664 public/sitemap*.xml
+```
+
+Deliberately **not** making `public/` itself group-writable: replacing an
+existing file only needs write permission on the file, so the daily run works
+without handing PHP the ability to create files in the docroot. The trade-off
+is that new sitemap files cannot be created by the scheduler — if a section
+outgrows one file (45k URLs) or a new section is added to the command, the
+first run after that must be done by a user who can write `public/`:
+
+```bash
+	php artisan sitemap:generate && sudo chgrp www-data public/sitemap*.xml && sudo chmod 664 public/sitemap*.xml
+```
+
+The command checks all of this up front and exits non-zero naming the offending
+files, so the condition shows up as a failed command rather than a silent
+staleness — Spatie's `writeToFile()` is a bare `file_put_contents()` that only
+raises a warning on failure. Verify a fix with a run as the scheduler user:
+
+```bash
+	sudo -u www-data php /var/www/project-name/artisan sitemap:generate
+```
+
 * Build assets
 ```bash
 npm run build

--- a/tests/Unit/SitemapPagesTest.php
+++ b/tests/Unit/SitemapPagesTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Console\Commands\GenerateSitemap;
+use Illuminate\Http\Request;
+use ReflectionClass;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Tests\TestCase;
+
+/**
+ * Guards the static page list in GenerateSitemap. Submitting a URL that 404s,
+ * redirects guests to /login, or is Disallow'd in robots.txt is worse than
+ * omitting it, and the list is hand-maintained — so pin the invariants rather
+ * than trusting it to stay in sync with routes/web.php by hand.
+ */
+class SitemapPagesTest extends TestCase
+{
+    /**
+     * @return array<string>
+     */
+    protected function pages(): array
+    {
+        /** @var array<string> $pages */
+        $pages = (new ReflectionClass(GenerateSitemap::class))->getConstant('PAGES');
+
+        return $pages;
+    }
+
+    public function test_every_sitemap_page_resolves_to_a_registered_get_route(): void
+    {
+        $this->assertNotEmpty($this->pages());
+
+        foreach ($this->pages() as $page) {
+            try {
+                $route = $this->app['router']->getRoutes()->match(Request::create($page, 'GET'));
+            } catch (NotFoundHttpException) {
+                $this->fail('Sitemap page '.$page.' does not match any registered GET route.');
+            }
+
+            $this->assertNotContains(
+                'auth',
+                $route->gatherMiddleware(),
+                'Sitemap page '.$page.' is auth-gated; guests would be redirected to /login.'
+            );
+        }
+    }
+
+    public function test_no_sitemap_page_is_disallowed_by_robots_txt(): void
+    {
+        $robots = file_get_contents(public_path('robots.txt'));
+        $this->assertIsString($robots);
+
+        // Only the wildcard block applies to the crawlers we care about; the
+        // MJ12bot block above it blocks everything and would match every page.
+        $wildcard = substr($robots, (int) strpos($robots, 'User-agent: *'));
+
+        preg_match_all('/^Disallow:\s*(\S+)/m', $wildcard, $matches);
+        $rules = array_filter($matches[1], fn ($rule) => ! str_contains($rule, '='));
+
+        foreach ($this->pages() as $page) {
+            foreach ($rules as $rule) {
+                $pattern = '#^'.str_replace('\*', '.*', preg_quote(rtrim($rule, '/'), '#')).'(/|$)#';
+
+                $this->assertDoesNotMatchRegularExpression(
+                    $pattern,
+                    $page,
+                    'Sitemap page '.$page.' is Disallow\'d in robots.txt by "'.$rule.'".'
+                );
+            }
+        }
+    }
+
+    public function test_pages_are_unique_and_root_relative(): void
+    {
+        $pages = $this->pages();
+
+        $this->assertSame(array_unique($pages), $pages, 'Duplicate entries in the sitemap page list.');
+
+        foreach ($pages as $page) {
+            $this->assertStringStartsWith('/', $page, $page.' must be root-relative.');
+            $this->assertSame($page, rtrim($page, '/') ?: '/', $page.' must not have a trailing slash.');
+        }
+    }
+}


### PR DESCRIPTION
## Why

The scheduled `sitemap:generate` run has been failing in production, surfacing as a Sentry warning:

```
file_put_contents(/var/www/events-tracker/public/sitemap-pages.xml): Failed to open stream: Permission denied
```

The sitemap files are owned by the deploying user, while `www-data` runs `schedule:run` — and `docs/deployment_notes.md` only ever chgrp'd `storage` and `bootstrap/cache`, never `public/`.

What made it hard to notice: Spatie's `writeToFile()` is a bare `file_put_contents()`, which only raises a warning on failure. The command carried on and **exited 0** while the sitemaps silently went stale. Worse, `public/sitemap.xml` happened to be `777` while the six section files were not, so every failed run still rewrote the index with fresh `lastmod` dates pointing at content that was never regenerated — actively telling Google that stale pages had just changed.

## Failing properly

- **Check writability up front**, before spending the query budget, and exit non-zero naming the offending files. Replacing a file only needs write permission on *the file*; only *creating* one needs it on the directory. So an unwritable directory is fatal just when a file we're about to write doesn't exist yet.
- **Assert after every write** that something actually landed on disk — covers what the up-front check can't predict (a new chunk file, a full disk, a read-only remount mid-run).
- **Document the ownership requirement**, including why `public/` is deliberately *not* made group-writable: replacing existing files doesn't need it, so PHP never gets the ability to create files in the docroot.

Verified against four scenarios, including a byte-for-byte reproduction of production's permission layout.

## Coverage

Audited every public GET route against the running site — real HTTP status, guest redirects, `noindex`, canonical, and robots.txt rules — rather than reading `routes/web.php`.

**Static pages: 11 → 21.** Added `/events/week`, `/events/past`, `/series/week`, `/threads`, `/calendar/free`, `/popular`, `/about`, `/help`, `/privacy`, `/tos`.

**Deliberately excluded** (reasons recorded in the constant's docblock):

| Excluded | Why |
| --- | --- |
| `/events/future` | Returns the same listing as `/events` (33 of 33 events shared) while declaring itself canonical |
| `/tools`, `/radar`, `/job-status` | 302 to `/login` |
| `/search` | Disallow'd in `robots.txt` |
| `/activity`, `/all-modules`, `/tag-calendar` | Churn or internal nav |

**New threads section.** All 124 threads are `visibility_id = 3` and return 200, but were absent entirely. `Thread` has no `getRouteKeyName()` override — unlike `Event` and `Entity` — so it's id-routed and `/threads/{slug}` 404s despite the slug column being populated.

**Skipped rows are now reported** rather than silently shrinking the sitemap (currently 2 rows: entity 118 with slug `"1337"`, tag 189 with slug `"deep house"`).

The four time-window pages were re-checked against the same duplicate standard and kept — they're distinct ranges with distinct titles targeting distinct queries. Worth knowing: `today` and `tonight` return identical event sets on ~63% of content-bearing days, because nearly everything here starts after 17:00. That's a content problem, not a reason to drop one.

## Tests

`tests/Unit/SitemapPagesTest.php` pins the hand-maintained page list: every entry must resolve to a registered GET route, carry no `auth` middleware, escape `robots.txt`'s wildcard block, and be unique and root-relative. No DB, runs in 0.8s. Confirmed it actually bites by injecting each failure mode (`/no-such-page`, `/tools`, `/search`, `/about/`).

Full unit suite green (314 tests), PHPStan clean. Sampled 50 generated URLs across all sections — all 200, and each exactly matches its page's own `<link rel="canonical">`.

## Deploying this

`sitemap-threads.xml` is a **new** file, and the recommended permission fix intentionally doesn't let `www-data` create files. The new guard catches this and names the missing file. One manual run is needed:

```bash
cd /var/www/events-tracker
php artisan sitemap:generate
sudo chgrp www-data public/sitemap*.xml
sudo chmod 664 public/sitemap*.xml
```

After that the nightly run replaces files in place and needs nothing further.

## Found along the way, not addressed here

- `/forums` and `/posts/all` return HTTP 200 whose body is a literal `HTTP/1.0 302 Found` header dump.
- `/events/daily` never responds; `/blogs/all` returns 500.
- `/events/past` shares its exact `<title>` with `/events`.
- 404 pages emit a self-referential `<link rel="canonical">`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)