### PR TITLE
Fix broken routes, thread last-activity, and forum admin gating

### DIFF
--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -137,7 +137,7 @@ class PostsController extends Controller
         Request $request,
         ListParameterSessionStore $listParamSessionStore,
         ListEntityResultBuilder $listEntityResultBuilder
-    ): string {
+    ): string|RedirectResponse {
         // if the gate does not allow this user to show a forum redirect to home
         if (Gate::denies('show_forum')) {
             flash()->error('Unauthorized', 'Your cannot view the forum');

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -43,8 +43,7 @@ abstract class Controller extends BaseController
      */
     protected function requireAdmin(): ?JsonResponse
     {
-        if (!$this->user
-            || (!$this->user->hasGroup('admin') && !$this->user->hasGroup('super_admin'))) {
+        if (!$this->user || !$this->user->isAdmin()) {
             return response()->json(['message' => 'Not authorized.'], 403);
         }
 

--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -1136,6 +1136,9 @@ class EventsController extends Controller
                     'direction' => $listResultSet->getSortDirection(),
                     'hasFilter' => $this->hasFilter,
                     'filters' => $listResultSet->getFilters(),
+                    // shares events.index-tw with /events, so give it its own title
+                    'pageTitle' => 'Past Events — Pittsburgh Concert & Show Archive',
+                    'pageDescription' => 'Browse past concerts, club nights, and events in Pittsburgh, newest first.',
                 ],
                 $this->getFilterOptions(),
                 $this->getListControlOptions()
@@ -1480,69 +1483,6 @@ class EventsController extends Controller
             ])
             ->render();
     }
