### PR TITLE
Fix: Incorrect integer value for entity_id on API event update [EVENTREPO-XV]

### DIFF
--- a/app/Http/Requests/EventPatchRequest.php
+++ b/app/Http/Requests/EventPatchRequest.php
@@ -51,6 +51,11 @@ class EventPatchRequest extends Request
             'door_price' => ['sometimes', 'nullable', 'numeric', 'between:0,999.99'],
             'primary_link' => ['sometimes', 'nullable', 'regex:/^http:\/\/|https:\/\/|^$/', 'max:255'],
             'ticket_link' => ['sometimes', 'nullable', 'regex:/^http:\/\/|https:\/\/|^$/', 'max:255'],
+            // Only validated when present. entity_list must be existing entity
+            // IDs so a bad body returns 422 rather than a raw SQL error on the
+            // entity_id integer column (EVENTREPO-XV).
+            'entity_list' => ['sometimes', 'nullable', 'array'],
+            'entity_list.*' => ['integer', 'exists:entities,id'],
         ];
     }
 }

--- a/app/Http/Requests/EventRequest.php
+++ b/app/Http/Requests/EventRequest.php
@@ -58,6 +58,12 @@ class EventRequest extends Request
             'door_price' => 'nullable|numeric|between:0,999.99',
             'primary_link' => ['nullable','regex:/^http:\/\/|https:\/\/|^$/','max:255'],
             'ticket_link' => ['nullable','regex:/^http:\/\/|https:\/\/|^$/','max:255'],
+            // entity_list is a set of existing entity IDs that get synced onto
+            // the event. Reject non-integer / unknown values here so a bad body
+            // (e.g. entity names instead of IDs) returns 422 rather than tripping
+            // the entity_id integer column with a raw SQL error (EVENTREPO-XV).
+            'entity_list' => ['nullable', 'array'],
+            'entity_list.*' => ['integer', 'exists:entities,id'],
         ];
     }
 
@@ -83,6 +89,9 @@ class EventRequest extends Request
             'primary_link.max' => 'A primary link must be less than 255 characters',
             'ticket_link.regex' => 'A ticket link must be a valid URL starting with http:// or https:// or blank',
             'ticket_link.max' => 'A ticket link must be less than 255 characters',
+            'entity_list.array' => 'The entity list must be an array of entity IDs',
+            'entity_list.*.integer' => 'Each entity in the entity list must be an entity ID',
+            'entity_list.*.exists' => 'Each entity in the entity list must reference an existing entity',
         ];
     }
 }

--- a/tests/Feature/ApiEventsCrudTest.php
+++ b/tests/Feature/ApiEventsCrudTest.php
@@ -156,6 +156,60 @@ class ApiEventsCrudTest extends TestCase
         $this->assertContains($response->status(), [302, 401, 403]);
     }
 
+    public function test_update_rejects_non_integer_entity_list(): void
+    {
+        $event = Event::factory()->create([
+            'created_by' => $this->user->id,
+            'slug' => 'zz-entity-list-target-'.uniqid(),
+        ]);
+
+        // Client sends entity names instead of IDs (EVENTREPO-XV): must 422,
+        // not trip the entity_id integer column with a raw SQL error.
+        $payload = $this->validPayload([
+            'slug' => $event->slug,
+            'entity_list' => ['Preserving Underground'],
+        ]);
+
+        $response = $this->putJson('/api/events/'.$event->slug, $payload);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors('entity_list.0');
+    }
+
+    public function test_update_syncs_valid_entity_ids(): void
+    {
+        $event = Event::factory()->create([
+            'created_by' => $this->user->id,
+            'slug' => 'zz-entity-sync-target-'.uniqid(),
+        ]);
+        $entity = \App\Models\Entity::factory()->create();
+
+        $payload = $this->validPayload([
+            'slug' => $event->slug,
+            'entity_list' => [$entity->id],
+        ]);
+
+        $response = $this->putJson('/api/events/'.$event->slug, $payload);
+
+        $response->assertOk();
+        $this->assertSame([$entity->id], $event->fresh()->entity_list);
+    }
+
+    public function test_patch_rejects_non_integer_entity_list(): void
+    {
+        $event = Event::factory()->create([
+            'created_by' => $this->user->id,
+            'slug' => 'zz-patch-entity-list-'.uniqid(),
+        ]);
+
+        $response = $this->patchJson('/api/events/'.$event->slug, [
+            'entity_list' => ['Preserving Underground'],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors('entity_list.0');
+    }
+
     public function test_patch_partial_update_for_creator(): void
     {
         $event = Event::factory()->create([


### PR DESCRIPTION
## Sentry issue

[EVENTREPO-XV](https://sentry.io/organizations/geoff-maddock/issues/7670781312/) — `Illuminate\Database\QueryException: SQLSTATE[HY000]: General error: 1366 Incorrect integer value: 'Preserving Underground' for column 'entity_id' at row 1` on `PUT /api/events/{event}`.

## Error summary

The failing request was a `PUT /api/events/e-town-concrete` with body:

```json
{ "name": "E-Town Concrete", "entity_list": ["Preserving Underground"], "tag_list": ["Hardcore", "Metalcore"], ... }
```

`Api\EventsController::update()` (line 1103) syncs `entity_list` **directly** onto the `entity_event` pivot:

```php
$event->tags()->sync($this->resolveTagIds($request->input('tag_list', [])));
$event->entities()->sync($request->input('entity_list', []));
```

Unlike `tag_list` — which passes through `resolveTagIds()` and accepts names — `entity_list` is synced raw. When the client sends an entity **name** (`"Preserving Underground"`) instead of an integer ID, the string reaches the `entity_id` integer FK column and MySQL raises an unhandled `QueryException`, returning a **500**.

No user feedback was attached to this issue.

## Root cause

`entity_list` is documented and tested as an array of **existing entity IDs** (`tests/Unit/Models/EventModelTest.php` asserts the `entity_list` accessor returns attached IDs; `tests/Feature/SeriesTest.php` passes `[$entity->id]`). Entities cannot be auto-created from a name the way tags can (they require a type, etc.), so the intended contract is IDs. There was no validation guarding the value before it hit the pivot sync, so malformed input surfaced as a raw database error instead of a client error.

## What changed

Added validation so bad input returns a clean **422** instead of a 500 — a minimal, targeted fix with no change to the intended API contract:

- **`app/Http/Requests/EventRequest.php`** (covers `store` + `update`): `entity_list` → `nullable|array`, `entity_list.*` → `integer|exists:entities,id`, plus friendly messages.
- **`app/Http/Requests/EventPatchRequest.php`** (covers `patch`): the same rules with `sometimes`, matching PATCH semantics (only validated when present).
- **`tests/Feature/ApiEventsCrudTest.php`**: PUT and PATCH with entity names now assert 422 with an `entity_list.0` validation error; PUT with a valid entity ID still syncs and returns 200.

`tag_list` is intentionally left untouched — it resolves/creates by name by design.

## Testing notes

PHP syntax was verified on all changed files (`php -l`). The full `composer` test/phpstan pipeline could **not** be run in this ephemeral environment: `composer install` fails on network (GitHub SSL timeouts, no auth token) so `vendor/` is absent, and there is no `.env`/MySQL. Please rely on CI to run PHPStan and the new feature tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_016TV2E3VGaJvSYPfdHzwwup)_