### PR TITLE
Add summaries and linked tags to the Discord digest

### DIFF
--- a/app/Console/Commands/PostDiscordDigest.php
+++ b/app/Console/Commands/PostDiscordDigest.php
@@ -77,7 +77,7 @@ class PostDiscordDigest extends Command
             $to = $now->copy()->addDays($target->digest_window_days);
 
             $events = $matcher->eventsFor($target, $from, $to)
-                ->with(['venue'])
+                ->with(['venue', 'tags'])
                 ->limit((int) config('discord.digest.max_events', 25))
                 ->get();
 

--- a/app/Services/Integrations/Discord/DiscordEmbedBuilder.php
+++ b/app/Services/Integrations/Discord/DiscordEmbedBuilder.php
@@ -4,6 +4,7 @@ namespace App\Services\Integrations\Discord;
 
 use App\Models\DiscordTarget;
 use App\Models\Event;
+use App\Models\Tag;
 use App\Services\EventTime;
 use Carbon\CarbonInterface;
 use Illuminate\Support\Collection;
@@ -33,6 +34,12 @@ use Illuminate\Support\Str;
 class DiscordEmbedBuilder
 {
     /**
+     * Shorter summary used when a full-detail roundup overruns the description
+     * budget. See digestDescription().
+     */
+    private const DIGEST_SUMMARY_FALLBACK = 60;
+
+    /**
      * A single-event announcement, reminder, or manual post.
      *
      * @return array<string, mixed>
@@ -56,14 +63,12 @@ class DiscordEmbedBuilder
         CarbonInterface $from,
         CarbonInterface $to,
     ): array {
-        $lines = $events->map(fn (Event $event): string => $this->digestLine($event))->all();
-
         $embed = [
             'title' => $this->clamp(
                 'Upcoming events · '.$from->format('M j').'–'.$to->format('M j'),
                 'title'
             ),
-            'description' => $this->joinWithinLimit($lines, (int) $this->limit('description')),
+            'description' => $this->digestDescription($events, (int) $this->limit('description')),
             'color' => $this->color($target),
             'footer' => ['text' => $this->clamp(config('app.app_name').' · '.rtrim((string) config('app.url'), '/'), 'footer')],
         ];
@@ -238,7 +243,60 @@ class DiscordEmbedBuilder
         return $this->clamp($tags, 'footer');
     }
 
-    private function digestLine(Event $event): string
+    /**
+     * The roundup body, at the richest detail level that fits.
+     *
+     * An entry with a summary and four linked tags costs roughly 450
+     * characters, so a full week of events can overrun the 4096 available. A
+     * roundup's job is to list the week: losing events off the end is worse
+     * than losing a few words of summary, so an overflow shortens every entry
+     * before it drops any.
+     *
+     * @param  Collection<int, Event>  $events
+     */
+    private function digestDescription(Collection $events, int $limit): string
+    {
+        $summary = (int) config('discord.digest.summary_length', 140);
+        $tags = (int) config('discord.digest.tag_limit', 4);
+        $entries = [];
+
+        // [summary length, tag count], richest first; 0 drops that part of the
+        // subtext. The last level is the bare headline the digest used before
+        // the subtext existed, which comfortably fits max_events.
+        $levels = [
+            [$summary, $tags],
+            [min(self::DIGEST_SUMMARY_FALLBACK, $summary), $tags],
+            [0, $tags],
+            [0, (int) min(2, $tags)],
+            [0, 0],
+        ];
+
+        foreach ($levels as [$summaryLength, $tagLimit]) {
+            $entries = $events->map(
+                fn (Event $event): string => $this->digestEntry($event, $summaryLength, $tagLimit)
+            )->all();
+
+            $joined = implode("\n\n", $entries);
+
+            if (mb_strlen($joined) <= $limit) {
+                return $joined;
+            }
+        }
+
+        // More events than fit even bare: drop the tail on a whole-entry
+        // boundary, so nothing ends mid markdown-link.
+        return $this->joinWithinLimit($entries, $limit);
+    }
+
+    /**
+     * One digest entry: a headline, and — when the event has either — a second
+     * line carrying its summary and up to $tagLimit linked tags.
+     *
+     * The second line is Discord subtext ('-# '), which renders small and grey.
+     * That keeps a 25-event roundup scannable: the headlines still read as a
+     * list, with the detail underneath rather than competing with them.
+     */
+    private function digestEntry(Event $event, int $summaryLength, int $tagLimit): string
     {
         $line = '**['.$this->escapeMarkdown($event->name).']('.route('events.show', $event).')**';
 
@@ -254,7 +312,64 @@ class DiscordEmbedBuilder
             $line .= ' · '.$price;
         }
 
+        $detail = array_merge(
+            array_filter([$this->digestSummary($event, $summaryLength)]),
+            $this->digestTags($event, $tagLimit),
+        );
+
+        if ([] !== $detail) {
+            $line .= "\n-# ".implode(' · ', $detail);
+        }
+
         return $line;
+    }
+
+    /**
+     * The event's summary, flattened to a single line.
+     *
+     * Whitespace is collapsed because a newline would terminate the subtext
+     * block, dropping the tags out of it and leaving a stray line in the
+     * middle of the roundup.
+     */
+    private function digestSummary(Event $event, int $length): ?string
+    {
+        if ($length <= 0) {
+            return null;
+        }
+
+        $summary = trim((string) $event->short);
+
+        if ('' === $summary) {
+            $summary = trim(strip_tags((string) $event->description));
+        }
+
+        $summary = trim((string) preg_replace('/\s+/u', ' ', $summary));
+
+        if ('' === $summary) {
+            return null;
+        }
+
+        return $this->escapeMarkdown(Str::limit($summary, $length, '…'));
+    }
+
+    /**
+     * Tags as links to their own pages, capped — a busy event can carry a
+     * dozen, which would swamp the summary it sits beside.
+     *
+     * @return array<int, string>
+     */
+    private function digestTags(Event $event, int $limit): array
+    {
+        if ($limit <= 0) {
+            return [];
+        }
+
+        return $event->tags
+            ->filter(fn (Tag $tag): bool => '' !== trim((string) $tag->name))
+            ->take($limit)
+            ->map(fn (Tag $tag): string => '['.$this->escapeMarkdown($tag->name).']('.route('tags.show', $tag).')')
+            ->values()
+            ->all();
     }
 
     /**
@@ -283,17 +398,18 @@ class DiscordEmbedBuilder
     }
 
     /**
-     * Join lines while staying under a character budget, rather than
-     * truncating mid-line and leaving a broken markdown link.
+     * Join entries while staying under a character budget, rather than
+     * truncating mid-entry and leaving a broken markdown link. Entries are
+     * separated by a blank line, since an entry is itself two lines.
      *
-     * @param  array<int, string>  $lines
+     * @param  array<int, string>  $entries
      */