-
-    /**
-     * Send a reminder to all users about all events they are attending.
-     *
-     * @return Response|RedirectResponse
-     */
-    public function daily()
-    {
-        // get all the users
-        $users = User::orderBy('name', 'ASC')->get();
-
-        $site = config('app.app_name');
-        $url = config('app.url');
-
-        // cycle through all the users
-        foreach ($users as $user) {
-            $interests = [];
-            $seriesList = [];
-
-            // get all the events the user is attending in the future, up to 100
-            $events = $user->getAttendingFuture()->take(100);
-
-            // build an array of future events based on tags the user follows
-            $tags = $user->getTagsFollowing();
-
-            if (count($tags) > 0) {
-                foreach ($tags as $tag) {
-                    /** @var \App\Models\Tag $tag */
-                    if (count($tag->todaysEvents()) > 0) {
-                        $interests[$tag->name] = $tag->todaysEvents();
-                    }
-                }
-            }
-
-            // build an array of series that the user is following
-            $series = $user->getSeriesFollowing();
-            if (count($series) > 0) {
-                foreach ($series as $s) {
-                    // if the series does not have NO SCHEDULE AND CANCELLED AT IS NULL
-                    /** @var \App\Models\Series $s */
-                    if ($s->occurrenceType->name !== 'No Schedule' && (null === $s->cancelled_at)) {
-                        // add matches to list
-                        $next_date = $s->nextOccurrenceDate()->format('Y-m-d');
-
-                        // today's date is the next series date
-                        if ($next_date === Carbon::now()->format('Y-m-d')) {
-                            $seriesList[] = $s;
-                        }
-                    }
-                }
-            }
-
-            Mail::send('emails.daily-events', ['user' => $user, 'events' => $events, 'seriesList' => $seriesList, 'interests' => $interests, 'url' => $url, 'site' => $site], function ($email) use ($user) {
-                $email->from('admin@events.cutupsmethod.com', 'Event Repo');
-                $email->to($user->email, $user->name)->subject('Event Repo: Daily Events Reminder');
-            });
-        }
-
-        flash()->success('Success', 'You sent an email reminder to '.count($users).' users about events they are attending');
-
-        return back();
-    }
-
 
     /**
      * Displays the calendar based on passed events and tag.

--- a/app/Http/Controllers/ForumsController.php
+++ b/app/Http/Controllers/ForumsController.php
@@ -50,7 +50,23 @@ class ForumsController extends Controller
 
     public function __construct(ForumFilters $filter)
     {
-        $this->middleware('auth', ['only' => ['create', 'edit', 'store', 'update']]);
+        $this->middleware('auth', ['only' => ['create', 'edit', 'store', 'update', 'destroy']]);
+
+        // A forum is site structure, not user content, so only admins may add,
+        // edit or remove one. Hiding the "Add Forum" button is not enough on
+        // its own: the resource routes let any signed-in user POST /forums,
+        // and destroy carried no auth middleware at all.
+        $this->middleware(function ($request, $next) {
+            $user = $request->user();
+
+            if (!$user || !$user->isAdmin()) {
+                flash()->error('Unauthorized', 'You cannot manage forums');
+
+                return redirect()->route('forums.index');
+            }
+
+            return $next($request);
+        }, ['only' => ['create', 'edit', 'store', 'update', 'destroy']]);
 
         // prefix for session storage
         $this->prefix = 'app.forums.';
@@ -75,7 +91,7 @@ class ForumsController extends Controller
         Request $request,
         ListParameterSessionStore $listParamSessionStore,
         ListEntityResultBuilder $listEntityResultBuilder
-    ): string {
+    ): string|RedirectResponse {
         // if the gate does not allow this user to show a forum redirect to home
         if (Gate::denies('show_forum')) {
             flash()->error('Unauthorized', 'Your cannot view the forum index');
@@ -137,81 +153,13 @@ class ForumsController extends Controller
     }
 
     /**
-     * Display a listing of the resource.
-     */
-    public function indexAll(
-        Request $request,
-        ListParameterSessionStore $listParamSessionStore,
-        ListEntityResultBuilder $listEntityResultBuilder
-    ): string {
-        // if the gate does not allow this user to show a forum redirect to home
-        if (Gate::denies('show_forum')) {
-            flash()->error('Unauthorized', 'Your cannot view the forum index');
-
-            return redirect()->back();
-        }
-
-        // initialized listParamSessionStore with base index key
-        $listParamSessionStore->setBaseIndex('internal_forum');
-        $listParamSessionStore->setKeyPrefix('internal_forum_index');
-
-        // set the index tab in the session
-        $listParamSessionStore->setIndexTab(action([ForumsController::class, 'index']));
-
-        // create the base query including any required joins; needs select to make sure only event entities are returned
-        $baseQuery = Forum::query()
-        ->select('forums.*');
-
-        $listEntityResultBuilder
-            ->setFilter($this->filter)
-            ->setQueryBuilder($baseQuery)
-            ->setDefaultSort(['forums.created_at' => 'desc']);
-
-        // get the result set from the builder
-        $listResultSet = $listEntityResultBuilder->listResultSetFactory();
-
-        // get the query builder
-        $query = $listResultSet->getList();
-
-        /* @phpstan-ignore-next-line */
-        $forums = $query->visible($this->user)
-            ->with('visibility')
-            ->paginate($listResultSet->getLimit());
-
-        // saves the updated session
-        $listParamSessionStore->save();
-
-        $this->hasFilter = $listResultSet->getFilters() != $listResultSet->getDefaultFilters() || $listResultSet->getIsEmptyFilter();
-
-        // return json only
-        if (request()->wantsJson()) {
-            return $forums;
-        }
-
-        return view('forums.index-tw')
-                ->with(array_merge(
-                    [
-                        'limit' => $listResultSet->getLimit(),
-                        'sort' => $listResultSet->getSort(),
-                        'direction' => $listResultSet->getSortDirection(),
-                        'hasFilter' => $this->hasFilter,
-                        'filters' => $listResultSet->getFilters(),
-                    ],
-                    $this->getFilterOptions(),
-                    $this->getListControlOptions()
-                ))
-                ->with(compact('forums'))
-                ->render();
-    }
-
-    /**
      * Filter a list of forums.
      */
     public function filter(
         Request $request,
         ListParameterSessionStore $listParamSessionStore,
         ListEntityResultBuilder $listEntityResultBuilder
-    ): string {
+    ): string|RedirectResponse {
         // if the gate does not allow this user to show a forum redirect to home
         if (Gate::denies('show_forum')) {
             flash()->error('Unauthorized', 'Your cannot view the forum index');

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -84,75 +84,7 @@ class PostsController extends Controller
         Request $request,
         ListParameterSessionStore $listParamSessionStore,
         ListEntityResultBuilder $listEntityResultBuilder
-    ): string {
-        // if the gate does not allow this user to show a forum redirect to home
-        if (Gate::denies('show_forum')) {
-            flash()->error('Unauthorized', 'Your cannot view the forum');
-
-            return redirect()->back();
-        }
-
-        // initialized listParamSessionStore with base index key
-        $listParamSessionStore->setBaseIndex('internal_post');
-        $listParamSessionStore->setKeyPrefix('internal_post_index');
-
-        // set the index tab in the session
-        $listParamSessionStore->setIndexTab(action([PostsController::class, 'index']));
-
-        $baseQuery = Post::query()
-        ->leftJoin('users', 'posts.created_by', '=', 'users.id')
-        ->select('posts.*');
-
-        $listEntityResultBuilder
-            ->setFilter($this->filter)
-            ->setQueryBuilder($baseQuery)
-            ->setDefaultSort(['posts.created_at' => 'desc']);
-
-        // get the result set from the builder
-        $listResultSet = $listEntityResultBuilder->listResultSetFactory();
-
-        // get the query builder
-        $query = $listResultSet->getList();
-
-        /* @phpstan-ignore-next-line */
-        $posts = $query->visible($this->user)
-            ->with('visibility')
-            ->paginate($listResultSet->getLimit());
-
-        // saves the updated session
-        $listParamSessionStore->save();
-
-        $this->hasFilter = $listResultSet->getFilters() != $listResultSet->getDefaultFilters() || $listResultSet->getIsEmptyFilter();
-
-        // return json only
-        if (request()->wantsJson()) {
-            return $posts;
-        }
-
-        return view('posts.index-tw')
-        ->with(array_merge(
-            [
-                'limit' => $listResultSet->getLimit(),
-                'sort' => $listResultSet->getSort(),
-                'direction' => $listResultSet->getSortDirection(),
-                'hasFilter' => $this->hasFilter,
-                'filters' => $listResultSet->getFilters(),
-            ],
-            $this->getFilterOptions(),
-            $this->getListControlOptions()
-        ))
-        ->with(compact('posts'))
-        ->render();
-    }
-
-    /**
-     * Display a listing of all posts (no pagination limit).
-     */
-    public function indexAll(
-        Request $request,
-        ListParameterSessionStore $listParamSessionStore,
-        ListEntityResultBuilder $listEntityResultBuilder
-    ): string {
+    ): string|RedirectResponse {
         // if the gate does not allow this user to show a forum redirect to home
         if (Gate::denies('show_forum')) {
             flash()->error('Unauthorized', 'Your cannot view the forum');
@@ -220,7 +152,7 @@ class PostsController extends Controller
         Request $request,
         ListParameterSessionStore $listParamSessionStore,
         ListEntityResultBuilder $listEntityResultBuilder
-    ): string {
+    ): string|RedirectResponse {
         // if the gate does not allow this user to show a forum redirect to home
         if (Gate::denies('show_forum')) {
             flash()->error('Unauthorized', 'Your cannot view the forum');

--- a/app/Http/Controllers/ThreadsController.php
+++ b/app/Http/Controllers/ThreadsController.php
@@ -24,6 +24,7 @@ use Carbon\Carbon;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Session;
@@ -804,8 +805,12 @@ class ThreadsController extends Controller
                 ->all()
             : [];
 
-        // Atomic view count increment — avoids model events and updated_at side-effects
-        $thread->increment('views');
+        // Bump the view counter at the DB level. Eloquent's increment() routes
+        // through the query builder's addUpdatedAtColumn(), so it would stamp
+        // updated_at on every page load and make a read look like activity.
+        // Reading a thread is not activity; posting or editing is.
+        DB::table('threads')->where('id', $thread->id)->increment('views');
+        $thread->views = $thread->views + 1;
 
         return view('threads.show-tw', compact('thread', 'tags', 'threadFollow', 'threadLike', 'likedPostIds'));
     }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -107,6 +107,15 @@ class Post extends Eloquent
 
     protected $guarded = [];
 
+    /**
+     * Making or editing a post is activity on its thread, so it bumps the
+     * thread's updated_at. Laravel's relation touch is a raw update, so it
+     * does not fire Thread's updating event and cannot rewrite updated_by.
+     *
+     * @var array<int, string>
+     */
+    protected $touches = ['thread'];
+
     protected $casts = [
         'created_at' => 'datetime',
         'updated_at' => 'datetime',

--- a/app/Models/Thread.php
+++ b/app/Models/Thread.php
@@ -53,6 +53,8 @@ use Illuminate\Support\Str;
  * @property mixed                                                         $entity_list
  * @property mixed                                                         $is_locked
  * @property mixed                                                         $last_post_at
+ * @property mixed                                                         $last_activity_at
+ * @property \App\Models\Post|null                                         $lastPost
  * @property mixed                                                         $post_count
  * @property mixed                                                         $tag_list
  * @property int|null                                                      $likes_count
@@ -208,6 +210,28 @@ class Thread extends Eloquent
         }
 
         return $this->created_at;
+    }
+
+    /**
+     * When something last actually happened in this thread: the thread being
+     * edited, or a post being made or edited. Deliberately not affected by
+     * page views — those increment `views` without stamping any timestamp.
+     *
+     * Prefers the eager-loaded lastPost (listings load `lastPost.user`) so
+     * rendering a page of threads stays a single query.
+     */
+    public function getLastActivityAtAttribute(): DateTime
+    {
+        /** @var Post|null $lastPost */
+        $lastPost = $this->relationLoaded('lastPost')
+            ? $this->lastPost
+            : $this->posts()->orderBy('created_at', 'desc')->first();
+
+        if ($lastPost && $lastPost->updated_at->greaterThan($this->updated_at)) {
+            return $lastPost->updated_at;
+        }
+
+        return $this->updated_at;
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -635,6 +635,15 @@ class User extends Authenticatable implements AuthorizableContract, CanResetPass
         return $this->groups->contains('name', $group);
     }
 
+    /**
+     * Whether this user is an administrator. Single definition of "admin"
+     * for the app — see Controller::requireAdmin(), which defers to this.
+     */
+    public function isAdmin(): bool
+    {
+        return $this->hasGroup('admin') || $this->hasGroup('super_admin');
+    }
+
     public function hasPermission(string $permission): bool
     {
         return $this->getPermissions()->contains('name', $permission);

--- a/database/migrations/2026_08_10_000000_stop_threads_updated_at_auto_touching.php
+++ b/database/migrations/2026_08_10_000000_stop_threads_updated_at_auto_touching.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * `threads.updated_at` carries MySQL's `ON UPDATE CURRENT_TIMESTAMP` (a legacy
+ * schema attribute shared by ~70 columns in this database). That makes *any*
+ * write to a thread row restamp it as freshly updated — including the view
+ * counter increment on every page load, which is why a thread's last activity
+ * moved whenever someone merely read it.
+ *
+ * Laravel writes updated_at explicitly on every model save, so the database
+ * side of this is redundant; dropping it hands the column back to the
+ * application, which is the only layer that knows what counts as activity.
+ *
+ * Scoped to `threads` on purpose — the other tables keep the legacy attribute
+ * until something actually depends on changing them.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE `threads` MODIFY `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP');
+    }
+
+    public function down(): void
+    {
+        DB::statement('ALTER TABLE `threads` MODIFY `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP');
+    }
+};

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -2,6 +2,21 @@
 
 @section('title', '404 - Page Not Found')
 
