### PR TITLE
Prompt new registrants to check their email for the activation link

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;
 use App\Models\User;
 use Illuminate\Foundation\Auth\RegistersUsers;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 
@@ -80,5 +81,25 @@ class RegisterController extends Controller
             'email' => $data['email'],
             'password' => Hash::make($data['password']),
         ]);
+    }
+
+    /**
+     * The user has been registered.
+     *
+     * Registration logs the user straight in and drops them on the homepage,
+     * which gave no hint that an activation email was on its way. Flag the
+     * session so the layout can surface the "check your email" modal on the
+     * page they land on. Returning null keeps the trait's normal redirect /
+     * JSON response handling.
+     *
+     * @param  \App\Models\User  $user
+     */
+    protected function registered(Request $request, $user): mixed
+    {
+        if (! $user->hasVerifiedEmail()) {
+            $request->session()->flash('show_verification_notice', $user->email);
+        }
+
+        return null;
     }
 }

--- a/resources/views/layouts/app-tw.blade.php
+++ b/resources/views/layouts/app-tw.blade.php
@@ -130,8 +130,11 @@
 	@include('flash')
 
 	@auth
-		{{-- Onboarding wins over the feedback prompt — never stack two modals. --}}
-		@if(auth()->user()->shouldSeeOnboarding() || session('show_onboarding'))
+		{{-- Never stack two modals: the just-registered activation prompt wins,
+		     then onboarding, then the feedback prompt. --}}
+		@if(session('show_verification_notice'))
+			@include('partials.verify-email-modal', ['email' => session('show_verification_notice')])
+		@elseif(auth()->user()->shouldSeeOnboarding() || session('show_onboarding'))
 			@include('partials.onboarding-modal')
 		@elseif(!empty($feedbackPrompt))
 			@include('partials.feedback-modal', ['payload' => $feedbackPrompt])

--- a/resources/views/partials/verify-email-modal.blade.php
+++ b/resources/views/partials/verify-email-modal.blade.php
@@ -1,0 +1,108 @@
+{{--
+    Post-registration "check your email" prompt.
+
+    Shown once, on the page a user lands on straight after registering, while
+    their account is still pending activation. RegisterController::registered()
+    flashes `show_verification_notice` with the address the link was sent to.
+
+    Deliberately self-contained Alpine rather than <x-ui.modal>: that component
+    emits an inline script with a hardcoded element id and stacks a fresh
+    document-level keydown listener on every render.
+
+    Required variables:
+      $email (string)  address the activation link was sent to
+--}}
+<style>[x-cloak]{display:none!important}</style>
+<div x-data="verifyEmailNotice()" x-show="open" x-cloak
+     @keydown.escape.window="open = false"
+     class="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
+     role="dialog" aria-modal="true" aria-labelledby="verify-email-title">
+    <div class="bg-secondary rounded-lg shadow-2xl max-w-md w-full border border-border ring-1 ring-black/5"
+         @click.stop>
+        <!-- Header -->
+        <div class="p-6 pb-4 text-center">
+            <div class="w-16 h-16 mx-auto bg-primary/10 rounded-full flex items-center justify-center mb-4">
+                <i class="bi bi-envelope-check text-primary text-3xl"></i>
+            </div>
+            <h2 id="verify-email-title" class="text-xl font-bold text-foreground">Check your email</h2>
+        </div>
+
+        <!-- Body -->
+        <div class="px-6 pb-2 space-y-3 text-sm text-muted-foreground text-center">
+            <p>
+                We sent an activation link to
+                <span class="font-medium text-foreground break-all">{{ $email }}</span>.
+                Click that link to finish activating your account.
+            </p>
+            <p>Until then you're signed in, but some features stay locked.</p>
+            <p class="text-xs">Can't find it? Check your spam or promotions folder.</p>
+
+            <p x-show="status" x-cloak class="text-xs"
+               :class="statusIsError ? 'text-destructive' : 'text-green-500'"
+               x-text="status"></p>
+        </div>
+
+        <!-- Footer -->
+        <div class="p-4 flex flex-wrap justify-between items-center gap-2">
+            <button type="button" @click="resend()" :disabled="sending"
+                    class="px-3 py-2 text-sm rounded-md text-muted-foreground hover:text-foreground hover:bg-background transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
+                <span x-show="!sending">Resend email</span>
+                <span x-show="sending" x-cloak>Sending&hellip;</span>
+            </button>
+            <button type="button" @click="open = false"
+                    class="px-4 py-2 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-opacity">
+                Got it
+            </button>
+        </div>
+    </div>
+</div>
+
+<script>
+    function verifyEmailNotice() {
+        return {
+            open: true,
+            sending: false,
+            status: '',
+            statusIsError: false,
+
+            csrf() {
+                return document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
+            },
+
+            // The resend endpoint answers JSON when asked: 202 on send, 204 if
+            // the address was already verified in another tab.
+            resend() {
+                if (this.sending) return;
+                this.sending = true;
+                this.status = '';
+                this.statusIsError = false;
+
+                fetch('{{ route('verification.resend') }}', {
+                    method: 'POST',
+                    headers: {
+                        'Accept': 'application/json',
+                        'X-CSRF-TOKEN': this.csrf(),
+                    },
+                })
+                    .then(r => {
+                        if (r.status === 204) {
+                            this.status = 'That address is already verified — you\'re all set.';
+                        } else if (r.ok) {
+                            this.status = 'Sent. A fresh activation link is on its way.';
+                        } else if (r.status === 429) {
+                            this.statusIsError = true;
+                            this.status = 'Too many requests. Please wait a minute and try again.';
+                        } else {
+                            this.statusIsError = true;
+                            this.status = 'Something went wrong. Please try again.';
+                        }
+                    })
+                    .catch(() => {
+                        this.statusIsError = true;
+                        this.status = 'Something went wrong. Please try again.';
+                    })
+                    .finally(() => { this.sending = false; });
+            },
+        };
+    }
+</script>

