### PR TITLE
Guard the remaining unfollow/unlike/unattend null dereferences

### DIFF
--- a/app/Http/Controllers/Api/EventsController.php
+++ b/app/Http/Controllers/Api/EventsController.php
@@ -1333,10 +1333,12 @@ class EventsController extends Controller
 
         // delete the attending response
         $response = EventResponse::where('event_id', '=', $id)->where('user_id', '=', $this->user->id)->where('response_type_id', '=', 1)->first();
-        $response->delete();
+        if ($response) {
+            $response->delete();
 
-        // add to activity log
-        Activity::log($event, $this->user, 7);
+            // add to activity log
+            Activity::log($event, $this->user, 7);
+        }
 
         // handle the request if ajax
         if ($request->ajax()) {
@@ -1524,7 +1526,9 @@ class EventsController extends Controller
 
         // delete the follow
         $response = Follow::where('object_id', '=', $id)->where('user_id', '=', $this->user->id)->where('object_type', '=', 'event')->first();
-        $response->delete();
+        if ($response) {
+            $response->delete();
+        }
 
         flash()->success('Success', 'You are no longer following the event.');
 

--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -2290,10 +2290,12 @@ class EventsController extends Controller
 
         // delete the attending response
         $response = EventResponse::where('event_id', '=', $id)->where('user_id', '=', $this->user->id)->where('response_type_id', '=', 1)->first();
-        $response->delete();
+        if ($response) {
+            $response->delete();
 
-        // add to activity log
-        Activity::log($event, $this->user, 7);
+            // add to activity log
+            Activity::log($event, $this->user, 7);
+        }
 
         // handle the request if ajax
         if ($request->ajax()) {
@@ -2871,7 +2873,9 @@ class EventsController extends Controller
 
         // delete the follow
         $response = Follow::where('object_id', '=', $id)->where('user_id', '=', $this->user->id)->where('object_type', '=', 'event')->first();
-        $response->delete();
+        if ($response) {
+            $response->delete();
+        }
 
         flash()->success('Success', 'You are no longer following the event.');
 

--- a/app/Http/Controllers/ThreadsController.php
+++ b/app/Http/Controllers/ThreadsController.php
@@ -997,7 +997,9 @@ class ThreadsController extends Controller
 
         // delete the follow
         $response = Follow::where('object_id', '=', $id)->where('user_id', '=', $this->user->id)->where('object_type', '=', 'thread')->first();
-        $response->delete();
+        if ($response) {
+            $response->delete();
+        }
 
         flash()->success('Success', 'You are no longer following the thread.');
 
@@ -1060,11 +1062,13 @@ class ThreadsController extends Controller
 
         // delete the like
         $response = Like::where('object_id', '=', $id)->where('user_id', '=', $this->user->id)->where('object_type', '=', 'thread')->first();
-        $response->delete();
+        if ($response) {
+            $response->delete();
 
-        // update the likes
-        --$thread->likes;
-        $thread->save();
+            // update the likes
+            --$thread->likes;
+            $thread->save();
+        }
 
         flash()->success('Success', 'You are no longer liking the thread.');
 

--- a/tests/Feature/UnfollowUnlikeNullGuardTest.php
+++ b/tests/Feature/UnfollowUnlikeNullGuardTest.php
@@ -3,9 +3,11 @@
 namespace Tests\Feature;
 
 use App\Models\Entity;
+use App\Models\Event;
 use App\Models\Post;
 use App\Models\Series;
 use App\Models\Tag;
+use App\Models\Thread;
 use App\Models\User;
 use App\Models\UserStatus;
 use Carbon\Carbon;
@@ -68,6 +70,42 @@ class UnfollowUnlikeNullGuardTest extends TestCase
         $response = $this->get('/tags/'.$tag->id.'/unfollow');
 
         $response->assertRedirect();
+    }
+
+    /** @test */
+    public function unattending_an_event_you_are_not_attending_does_not_error(): void
+    {
+        $this->actingAs($this->activeUser());
+        $event = Event::factory()->create();
+
+        $response = $this->get('/events/'.$event->id.'/unattend');
+
+        $response->assertRedirect();
+        $this->assertEquals(0, $event->eventResponses()->count());
+    }
+
+    /** @test */
+    public function unfollowing_a_thread_you_do_not_follow_does_not_error(): void
+    {
+        $this->actingAs($this->activeUser());
+        $thread = Thread::factory()->create();
+
+        $response = $this->get('/threads/'.$thread->id.'/unfollow');
+
+        $response->assertRedirect();
+    }
+
+    /** @test */
+    public function unliking_a_thread_you_do_not_like_does_not_error_or_decrement_likes(): void
+    {
+        $this->actingAs($this->activeUser());
+        $thread = Thread::factory()->create(['likes' => 3]);
+
+        $response = $this->get('/threads/'.$thread->id.'/unlike');
+
+        $response->assertRedirect();
+        // Likes must not be decremented when no like existed.
+        $this->assertEquals(3, $thread->fresh()->likes);
     }
 
     /** @test */


### PR DESCRIPTION
## What happened

Sentry [EVENTREPO-XT](https://geoff-maddock.sentry.io/issues/7670169650/) — `Error: Call to a member function delete() on null` at `EventsController.php:2293`, from a real `GET /events/8178/unattend` in production.

`unattend()` looked up the user's attending `EventResponse` and called `->delete()` on it without checking the lookup found anything. Since these are plain `GET` links, hitting the URL with no attending row is easy to do by accident — a double-click, a back-button replay, a stale cached card still showing the attending state, or a browser link prefetch. Result: an unhandled 500 instead of a no-op.

Same class of bug as #1936 ("Fix unfollow/unlike 500s…"), which covered entities, series, tags, posts and blogs. Events and threads were missed in that sweep.

## The fix

The guard pattern #1936 established, applied to every remaining unguarded site:

| File | Method | Notes |
|---|---|---|
| `EventsController.php:2292` | `unattend` | the reported bug |
| `EventsController.php:2873` | `unfollow` | same bug, currently unrouted |
| `Api/EventsController.php:1335, 1526` | `unattend`, `unfollow` | duplicate copies, unrouted dead code, fixed for consistency |
| `ThreadsController.php:999, 1062` | `unfollow`, `unlike` | live routes, same latent 500 |

`Activity::log(…, 7)` and the `--$thread->likes` decrement move inside the guard, so a phantom unattend/unlike can't log bogus activity or drive the like counter negative. `Api\EventsController::unattendJson` (`DELETE /api/events/{event}/attend`) was already guarded — unchanged.

These endpoints are now idempotent: they redirect back with the success flash whether or not a row existed, matching the ones #1936 already fixed.

## Testing

- 3 new regression tests in `tests/Feature/UnfollowUnlikeNullGuardTest.php` (event unattend, thread unfollow, thread unlike). Verified they **error** against the pre-fix controllers and pass with the fix; file is 7/7 green.
- PHPStan clean.

Fixes EVENTREPO-XT

🤖 Generated with [Claude Code](https://claude.com/claude-code)