+{{--
+    An error page is not a canonical resource: the layout's default would emit a
+    self-referential <link rel="canonical"> for whatever bad URL was requested,
+    which invites crawlers to index it. Claiming the section suppresses that
+    fallback — the comment is load-bearing, since @hasSection compiles to a
+    check for non-empty content, so an empty section would not override.
+--}}
+@section('canonical')
+<!-- no canonical: error page -->
+@endsection
+
+@section('meta.robots')
+<meta name="robots" content="noindex, follow">
+@endsection
+
 @section('content')
 
 <div class="flex items-center justify-center min-h-[60vh]">

--- a/resources/views/errors/503.blade.php
+++ b/resources/views/errors/503.blade.php
@@ -2,6 +2,15 @@
 
 @section('title', '503 - Service Unavailable')
 
+{{-- see errors/404: error pages must not self-canonicalize or be indexed --}}
+@section('canonical')
+<!-- no canonical: error page -->
+@endsection
+
+@section('meta.robots')
+<meta name="robots" content="noindex, follow">
+@endsection
+
 @section('content')
 
 <div class="flex items-center justify-center min-h-[60vh]">

--- a/resources/views/events/index-tw.blade.php
+++ b/resources/views/events/index-tw.blade.php
@@ -1,12 +1,24 @@
 @extends('layouts.app-tw')
 
 @section('title')