--- a/tests/Feature/Auth/RegistrationVerificationNoticeTest.php
+++ b/tests/Feature/Auth/RegistrationVerificationNoticeTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use App\Models\UserStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Validator;
+use Tests\TestCase;
+
+class RegistrationVerificationNoticeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+
+        // The registration form is captcha-gated; make the rule a no-op here.
+        Validator::extend('captcha', fn () => true);
+    }
+
+    private function registrationPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'name' => 'Notice Tester',
+            'email' => 'notice-'.uniqid().'@example.com',
+            'password' => 'password1234',
+            'password_confirmation' => 'password1234',
+            'g-recaptcha-response' => 'valid-captcha-token',
+        ], $overrides);
+    }
+
+    public function test_registration_flashes_the_verification_notice(): void
+    {
+        Notification::fake();
+
+        $payload = $this->registrationPayload();
+
+        $response = $this->post('/register', $payload);
+
+        $response->assertRedirect('/');
+        $response->assertSessionHas('show_verification_notice', $payload['email']);
+    }
+
+    public function test_landing_page_renders_the_activation_modal_after_registering(): void
+    {
+        // Pin the status: the factory randomises it, and CheckBanned bounces
+        // banned/suspended users to login before the page ever renders.
+        $user = User::factory()->create([
+            'email_verified_at' => null,
+            'user_status_id' => UserStatus::PENDING,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->withSession(['show_verification_notice' => $user->email])
+            ->get('/');
+
+        $response->assertOk();
+        $response->assertSee('Check your email');
+        $response->assertSee('activation link', false);
+        $response->assertSee($user->email);
+    }
+
+    public function test_activation_modal_is_not_shown_without_the_flash(): void
+    {
+        // Pin the status: the factory randomises it, and CheckBanned bounces
+        // banned/suspended users to login before the page ever renders.
+        $user = User::factory()->create([
+            'email_verified_at' => null,
+            'user_status_id' => UserStatus::PENDING,
+        ]);
+
+        $response = $this->actingAs($user)->get('/');
+
+        $response->assertOk();
+        $response->assertDontSee('verify-email-title');
+    }
+}


### PR DESCRIPTION
## Problem

Registration logs the new user straight in and redirects them to the homepage. Nothing on that page says an activation email was sent, so the account quietly sits unverified until the user happens to find the link in their inbox.

## Change

- **`RegisterController::registered()`** — new hook that flashes `show_verification_notice` with the new user's email address. It returns `null`, so `RegistersUsers`' normal redirect / JSON-response handling is untouched (the API registration path is unaffected).
- **`resources/views/partials/verify-email-modal.blade.php`** — new self-contained Alpine overlay: envelope icon, "Check your email", the address the link was sent to, a spam-folder hint, a **Resend email** button and **Got it** to dismiss. Escape closes it too.
  - Resend POSTs to `verification.resend` with `Accept: application/json` — the `VerifiesEmails` trait answers 202 (sent) / 204 (already verified) for JSON requests — so the outcome reports inline instead of navigating away. The 429 throttle response gets its own message.
  - Follows `partials/feedback-modal.blade.php` rather than `<x-ui.modal>`, for the reason documented in that file's header (the component emits an inline script with a hardcoded element id and stacks a document-level keydown listener on every render).
- **`layouts/app-tw.blade.php`** — the activation prompt takes precedence in the existing single-modal chain, ahead of onboarding and the feedback prompt. No conflict in practice: `User::shouldSeeOnboarding()` already returns false for unverified users.

The modal is one-shot — it's driven by flash data, so a refresh or any later page load won't show it again. Users who want the prompt back still have `/email/verify`.

## Testing

New `tests/Feature/Auth/RegistrationVerificationNoticeTest.php`:

- registration flashes `show_verification_notice` with the registered address (captcha rule stubbed out, as in `ApiUserRegistrationTest`)
- the landing page renders the modal with that address when the flag is present
- nothing renders without it

```
./vendor/bin/phpunit tests/Feature/Auth/ tests/Feature/EmailVerificationTest.php tests/Feature/AuthControllersTest.php
OK (33 tests, 62 assertions)
```

`./vendor/bin/phpstan analyse app/Http/Controllers/Auth/RegisterController.php` — no errors.

Manual check worth doing on a review deploy: register, confirm the modal appears on the homepage with the right address, hit **Resend** and confirm a second verification mail arrives and the inline "Sent" message shows.

### Note for future tests

`UserFactory` assigns a **random** `user_status_id`, and the global `CheckBanned` middleware redirects banned/suspended users to login. Any feature test that fetches a page as a factory user is flaky unless it pins the status — these tests pin `UserStatus::PENDING`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)