-    private function joinWithinLimit(array $lines, int $limit): string
+    private function joinWithinLimit(array $entries, int $limit): string
     {
         $out = '';
 
-        foreach ($lines as $line) {
-            $candidate = ('' === $out) ? $line : $out."\n".$line;
+        foreach ($entries as $line) {
+            $candidate = ('' === $out) ? $line : $out."\n\n".$line;
 
             if (mb_strlen($candidate) > $limit) {
                 break;

--- a/config/discord.php
+++ b/config/discord.php
@@ -54,12 +54,18 @@ return [
     /*
     | Weekly digest defaults. day is a Carbon dayOfWeek (0 = Sunday, 4 = Thursday),
     | hour is 0-23 in the app timezone. max_events caps a single roundup.
+    |
+    | summary_length and tag_limit bound the subtext line under each entry.
+    | They exist because one verbose event must not crowd later events out of
+    | the description budget — the roundup stops adding entries once it is full.
     */
     'digest' => [
         'default_day' => 4,
         'default_hour' => 10,
         'window_days' => 7,
         'max_events' => 25,
+        'summary_length' => 140,
+        'tag_limit' => 4,
     ],
 
     /*

--- a/docs/discord-integration.md
+++ b/docs/discord-integration.md
@@ -78,6 +78,24 @@ is logged and skipped so one bad webhook cannot stop the rest of the week's dige
 Window is the target's `digest_window_days` (default 7), capped at
 `discord.digest.max_events` (default 25) events.
 
+Each entry is two lines — a headline, then Discord subtext (`-# `, small grey
+text) carrying the event's summary and up to `digest.tag_limit` tags, linked to
+their tag pages:
+
+```
+**[Sinners - Vampire Themed Club Night](…)** — Aug 13, 2026 · Belvederes · $5
+-# Goth, industrial and darkwave DJs until 2am. · [goth](…) · [industrial](…)
+```
+
+The subtext is omitted entirely for an event with neither a summary nor tags.
+
+A full entry costs ~450 characters against Discord's 4096-character
+description, so a busy week does not fit at full detail. Rather than dropping
+the tail of the week, the builder retries at successively lower detail —
+shorter summary, no summary, fewer tags, headline only — and takes the richest
+level that fits. Only if `max_events` bare headlines still overrun does it
+truncate, and then on a whole-entry boundary so no line ends mid-link.
+
 ## Enabling it
 
 Designed to be turned on gradually. Work through these in order.
@@ -182,6 +200,8 @@ narrow criteria, then loosen.
 | `digest.default_hour` | — | 10 | Default digest hour |
 | `digest.window_days` | — | 7 | Default lookahead |
 | `digest.max_events` | — | 25 | Cap on one roundup |
+| `digest.summary_length` | — | 140 | Per-entry summary cap in the roundup |
+| `digest.tag_limit` | — | 4 | Tags shown per roundup entry |
 | `timeout` | `DISCORD_TIMEOUT` | 10 | Webhook HTTP timeout |
 | `embed_color` | — | `0x7B2FF7` | Embed accent |
 | `username` | `DISCORD_WEBHOOK_USERNAME` | — | Override webhook display name |

--- a/tests/Feature/DiscordEmbedBuilderTest.php
+++ b/tests/Feature/DiscordEmbedBuilderTest.php
@@ -286,6 +286,115 @@ class DiscordEmbedBuilderTest extends TestCase
         }
     }
 
+    public function test_a_digest_entry_carries_a_summary_and_linked_tags(): void
+    {
+        $event = Event::factory()->create(['short' => 'Goth and industrial DJs until 2am.']);
+        $event->tags()->attach(Tag::factory()->create(['name' => 'techno', 'slug' => 'techno'])->id);
+
+        $description = $this->digestDescription($event->fresh());
+
+        $this->assertStringContainsString('-# Goth and industrial DJs until 2am. · [techno](', $description);
+        $this->assertStringContainsString('/tags/techno)', $description);
+    }
+
+    public function test_a_digest_entry_lists_at_most_four_tags(): void
+    {
+        $event = Event::factory()->create();
+
+        foreach (['one', 'two', 'three', 'four', 'five'] as $name) {
+            $event->tags()->attach(Tag::factory()->create(['name' => $name, 'slug' => $name])->id);
+        }
+
+        $description = $this->digestDescription($event->fresh());
+
+        $this->assertStringContainsString('/tags/four)', $description);
+        $this->assertStringNotContainsString('/tags/five)', $description);
+    }
+
+    public function test_a_digest_summary_is_flattened_to_one_line_and_truncated(): void
+    {
+        // A newline would end the subtext block, dropping the tags out of it
+        // and leaving a stray line mid-roundup.
+        $event = Event::factory()->create();
+        $event->tags()->attach(Tag::factory()->create(['name' => 'techno', 'slug' => 'techno'])->id);
+
+        // Assigned in memory: the column is narrower than the summary cap, so
+        // a persisted row cannot exercise the truncation.
+        $event = $event->fresh();
+        $event->short = "Two rooms\nof techno ".str_repeat('and more ', 40);
+
+        $subtext = $this->digestSubtext($event);
+
+        $this->assertStringContainsString('Two rooms of techno', $subtext);
+        $this->assertStringContainsString('/tags/techno)', $subtext);
+        $this->assertLessThanOrEqual(200, mb_strlen($subtext));
+    }
+
+    public function test_a_digest_entry_with_nothing_to_add_stays_a_single_line(): void
+    {
+        $event = Event::factory()->create(['short' => '', 'description' => '']);
+
+        $this->assertStringNotContainsString('-# ', $this->digestDescription($event));
+    }
+
+    public function test_a_full_roundup_shortens_entries_rather_than_dropping_events(): void
+    {
+        // max_events worth of detail-heavy entries overruns 4096 characters.
+        // Every event must still be listed — a roundup missing the back half
+        // of the week is worse than one with clipped summaries.
+        $events = Event::factory()->count((int) config('discord.digest.max_events', 25))->create();
+        $tags = Tag::factory()->count(4)->create();
+
+        foreach ($events as $event) {
+            $event->tags()->attach($tags->pluck('id')->all());
+            $event->short = Str::random(140);
+        }
+
+        $payload = $this->builder()->forDigest(
+            DiscordTarget::factory()->create(),
+            $events->map(fn (Event $event): Event => tap($event->fresh(), function (Event $fresh) use ($event): void {
+                $fresh->short = $event->short;
+            })),
+            now(),
+            now()->addWeek(),
+        );
+
+        $description = $payload['embeds'][0]['description'];
+
+        $this->assertLessThanOrEqual(4096, mb_strlen($description));
+
+        foreach ($events as $event) {
+            $this->assertStringContainsString('/events/'.$event->slug, $description);
+        }
+    }
+
+    private function digestDescription(Event $event): string
+    {
+        $payload = $this->builder()->forDigest(
+            DiscordTarget::factory()->create(),
+            collect([$event]),
+            now(),
+            now()->addWeek(),
+        );
+
+        return $payload['embeds'][0]['description'];
+    }
+
+    /**
+     * The subtext line of a one-event digest.
+     */
+    private function digestSubtext(Event $event): string
+    {
+        $lines = array_values(array_filter(
+            explode("\n", $this->digestDescription($event)),
+            fn (string $line): bool => str_starts_with($line, '-# ')
+        ));
+
+        $this->assertCount(1, $lines, 'Expected exactly one subtext line.');
+
+        return $lines[0];
+    }
+
     public function test_a_test_message_carries_no_mention(): void
     {
         $target = DiscordTarget::factory()->create(['mention' => '@everyone']);


### PR DESCRIPTION
Enhances the weekly Discord roundup ([#2058](https://github.com/geoff-maddock/events-tracker/issues/2058)) so each entry carries the event's summary and up to four tags, linked to their tag pages.

## Before

```
**Sinners - Vampire Themed Club Night** — Aug 13, 2026 · Belvederes · $5
**Cycle Techno** — Aug 14, 2026 · Bantha Tea Bar
**Quality Control** — Aug 14, 2026 · Spirit
```

## After

```
**Sinners - Vampire Themed Club Night** — Aug 13, 2026 · Belvederes · $5
-# Goth, industrial and darkwave DJs until 2am, with a costume contest at midnight. · goth · industrial · darkwave · club

**Cycle Techno** — Aug 14, 2026 · Bantha Tea Bar
-# techno · djs

**Quality Control** — Aug 14, 2026 · Spirit
-# Monthly bass night in the upstairs lounge.
```

The second line is Discord subtext (`-# `), which renders small and grey — the headlines still read as a list, with the detail underneath rather than competing with them. Tags render as `[techno](https://arcane.city/tags/techno)`. An event with neither a summary nor tags stays a single line.

## Fitting the character budget

A full entry costs ~450 characters against Discord's 4096-character description, so a busy week does not fit at full detail — last week's 9-event digest would have been near the edge, and `max_events` (25) blows well past it.

Rather than silently dropping the back half of the week, `digestDescription()` retries at successively lower detail — shorter summary, no summary, fewer tags, headline only — and takes the richest level that fits. Only if 25 bare headlines still overrun does it truncate, and then on a whole-entry boundary so no line ends mid markdown-link.

## Notes

- Summary comes from `short`, falling back to a stripped `description`, capped at `discord.digest.summary_length` (140). Whitespace is collapsed — a newline would terminate the subtext block, dropping the tags out of it.
- `PostDiscordDigest` now eager-loads `tags`; without it the roundup ran a query per event.
- New config: `discord.digest.summary_length` (140) and `discord.digest.tag_limit` (4). Both documented in `docs/discord-integration.md`.
- Reminder, announce and manual posts are untouched — they already carried the description and tags in the embed body and footer.

## Testing

Five new cases in `DiscordEmbedBuilderTest`: summary + linked tags, the four-tag cap, flatten/truncate of a multi-line summary, single-line entry when there is nothing to add, and a full 25-event roundup still listing every event. Full Discord suite green (46 tests), PHPStan clean on the touched paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)