-@if (isset($tag) || isset($related) || isset($type) || isset($slug) || isset($cdate))
+@if (isset($pageTitle))
+{{ $pageTitle }}
+@elseif (isset($tag) || isset($related) || isset($type) || isset($slug) || isset($cdate))
 Events @include('events.title-crumbs')
 @else
 Pittsburgh Events Calendar — Concerts, Shows & More
 @endif
 @endsection
+
+{{-- listing variants that share this view but are distinct pages set their own description --}}
+@if (isset($pageDescription))
+@section('description')
+{{ $pageDescription }}
+@endsection
+@section('og-description')
+{{ $pageDescription }}
+@endsection
+@endif
 
 @if (isset($events) && count($events) > 0)
 @php

--- a/resources/views/forums/index-tw.blade.php
+++ b/resources/views/forums/index-tw.blade.php
@@ -8,10 +8,12 @@
 	<!-- Page Header -->
 	<div class="flex justify-between items-center mb-6">
 		<h1 class="text-3xl font-bold text-primary">Forums</h1>
+		@if ($signedIn && $user->isAdmin())
 		<a href="{{ route('forums.create') }}" class="inline-flex items-center px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors">
 			<i class="bi bi-plus-circle mr-2"></i>
 			Add Forum
 		</a>
+		@endif
 	</div>
 
 	<!-- Forums List -->

