### PR TITLE
Fix: guard unattend against null EventResponse [EVENTREPO-XT]

### DIFF
--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -2288,12 +2288,17 @@ class EventsController extends Controller
             return back();
         }
 
-        // delete the attending response
+        // delete the attending response if one exists
         $response = EventResponse::where('event_id', '=', $id)->where('user_id', '=', $this->user->id)->where('response_type_id', '=', 1)->first();
-        $response->delete();
 
-        // add to activity log
-        Activity::log($event, $this->user, 7);
+        // the user may have no attending response (stale link, double submit, or a GET prefetch of this route);
+        // treat unattend as idempotent rather than erroring on a null response
+        if ($response) {
+            $response->delete();
+
+            // add to activity log
+            Activity::log($event, $this->user, 7);
+        }
 
         // handle the request if ajax
         if ($request->ajax()) {

--- a/tests/Feature/EventsTest.php
+++ b/tests/Feature/EventsTest.php
@@ -208,6 +208,24 @@ class EventsTest extends TestCase
             ->assertSee('Grid-filter-type');
     }
 
+    public function testUnattendWithoutAttendingResponseDoesNotError()
+    {
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $event = Event::factory()->create();
+
+        // The user has no attending response. unattend is a GET route, so a stale
+        // link, double submit, or link prefetch can hit it with nothing to delete;
+        // it must not call delete() on null and 500 (EVENTREPO-XT).
+        $response = $this->actingAs($user)->get('/events/'.$event->id.'/unattend');
+
+        $response->assertRedirect();
+        $this->assertDatabaseMissing('event_responses', [
+            'event_id' => $event->id,
+            'user_id' => $user->id,
+            'response_type_id' => 1,
+        ]);
+    }
+
     /**
      * A basic functional test example.
      *


### PR DESCRIPTION
## Sentry issue

[EVENTREPO-XT](https://sentry.io/organizations/geoff-maddock/issues/7670169650/) — `Error: Call to a member function delete() on null` at `/events/{id}/unattend` (last seen 2026-08-13).

No user feedback was attached to this issue.

## The error

`EventsController@unattend` looks up the user's attending response and immediately deletes it:

```php
$response = EventResponse::where('event_id', '=', $id)
    ->where('user_id', '=', $this->user->id)
    ->where('response_type_id', '=', 1)
    ->first();
$response->delete();
```

When the user has **no** attending response (`response_type_id = 1`), `first()` returns `null` and `->delete()` throws *"Call to a member function delete() on null."*

## Root cause

`events/{id}/unattend` is registered as a **GET** route (`routes/web.php`), so it is reachable without an attending response ever existing:

- a stale "unattend" link after the response was already removed,
- a double submit / double click,
- a link prefetcher or crawler following the GET URL.

Any of these hits the endpoint with nothing to delete.

## What changed

- **`app/Http/Controllers/EventsController.php`** — guard the `delete()` and the activity-log write behind a null check, making `unattend` idempotent: hitting it while not attending is now a no-op that redirects back instead of 500ing. (The success/AJAX response is unchanged and still accurate — the user ends up not attending either way.)
- **`tests/Feature/EventsTest.php`** — regression test `testUnattendWithoutAttendingResponseDoesNotError` covering the not-attending case (asserts a redirect, not a 500), following the existing `EVENTREPO-*` regression-test convention in this file.

## Testing notes

`php -l` passes on both changed files. The full test suite (`composer tests`) and PHPStan could not be run in this sandbox — Composer dependencies could not be installed (the environment blocks GitHub dist downloads) and no MySQL/`.env` is available — so CI is relied on to run PHPStan and the migrate+seed+phpunit pipeline on this PR.

## Note: two related Sentry issues already fixed

While triaging, I found two other unresolved Sentry issues that are **already fixed on `main`** and need no code change — just resolving in Sentry:

- **EVENTREPO-X8** — `Unable to prepare route [reviews/filter] for serialization. Another route has already been assigned name [reviews.filter].` A duplicate `reviews.filter` route was removed in commit `06294d5` ("Route fix").
- **EVENTREPO-X7** — `Route [entities.quickCheck] not defined.` This was a *symptom* of X8: the duplicate route name broke `php artisan route:cache`, leaving a stale route cache that didn't include the then-newly-added `entities.quickCheck` route (#2027). Fixing X8 lets the cache rebuild. Both last occurred within minutes of each other on 2026-07-29 and stopped after `06294d5` deployed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtSxy92a69NTLXCy9XNcbZ)_