### PR TITLE
Log Discord run outcomes, not just failures

### DIFF
--- a/app/Console/Commands/PostDiscordDigest.php
+++ b/app/Console/Commands/PostDiscordDigest.php
@@ -7,6 +7,7 @@ use App\Models\DiscordTarget;
 use App\Services\Integrations\Discord\DiscordEventPoster;
 use App\Services\Integrations\Discord\DiscordTargetMatcher;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
 
 /**
  * Posts the weekly roundup (issue #2058).
@@ -33,6 +34,7 @@ class PostDiscordDigest extends Command
     {
         if (! config('discord.enabled')) {
             $this->info('Discord posting is disabled (DISCORD_ENABLED). Nothing to do.');
+            Log::info('Discord digest: skipped, integration disabled (DISCORD_ENABLED).');
 
             return Command::SUCCESS;
         }
@@ -55,8 +57,22 @@ class PostDiscordDigest extends Command
         // what makes the hourly schedule safe.
         $weekKey = $now->format('o-\WW');
         $sent = 0;
+        $targets = $query->get();
 
-        foreach ($query->get() as $target) {
+        // 23 runs out of 24 match nothing, so the routine "no target is due"
+        // case is debug — but it still has to be written somewhere, because
+        // "did the scheduler even fire?" is otherwise unanswerable after the
+        // fact: cron discards the command's stdout.
+        Log::log($targets->isEmpty() ? 'debug' : 'info', 'Discord digest: run started', [
+            'week' => $weekKey,
+            'hour' => $now->hour,
+            'day_of_week' => $now->dayOfWeek,
+            'targets_due' => $targets->count(),
+            'dry_run' => $dryRun,
+            'forced' => $force,
+        ]);
+
+        foreach ($targets as $target) {
             $from = $now->copy();
             $to = $now->copy()->addDays($target->digest_window_days);
 
@@ -83,6 +99,17 @@ class PostDiscordDigest extends Command
                 if ($post->isSent()) {
                     $sent++;
                 }
+
+                // The ledger status is the answer to "why was the channel
+                // quiet this week" — 'skipped' on an empty window reads very
+                // differently from a digest that was already sent.
+                Log::info('Discord digest: target processed', [
+                    'target_id' => $target->id,
+                    'target' => $target->name,
+                    'week' => $weekKey,
+                    'events' => $events->count(),
+                    'status' => $post->status,
+                ]);
             } catch (DiscordWebhookException $e) {
                 // Recorded and logged by the poster; one bad channel must not
                 // stop the rest of the week's digests.
@@ -91,6 +118,15 @@ class PostDiscordDigest extends Command
         }
 
         $this->info($sent.' digest(s) posted for '.$weekKey.'.');
+
+        if (! $targets->isEmpty()) {
+            Log::info('Discord digest: run finished', [
+                'week' => $weekKey,
+                'targets_due' => $targets->count(),
+                'sent' => $sent,
+                'dry_run' => $dryRun,
+            ]);
+        }
 
         return Command::SUCCESS;
     }

--- a/app/Console/Commands/PostDiscordReminders.php
+++ b/app/Console/Commands/PostDiscordReminders.php
@@ -32,27 +32,43 @@ class PostDiscordReminders extends Command
     {
         if (! config('discord.enabled')) {
             $this->info('Discord posting is disabled (DISCORD_ENABLED). Nothing to do.');
+            Log::info('Discord reminders: skipped, integration disabled (DISCORD_ENABLED).');
 
             return Command::SUCCESS;
         }
 
         $dryRun = (bool) $this->option('dry-run');
 
-        $targets = DiscordTarget::forMode(DiscordTarget::MODE_REMINDER)->with('criteria');
+        $query = DiscordTarget::forMode(DiscordTarget::MODE_REMINDER)->with('criteria');
 
         if ($targetId = $this->option('target')) {
-            $targets->whereKey($targetId);
+            $query->whereKey($targetId);
         }
 
+        $targets = $query->get();
         $queued = 0;
 
-        foreach ($targets->get() as $target) {
+        // Zero targets here is the commonest reason for silence, and it is
+        // indistinguishable from "the scheduler never ran" unless it is
+        // written down: cron discards the command's stdout.
+        Log::info('Discord reminders: run started', [
+            'targets_opted_in' => $targets->count(),
+            'dry_run' => $dryRun,
+        ]);
+
+        foreach ($targets as $target) {
             foreach ($target->effectiveReminderOffsets() as $offset) {
                 $queued += $this->remindersFor($matcher, $target, $offset, $dryRun);
             }
         }
 
         $this->info(($dryRun ? 'Would queue ' : 'Queued ').$queued.' Discord reminder(s).');
+
+        Log::info('Discord reminders: run finished', [
+            'targets_opted_in' => $targets->count(),
+            'queued' => $queued,
+            'dry_run' => $dryRun,
+        ]);
 
         return Command::SUCCESS;
     }
@@ -73,6 +89,15 @@ class PostDiscordReminders extends Command
 
         $events = $matcher->eventsFor($target, $from, $to)->get();
         $queued = 0;
+
+        // Separates "the criteria matched nothing" from "the criteria matched
+        // but every hit was suppressed" — the two look identical in the count.
+        Log::debug('Discord reminders: window scanned', [
+            'target_id' => $target->id,
+            'target' => $target->name,
+            'offset_days' => $offset,
+            'matched' => $events->count(),
+        ]);
 
         foreach ($events as $event) {
             if ($this->postedTooRecently($target, $event)) {

--- a/app/Services/Integrations/Discord/DiscordEventPoster.php
+++ b/app/Services/Integrations/Discord/DiscordEventPoster.php
@@ -141,14 +141,31 @@ class DiscordEventPoster
         $post = $this->claim($target, $eventId, $reason, $reasonKey, $userId);
 
         if ($post->isSent() && ! $allowResend) {
+            Log::debug('Discord: already sent, no-op', [
+                'target_id' => $target->id,
+                'event_id' => $eventId,
+                'reason' => $reason,
+                'reason_key' => $reasonKey,
+            ]);
+
             return $post;
         }
 
         if (! config('discord.enabled') || ! $target->is_enabled) {
+            $reasonSkipped = config('discord.enabled') ? 'Target disabled' : 'Discord integration disabled';
+
             $post->fill([
                 'status' => DiscordPost::STATUS_SKIPPED,
-                'error' => config('discord.enabled') ? 'Target disabled' : 'Discord integration disabled',
+                'error' => $reasonSkipped,
             ])->save();
+
+            Log::info('Discord: post skipped', [
+                'target_id' => $target->id,
+                'target' => $target->name,
+                'event_id' => $eventId,
+                'reason' => $reason,
+                'skipped_because' => $reasonSkipped,
+            ]);
 
             return $post;
         }
@@ -174,6 +191,18 @@ class DiscordEventPoster
         ])->save();
 
         $target->recordSuccess();
+
+        // The counterpart to the failure line below. Without it the log can
+        // only ever prove that something went wrong, never that anything went
+        // right, which is the harder question when a channel looks quiet.
+        Log::info('Discord post sent', [
+            'target_id' => $target->id,
+            'target' => $target->name,
+            'event_id' => $eventId,
+            'reason' => $reason,
+            'reason_key' => $reasonKey,
+            'message_id' => $result['message_id'],
+        ]);
 
         if (null !== $event) {
             $this->recordEventSuccess($event, $result['message_id'], $userId);

--- a/docs/discord-integration.md
+++ b/docs/discord-integration.md
@@ -244,13 +244,68 @@ php artisan test --filter Discord
 Covers the poster, target matcher, embed builder, webhook client, admin UI, auto-post
 listener, manual post, and both scheduled commands.
 
+## Logging
+
+Cron discards the scheduled commands' stdout, so both commands and the poster write
+what they did to the application log. Every line is prefixed `Discord`:
+
+```bash
+grep -i discord storage/logs/laravel-$(date +%F).log
+```
+
+| Line | Level | Meaning |
+|---|---|---|
+| `Discord reminders: run started` / `run finished` | info | The daily sweep fired. `targets_opted_in` is how many targets have `post_reminders` on; `queued` is how many jobs it dispatched. |
+| `Discord reminders: window scanned` | debug | Per target and offset, how many events the criteria matched — separates "matched nothing" from "matched, then suppressed". |
+| `Discord reminders: reminder suppressed, posted recently` | info | `reminder_min_gap_hours` swallowed one. |
+| `Discord digest: run started` | debug / **info** | The hourly run fired. Logged at debug when no target is due for this hour (23 hours out of 24), info when one is. |
+| `Discord digest: target processed` | info | Carries `events` and the ledger `status` — `skipped` means an empty window, `sent` means a real roundup. |
+| `Discord digest: run finished` | info | Summary; only written when a target was actually due. |
+| `Discord post sent` | info | One message delivered, with its `message_id`. |
+| `Discord: post skipped` | info | The integration or the target is disabled. |
+| `Discord: already sent, no-op` | debug | The claim-first ledger stopped a duplicate. This is the dedupe working. |
+| `Discord post failed` | error | Delivery failed; carries the HTTP status and Discord error code. |
+
+Webhook URLs are never logged — failure lines carry `maskedUrl()` only.
+
+The `discord_posts` table is the authoritative ledger and outlives the 7-day log
+rotation:
+
+```sql
+SELECT discord_target_id, event_id, reason, reason_key, status, error, posted_at
+FROM discord_posts ORDER BY id DESC LIMIT 20;
+```
+
 ## Troubleshooting
 
 | Symptom | Likely cause |
 |---|---|
 | Nothing posts at all | `DISCORD_ENABLED` false, or config cached before it was set |
+| Nothing has posted since enabling it | Most likely nothing is *due* yet. The digest fires only on the target's `digest_day`/`digest_hour`; announce needs a **new** event to gain a flyer (it does not backfill); reminders need `post_reminders` on. Confirm with the dry runs below. |
 | Reminders/digests never fire, manual works | `schedule:run` not in cron — see [Scheduled tasks](deployment_notes.md#scheduled-tasks) |
 | Announce/reminders never fire, digest works | Queue worker not running (digest posts inline, the others queue) |
 | A target went quiet on its own | Auto-disabled after repeated permanent failures, or the webhook was deleted in Discord — check `is_enabled` and the failure email |
 | Digest posted twice in a week | Should be impossible; the ISO week key dedupes. Check for two targets on the same channel. |
 | A target posts nothing but is enabled | `match_all` off with no criteria matches nothing by design |
+
+### Checking a live install
+
+Read-only, safe to run on production at any time:
+
+```bash
+# Is the feature actually on in the CACHED config? (env() alone will lie)
+php artisan tinker --execute="var_dump(config('discord.enabled'));"
+
+# Is the scheduler registered, and when does each command run next?
+php artisan schedule:list
+
+# What would each command send right now?
+php artisan discord:reminders --dry-run
+php artisan discord:digest --dry-run --force
+```
+
+`--dry-run` sends nothing. Dropping `--dry-run` from the digest posts for real — use
+`--target=ID` to keep that to one channel.
+
+Reminders reporting `0` while the digest dry run lists events means the target has
+`post_reminders` off; `forMode()` filters it out before any event is considered.


### PR DESCRIPTION
Every Log:: call in the Discord integration was on the failure path, so a run that worked -- or a run that correctly did nothing -- left no trace at all. Cron discards the scheduled commands' stdout, which made "did this even fire?" unanswerable after the fact and turned an ordinary "nothing is due yet" into something indistinguishable from a broken scheduler.

Both commands now log run started/finished with the counts that explain the outcome, and the poster logs a successful send alongside its existing failure line. The digest's start line is debug when no target is due for the hour and info when one is: it runs hourly and matches nothing 23 times out of 24, so info on every tick would be pure noise.

Reminders also get a per-target, per-offset debug line, which separates "the criteria matched nothing" from "matched, then suppressed by reminder_min_gap_hours" -- identical in the summary count otherwise.

Webhook URLs stay out of the log; failure lines carry maskedUrl() only.

Docs gain a table of every line and its meaning, plus the read-only commands for checking a live install.