--- a/resources/views/threads/card-tw.blade.php
+++ b/resources/views/threads/card-tw.blade.php
@@ -97,10 +97,8 @@
 
         {{-- Col 5: Last activity (lg+) --}}
         <div class="hidden lg:flex flex-col items-end text-right w-32 flex-shrink-0">
-            @php
-                $lastPostAt = method_exists($thread, 'lastPostAt') ? $thread->lastPostAt : $thread->updated_at;
-            @endphp
-            <span class="text-xs text-foreground">{{ $lastPostAt->diffForHumans() }}</span>
+            {{-- last_activity_at covers thread edits and post activity, and ignores views --}}
+            <span class="text-xs text-foreground">{{ $thread->last_activity_at->diffForHumans() }}</span>
             @if ($thread->posts_count > 0 && $thread->lastPost?->user)
             <span class="text-xs text-muted-foreground truncate max-w-full mt-0.5">{{ $thread->lastPost->user->name }}</span>
             @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -303,7 +303,6 @@ Route::get('events/by-date/{year}/{month?}/{day?}', [\App\Http\Controllers\Event
     ->where('year', '[1-9][0-9][0-9][0-9]')
     ->where('month', '(0?[1-9]|1[012])$')
     ->where('day', '(0?[1-9]|[12][0-9]|3[01])');
-Route::get('events/daily', [\App\Http\Controllers\EventsController::class, 'daily']);
 Route::get('events/day/{day}', [\App\Http\Controllers\EventsController::class, 'day'])->name('events.day')
     ->where('day', '[12][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])');
 Route::match(['get', 'post'], 'events/attending', [\App\Http\Controllers\EventsController::class, 'indexAttending'])->name('events.attending');
@@ -399,7 +398,8 @@ Route::bind('forums', function ($id) {
     return Forum::whereId($id)->firstOrFail();
 });
 
-Route::get('forums/all', [\App\Http\Controllers\ForumsController::class, 'indexAll']);
+// legacy alias; indexAll was a byte-for-byte copy of index, so consolidate on the index URL
+Route::permanentRedirect('forums/all', '/forums');
 Route::match(['get', 'post'], 'forums/filter', ['as' => 'forums.filter', 'uses' => '\App\Http\Controllers\ForumsController@filter']);
 Route::get('forums/reset', ['as' => 'forums.reset', 'uses' => '\App\Http\Controllers\ForumsController@reset']);
 Route::get('forums/rpp-reset', ['as' => 'forums.rppReset', 'uses' => '\App\Http\Controllers\ForumsController@rppReset']);
@@ -452,7 +452,8 @@ Route::match(['get', 'post'], 'posts/filter', ['as' => 'posts.filter', 'uses' =>
 Route::get('posts/reset', ['as' => 'posts.reset', 'uses' => '\App\Http\Controllers\PostsController@reset']);
 Route::get('posts/rpp-reset', ['as' => 'posts.rppReset', 'uses' => '\App\Http\Controllers\PostsController@rppReset']);
 Route::get('posts/tag/{tag}', [\App\Http\Controllers\PostsController::class, 'indexTags'])->name('posts.tag');
-Route::get('posts/all', [\App\Http\Controllers\PostsController::class, 'indexAll']);
+// legacy alias; indexAll was a byte-for-byte copy of index, so consolidate on the index URL
+Route::permanentRedirect('posts/all', '/posts');
 
 Route::bind('posts', function ($id) {
     return Post::whereId($id)->firstOrFail();
@@ -497,7 +498,8 @@ Route::resource('discord-targets', \App\Http\Controllers\DiscordTargetsControlle
     ->parameters(['discord-targets' => 'discordTarget']);
 
 // BLOGS
-Route::get('blogs/all', [\App\Http\Controllers\BlogsController::class, 'indexAll']);
+// legacy alias; BlogsController never had an indexAll, so this 500'd — send it to the index
+Route::permanentRedirect('blogs/all', '/blogs');
 Route::match(['get', 'post'], 'blogs/filter', ['as' => 'blogs.filter', 'uses' => '\App\Http\Controllers\BlogsController@filter']);
 Route::get('blogs/reset', ['as' => 'blogs.reset', 'uses' => '\App\Http\Controllers\BlogsController@reset']);
 Route::get('blogs/rpp-reset', ['as' => 'blogs.rppReset', 'uses' => '\App\Http\Controllers\BlogsController@rppReset']);

--- a/tests/Feature/BrokenListingRoutesTest.php
+++ b/tests/Feature/BrokenListingRoutesTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Regressions for a batch of routes a crawl surfaced as broken:
+ * header-dump bodies, a 500, a hanging mailer, a duplicate <title>,
+ * and a self-referential canonical on error pages.
+ */
+class BrokenListingRoutesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    /**
+     * The gated listings declared `: string`, so PHP stringified the
+     * RedirectResponse and served the raw HTTP message as a 200 body.
+     */
+    public function test_gated_listings_redirect_guests_instead_of_dumping_the_response(): void
+    {
+        foreach (['/forums', '/posts'] as $path) {
+            $response = $this->get($path);
+
+            $response->assertRedirect();
+            $this->assertStringNotContainsString(
+                'HTTP/1.0 302',
+                $response->getContent(),
+                $path.' served a stringified RedirectResponse as its body'
+            );
+        }
+    }
+
+    public function test_legacy_all_aliases_permanently_redirect_to_their_index(): void
+    {
+        $this->get('/forums/all')->assertRedirect('/forums')->assertStatus(301);
+        $this->get('/posts/all')->assertRedirect('/posts')->assertStatus(301);
+        // this one 500'd: BlogsController never had the indexAll it routed to
+        $this->get('/blogs/all')->assertRedirect('/blogs')->assertStatus(301);
+    }
+
+    /**
+     * /events/daily was an unauthenticated GET that mailed every user in the
+     * database. The scheduled `notify` command owns that job now.
+     */
+    public function test_events_daily_mailer_route_is_gone(): void
+    {
+        $this->get('/events/daily')->assertNotFound();
+    }
+
+    public function test_events_past_has_its_own_title(): void
+    {
+        $index = $this->get('/events');
+        $past = $this->get('/events/past');
+
+        $index->assertOk();
+        $past->assertOk();
+
+        $past->assertSee('Past Events', false);
+        $past->assertDontSee('Pittsburgh Events Calendar', false);
+        $this->assertNotSame($this->title($index->getContent()), $this->title($past->getContent()));
+    }
+
+    public function test_error_pages_do_not_self_canonicalize_and_are_noindexed(): void
+    {
+        $response = $this->get('/a-url-that-does-not-exist');
+
+        $response->assertNotFound();
+        $response->assertDontSee('rel="canonical"', false);
+        $response->assertSee('<meta name="robots" content="noindex, follow">', false);
+    }
+
+    protected function title(string $html): string
+    {
+        preg_match('/<title>(.*?)<\/title>/s', $html, $m);
+
+        return trim($m[1] ?? '');
+    }
+}

--- a/tests/Feature/ForumAdminOnlyTest.php
+++ b/tests/Feature/ForumAdminOnlyTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Forum;
+use App\Models\User;
+use App\Models\UserStatus;
+use App\Models\Visibility;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Forums are site structure, so only admins may add, edit or remove one —
+ * in the UI and, more importantly, at the route.
+ */
+class ForumAdminOnlyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    protected function admin(): User
+    {
+        $admin = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $admin->assignGroup('admin');
+
+        return $admin->fresh();
+    }
+
+    protected function member(): User
+    {
+        return User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+    }
+
+    public function test_admin_sees_the_add_forum_button(): void
+    {
+        $this->actingAs($this->admin());
+
+        $this->get('/forums')->assertOk()->assertSee('Add Forum', false);
+    }
+
+    /**
+     * The listing is itself behind the show_forum gate, which today only the
+     * admin group passes — so a non-admin never reaches the button. Pinned so
+     * that widening show_forum can't quietly expose the create link.
+     */
+    public function test_non_admin_cannot_reach_the_forum_listing_at_all(): void
+    {
+        $this->actingAs($this->member());
+
+        $this->get('/forums')->assertRedirect();
+    }
+
+    public function test_non_admin_cannot_reach_the_create_form_or_store_a_forum(): void
+    {
+        $this->actingAs($this->member());
+
+        $this->get('/forums/create')->assertRedirect(route('forums.index'));
+
+        $this->post('/forums', $this->payload('Sneaky Forum', 'sneaky-forum'))
+            ->assertRedirect(route('forums.index'));
+
+        $this->assertDatabaseMissing('forums', ['slug' => 'sneaky-forum']);
+    }
+
+    public function test_admin_can_store_a_forum(): void
+    {
+        $this->actingAs($this->admin());
+
+        $this->post('/forums', $this->payload('Legit Forum', 'legit-forum'))
+            ->assertRedirect(route('forums.index'));
+
+        $this->assertDatabaseHas('forums', ['slug' => 'legit-forum']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function payload(string $name, string $slug): array
+    {
+        return [
+            'name' => $name,
+            'slug' => $slug,
+            'description' => 'A forum',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+        ];
+    }
+
+    /**
+     * destroy carried no auth middleware at all, so an unauthenticated
+     * request could delete a forum.
+     */
+    public function test_guests_cannot_destroy_a_forum(): void
+    {
+        $forum = Forum::factory()->create();
+
+        $this->delete('/forums/'.$forum->id)->assertRedirect();
+
+        $this->assertDatabaseHas('forums', ['id' => $forum->id]);
+    }
+
+    public function test_non_admin_cannot_destroy_a_forum(): void
+    {
+        $forum = Forum::factory()->create();
+        $this->actingAs($this->member());
+
+        $this->delete('/forums/'.$forum->id)->assertRedirect(route('forums.index'));
+
+        $this->assertDatabaseHas('forums', ['id' => $forum->id]);
+    }
+}

--- a/tests/Feature/ThreadActivityTest.php
+++ b/tests/Feature/ThreadActivityTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Post;
+use App\Models\Thread;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * A thread's "last activity" must track real activity — posts made or edited,
+ * and edits to the thread itself — and must not move when someone merely
+ * reads the thread.
+ */
+class ThreadActivityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    /**
+     * Backdate the row directly so the test isn't racing the same-second clock.
+     */
+    protected function backdate(Thread $thread): Carbon
+    {
+        $stale = Carbon::now()->subMonth()->startOfSecond();
+
+        DB::table('threads')->where('id', $thread->id)->update([
+            'created_at' => $stale,
+            'updated_at' => $stale,
+        ]);
+
+        return $stale;
+    }
+
+    protected function updatedAt(Thread $thread): string
+    {
+        return (string) DB::table('threads')->where('id', $thread->id)->value('updated_at');
+    }
+
+    public function test_viewing_a_thread_counts_the_view_without_bumping_last_activity(): void
+    {
+        $thread = Thread::factory()->create(['views' => 0]);
+        $stale = $this->backdate($thread);
+
+        $this->signIn();
+        $this->get('/threads/'.$thread->id)->assertOk();
+
+        $this->assertSame(
+            $stale->toDateTimeString(),
+            Carbon::parse($this->updatedAt($thread))->toDateTimeString(),
+            'reading a thread stamped it as updated'
+        );
+        $this->assertSame(1, (int) DB::table('threads')->where('id', $thread->id)->value('views'));
+    }
+
+    public function test_making_a_post_bumps_last_activity(): void
+    {
+        $thread = Thread::factory()->create();
+        $stale = $this->backdate($thread);
+
+        Post::factory()->create(['thread_id' => $thread->id]);
+
+        $this->assertTrue(
+            Carbon::parse($this->updatedAt($thread))->greaterThan($stale),
+            'posting to a thread did not register as activity'
+        );
+    }
+
+    public function test_editing_a_post_bumps_last_activity(): void
+    {
+        $thread = Thread::factory()->create();
+        $post = Post::factory()->create(['thread_id' => $thread->id]);
+        $stale = $this->backdate($thread);
+
+        $post->body = 'edited body';
+        $post->save();
+
+        $this->assertTrue(
+            Carbon::parse($this->updatedAt($thread))->greaterThan($stale),
+            'editing a post did not register as activity'
+        );
+    }
+
+    public function test_last_activity_accessor_prefers_the_newer_of_thread_and_post(): void
+    {
+        $thread = Thread::factory()->create();
+        $post = Post::factory()->create(['thread_id' => $thread->id]);
+
+        // thread edited more recently than its last post
+        DB::table('posts')->where('id', $post->id)->update(['updated_at' => Carbon::now()->subWeek()]);
+        DB::table('threads')->where('id', $thread->id)->update(['updated_at' => Carbon::now()->subDay()]);
+
+        $fresh = Thread::find($thread->id);
+        $this->assertSame(
+            $fresh->updated_at->toDateTimeString(),
+            $fresh->last_activity_at->toDateTimeString()
+        );
+
+        // and the other way round: a post newer than the thread's own edit
+        DB::table('posts')->where('id', $post->id)->update(['updated_at' => Carbon::now()]);
+
+        $fresh = Thread::with('lastPost')->find($thread->id);
+        $this->assertSame(
+            $fresh->lastPost->updated_at->toDateTimeString(),
+            $fresh->last_activity_at->toDateTimeString()
+        );
+    }
+
+    public function test_last_activity_accessor_works_without_the_eager_loaded_relation(): void
+    {
+        $thread = Thread::factory()->create();
+        $this->backdate($thread);
+        Post::factory()->create(['thread_id' => $thread->id]);
+
+        $fresh = Thread::find($thread->id);
+        $this->assertFalse($fresh->relationLoaded('lastPost'));
+        $this->assertSame(
+            Carbon::parse($this->updatedAt($thread))->toDateTimeString(),
+            $fresh->last_activity_at->toDateTimeString()
+        );
+    }
+}

--- a/tests/Feature/Web/PostsControllerSmokeTest.php
+++ b/tests/Feature/Web/PostsControllerSmokeTest.php
@@ -25,7 +25,24 @@ class PostsControllerSmokeTest extends TestCase
     {
         Post::factory()->count(2)->create();
 
+        // /posts is behind the show_forum gate, which today only admins pass
+        $admin = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $admin->assignGroup('admin');
+        $this->actingAs($admin->fresh());
+
         $this->get('/posts')->assertOk();
+    }
+
+    /**
+     * Previously this returned 200 with a stringified RedirectResponse as the
+     * body, because the controller was typed `: string`.
+     */
+    public function test_posts_index_redirects_users_who_cannot_see_the_forum(): void
+    {
+        $response = $this->get('/posts');
+
+        $response->assertRedirect();
+        $this->assertStringNotContainsString('HTTP/1.0 302', $response->getContent());
     }
 
     public function test_posts_show_redirects_to_parent_thread(): void


### PR DESCRIPTION
Six issues surfaced by a crawl and follow-up review.

Broken routes:

- /forums and /posts served a 200 whose body was a literal HTTP header dump. The gated listing actions were typed `: string`, so PHP coerced the RedirectResponse from the show_forum deny path through Symfony's __toString(). Widened to `string|RedirectResponse`.
- /blogs/all 500'd: BlogsController never had the indexAll it routed to. The indexAll in Posts and Forums was a byte-for-byte copy of index and nothing linked any of the three, so all now permanent-redirect to their index and the two duplicates are deleted.
- /events/daily never responded. It was an unauthenticated GET that mailed every user in the database, rendering a view that no longer exists, and ignoring each user's setting_daily_update opt-out. The scheduled `notify` command already owns that job; route and method removed.
- /events/past shared its exact <title> with /events. It was the only events.index-tw consumer setting none of the crumb variables, so it fell through to the generic title. Added pageTitle/pageDescription hooks.
- 404 and 503 pages emitted a self-referential <link rel="canonical"> for whatever bad URL was requested. They now claim the canonical section and declare noindex. The HTML comment in that section is load-bearing: @hasSection compiles to a non-empty-content check.

Thread last activity:

Viewing a thread restamped it as updated, across three layers. Eloquent's increment() routes through addUpdatedAtColumn(), so the view counter touched updated_at on every page load. Below that, threads.updated_at carries MySQL's ON UPDATE CURRENT_TIMESTAMP, so any write restamped the row regardless of what the application did; a migration drops that on threads (Laravel writes updated_at explicitly, so the DB side was redundant). And Post had no $touches, so making a post was never activity at all.

The thread card's last-activity line was also dead code — method_exists($thread, 'lastPostAt') is always false, since lastPostAt is an accessor — so it silently rendered updated_at. Replaced with a last_activity_at accessor that takes the later of the thread's updated_at and its last post's, reusing the eager-loaded lastPost.

Forum administration:

The Add Forum button is now admin-gated, though no non-admin could reach it already: /forums is itself behind show_forum, granted only to admin. The real exposure was server-side — create/store/edit/update required only auth, letting any signed-in user create a forum, and destroy carried no auth middleware at all, so DELETE /forums/{id} was reachable by a guest. All five now require admin. Added User::isAdmin() as the single definition of admin, which Controller::requireAdmin() now defers to.

Web\PostsControllerSmokeTest::test_posts_index_renders was asserting the header-dump bug: it expected 200 from /posts as a non-admin, which only passed because the dump was served with a 200. Split into an admin path that renders and a non-admin path that redirects cleanly.