### PR TITLE
Stop mail transport failures from 500ing event creation

### DIFF
--- a/app/Http/Controllers/Api/BlogsController.php
+++ b/app/Http/Controllers/Api/BlogsController.php
@@ -8,6 +8,7 @@ use App\Http\Requests\BlogPatchRequest;
 use App\Http\Requests\BlogRequest;
 use App\Http\Resources\BlogCollection;
 use App\Http\Resources\BlogResource;
+use App\Services\BestEffortMailer;
 use Illuminate\Http\JsonResponse;
 use App\Http\ResultBuilder\ListEntityResultBuilder;
 use App\Models\Activity;
@@ -183,6 +184,10 @@ class BlogsController extends Controller
         $site = config('app.app_name');
         $url = config('app.url');
 
+        // Follower notification is best-effort — the blog is already saved, so
+        // a mail failure must not surface as a 500.
+        $mailer = new BestEffortMailer();
+
         // notify users following any of the tags
         $tags = $blog->tags()->get();
         $users = [];
@@ -193,15 +198,19 @@ class BlogsController extends Controller
             foreach ($tag->followers() as $user) {
                 // if the user hasn't already been notified, then email them
                 if (!array_key_exists($user->id, $users)) {
-                    Mail::send('emails.following-thread', ['user' => $user, 'blog' => $blog, 'object' => $tag, 'reply_email' => $reply_email, 'site' => $site, 'url' => $url], function ($m) use ($user, $blog, $tag, $reply_email, $site) {
-                        $m->from($reply_email, $site);
+                    $mailer->attempt(function () use ($user, $blog, $tag, $reply_email, $site, $url) {
+                        Mail::send('emails.following-thread', ['user' => $user, 'blog' => $blog, 'object' => $tag, 'reply_email' => $reply_email, 'site' => $site, 'url' => $url], function ($m) use ($user, $blog, $tag, $reply_email, $site) {
+                            $m->from($reply_email, $site);
 
-                        $m->to($user->email, $user->name)->subject($site.': '.$tag->name.' :: '.$blog->created_at->format('D F jS').' '.$blog->name);
-                    });
+                            $m->to($user->email, $user->name)->subject($site.': '.$tag->name.' :: '.$blog->created_at->format('D F jS').' '.$blog->name);
+                        });
+                    }, ['blog_id' => $blog->id, 'user_id' => $user->id, 'via' => 'tag']);
                     $users[$user->id] = $tag->name;
                 }
             }
         }
+
+        $mailer->logSummary('Api\\BlogsController@notifyFollowing', ['blog_id' => $blog->id]);
 
         return back();
     }

--- a/app/Http/Controllers/Api/EventsController.php
+++ b/app/Http/Controllers/Api/EventsController.php
@@ -1071,12 +1071,7 @@ class EventsController extends Controller
             }
         }
 
-        $summary = $mailer->summary();
-        if ($summary['failed'] > 0 || $summary['skipped'] > 0) {
-            Log::warning('Api\EventsController@notifyFollowing: some follower notifications were not sent', $summary + [
-                'event_id' => $event->id,
-            ]);
-        }
+        $mailer->logSummary('Api\EventsController@notifyFollowing', ['event_id' => $event->id]);
     }
 
     /**

--- a/app/Http/Controllers/Api/EventsController.php
+++ b/app/Http/Controllers/Api/EventsController.php
@@ -30,6 +30,7 @@ use App\Models\Thread;
 use App\Models\User;
 use App\Models\Visibility;
 use App\Notifications\EventPublished;
+use App\Services\BestEffortMailer;
 use App\Services\Embeds\OembedExtractor;
 use App\Services\ImageHandler;
 use App\Services\RssFeed;
@@ -1013,6 +1014,10 @@ class EventsController extends Controller
         $site = config('app.app_name');
         $url = config('app.url');
 
+        // Follower notification is best-effort — the event is already saved, so
+        // a mail failure must not surface as a 500 on event creation.
+        $mailer = new BestEffortMailer();
+
         // notify users following any of the tags
         $tags = $event->tags()->get();
         $users = [];
@@ -1030,8 +1035,11 @@ class EventsController extends Controller
                 // no user_id attribute (it was always null, collapsing every
                 // follower onto one key and skipping all but the first)
                 if (!array_key_exists($user->id, $users)) {
-                    Mail::to($user->email)
-                        ->send(new FollowingUpdate($url, $site, $admin_email, $reply_email, $user, $event, $tag));
+                    $mailer->send(
+                        $user->email,
+                        new FollowingUpdate($url, $site, $admin_email, $reply_email, $user, $event, $tag),
+                        ['event_id' => $event->id, 'user_id' => $user->id, 'via' => 'tag']
+                    );
                     $users[$user->id] = $tag->name;
                 } else {
                     $users[$user->id] = $users[$user->id].', '.$tag->name;
@@ -1051,13 +1059,23 @@ class EventsController extends Controller
                 }
                 // if the user hasn't already been notified, then email them
                 if (!array_key_exists($user->id, $users)) {
-                    Mail::to($user->email)
-                        ->send(new FollowingUpdate($url, $site, $admin_email, $reply_email, $user, $event, $entity));
+                    $mailer->send(
+                        $user->email,
+                        new FollowingUpdate($url, $site, $admin_email, $reply_email, $user, $event, $entity),
+                        ['event_id' => $event->id, 'user_id' => $user->id, 'via' => 'entity']
+                    );
                     $users[$user->id] = $entity->name;
                 } else {
                     $users[$user->id] = $users[$user->id].', '.$entity->name;
                 }
             }
+        }
+
+        $summary = $mailer->summary();
+        if ($summary['failed'] > 0 || $summary['skipped'] > 0) {
+            Log::warning('Api\EventsController@notifyFollowing: some follower notifications were not sent', $summary + [
+                'event_id' => $event->id,
+            ]);
         }
     }
 

--- a/app/Http/Controllers/Api/PostsController.php
+++ b/app/Http/Controllers/Api/PostsController.php
@@ -17,6 +17,7 @@ use App\Models\Tag;
 use App\Models\Thread;
 use App\Models\User;
 use App\Models\Visibility;
+use App\Services\BestEffortMailer;
 use App\Services\SessionStore\ListParameterSessionStore;
 use App\Services\StringHelper;
 use Illuminate\Http\RedirectResponse;
@@ -340,6 +341,10 @@ class PostsController extends Controller
         $tags = $thread->tags()->get();
         $users = [];
 
+        // Follower notification is best-effort — the post is already saved, so
+        // a mail failure must not surface as a 500 on posting.
+        $mailer = new BestEffortMailer();
+
         // notify users who are following this thread
         foreach ($thread->followers() as $user) {
             // if the user does not have this setting, continue
@@ -348,7 +353,11 @@ class PostsController extends Controller
             }
             // if the user hasn't already been notified, then email them
             if (!array_key_exists($user->id, $users)) {
-                Mail::to($user->email)->send(new FollowingPostUpdate($url, $site, $admin_email, $reply_email, $user, $thread, $post));
+                $mailer->send(
+                    $user->email,
+                    new FollowingPostUpdate($url, $site, $admin_email, $reply_email, $user, $thread, $post),
+                    ['post_id' => $post->id, 'user_id' => $user->id, 'via' => 'thread']
+                );
                 $users[$user->id] = $thread->name;
             }
         }
@@ -362,7 +371,11 @@ class PostsController extends Controller
                 }
                 // if the user hasn't already been notified, then email them
                 if (!array_key_exists($user->id, $users)) {
-                    Mail::to($user->email)->send(new FollowingPostUpdate($url, $site, $admin_email, $reply_email, $user, $thread, $post, $tag));
+                    $mailer->send(
+                        $user->email,
+                        new FollowingPostUpdate($url, $site, $admin_email, $reply_email, $user, $thread, $post, $tag),
+                        ['post_id' => $post->id, 'user_id' => $user->id, 'via' => 'tag']
+                    );
                     $users[$user->id] = $tag->name;
                 }
             }
@@ -380,11 +393,17 @@ class PostsController extends Controller
 
                 // if the user hasn't already been notified, then email them
                 if (!array_key_exists($user->id, $users)) {
-                    Mail::to($user->email)->send(new FollowingPostUpdate($url, $site, $admin_email, $reply_email, $user, $thread, $post));
+                    $mailer->send(
+                        $user->email,
+                        new FollowingPostUpdate($url, $site, $admin_email, $reply_email, $user, $thread, $post),
+                        ['post_id' => $post->id, 'user_id' => $user->id, 'via' => 'series']
+                    );
                     $users[$user->id] = $series->name;
                 }
             }
         }
+
+        $mailer->logSummary('Api\\PostsController@notifyFollowing', ['post_id' => $post->id]);
 
         return back();
     }

--- a/app/Http/Controllers/Api/TagsController.php
+++ b/app/Http/Controllers/Api/TagsController.php
@@ -14,6 +14,7 @@ use App\Models\Follow;
 use App\Models\Series;
 use App\Models\Tag;
 use App\Models\TagType;
+use App\Services\BestEffortMailer;
 use App\Services\SessionStore\ListParameterSessionStore;
 use App\Services\StringHelper;
 use Carbon\Carbon;
@@ -488,20 +489,28 @@ class TagsController extends Controller
         $site = config('app.app_name');
         $url = config('app.url');
 
+        // Follower notification is best-effort — the tag is already saved, so
+        // a mail failure must not surface as a 500.
+        $mailer = new BestEffortMailer();
+
         // notify users following any of the tags
         $users = [];
 
         foreach ($tag->followers() as $user) {
             // if the user hasn't already been notified, then email them
             if (!array_key_exists($user->id, $users)) {
-                Mail::send('emails.following-thread', ['user' => $user, 'object' => $tag, 'reply_email' => $reply_email, 'site' => $site], function ($m) use ($user, $tag, $reply_email, $site) {
-                    $m->from($reply_email, $site);
+                $mailer->attempt(function () use ($user, $tag, $reply_email, $site) {
+                    Mail::send('emails.following-thread', ['user' => $user, 'object' => $tag, 'reply_email' => $reply_email, 'site' => $site], function ($m) use ($user, $tag, $reply_email, $site) {
+                        $m->from($reply_email, $site);
 
-                    $m->to($user->email, $user->name)->subject($site.': '.$tag->name.' :: '.$tag->created_at->format('D F jS'));
-                });
+                        $m->to($user->email, $user->name)->subject($site.': '.$tag->name.' :: '.$tag->created_at->format('D F jS'));
+                    });
+                }, ['tag_id' => $tag->id, 'user_id' => $user->id]);
                 $users[$user->id] = $tag->name;
             }
         }
+
+        $mailer->logSummary('Api\\TagsController@notifyFollowing', ['tag_id' => $tag->id]);
 
         return back();
     }

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -22,6 +22,7 @@ use App\Models\Profile;
 use App\Models\User;
 use App\Models\UserStatus;
 use App\Models\Visibility;
+use App\Services\BestEffortMailer;
 use App\Services\ImageHandler;
 use App\Services\SessionStore\ListParameterSessionStore;
 use Carbon\Carbon;
@@ -403,7 +404,9 @@ class UsersController extends Controller
         $site = config('app.app_name');
         $url = config('app.url');
 
-        Mail::to($user->email)->send(new UserActivation($url, $site, $admin_email, $reply_email, $user));
+        // The activation itself succeeded; a mail failure is logged and
+        // reported, not turned into a failed API response.
+        (new BestEffortMailer())->send($user->email, new UserActivation($url, $site, $admin_email, $reply_email, $user), ['user_id' => $user->id]);
 
         return response()->json(new UserResource($user));
     }
@@ -442,7 +445,9 @@ class UsersController extends Controller
         $site = config('app.app_name');
         $url = config('app.url');
 
-        Mail::to($user->email)->send(new UserSuspended($url, $site, $admin_email, $reply_email, $user));
+        // The suspension itself succeeded; a mail failure is logged and
+        // reported, not turned into a failed API response.
+        (new BestEffortMailer())->send($user->email, new UserSuspended($url, $site, $admin_email, $reply_email, $user), ['user_id' => $user->id]);
 
         return back();
     }
@@ -642,9 +647,11 @@ class UsersController extends Controller
             }
         }
 
-        Mail::to($user->email)->send(new UserUpdate($url, $site, $admin_email, $reply_email, $user, $attendingEvents, $seriesList, $interests));
-
-        flash()->success('Success', 'A daily-style notification email was sent to  '.$user->name.' at '.$user->email);
+        if ((new BestEffortMailer())->send($user->email, new UserUpdate($url, $site, $admin_email, $reply_email, $user, $attendingEvents, $seriesList, $interests), ['user_id' => $user->id])) {
+            flash()->success('Success', 'A daily-style notification email was sent to  '.$user->name.' at '.$user->email);
+        } else {
+            flash()->error('Email not sent', 'The daily-style notification email to '.$user->email.' could not be sent.');
+        }
 
         return back();
     }
@@ -723,8 +730,7 @@ class UsersController extends Controller
         // if there are more than 0 events
         if ((null !== $attendingEvents && $attendingEvents->count() > 0) || (null !== $seriesList && count($seriesList) > 0) || (null !== $interests && count($interests) > 0)) {
             // send an email containing that list
-            Mail::to($user->email)
-                ->send(new WeeklyUpdate($url, $site, $admin_email, $reply_email, $user, $attendingEvents, $seriesList, $interests));
+            (new BestEffortMailer())->send($user->email, new WeeklyUpdate($url, $site, $admin_email, $reply_email, $user, $attendingEvents, $seriesList, $interests), ['user_id' => $user->id]);
         }
 
         return back();

--- a/app/Http/Controllers/BlogsController.php
+++ b/app/Http/Controllers/BlogsController.php
@@ -14,6 +14,7 @@ use App\Models\Menu;
 use App\Models\Tag;
 use App\Models\User;
 use App\Models\Visibility;
+use App\Services\BestEffortMailer;
 use App\Services\ImageHandler;
 use App\Services\SessionStore\ListParameterSessionStore;
 use Illuminate\Http\RedirectResponse;
@@ -243,6 +244,10 @@ class BlogsController extends Controller
         $site = config('app.app_name');
         $url = config('app.url');
 
+        // Follower notification is best-effort — the blog is already saved, so
+        // a mail failure must not surface as a 500.
+        $mailer = new BestEffortMailer();
+
         // notify users following any of the tags
         $tags = $blog->tags()->get();
         $users = [];
@@ -253,15 +258,19 @@ class BlogsController extends Controller
             foreach ($tag->followers() as $user) {
                 // if the user hasn't already been notified, then email them
                 if (!array_key_exists($user->id, $users)) {
-                    Mail::send('emails.following-thread', ['user' => $user, 'blog' => $blog, 'object' => $tag, 'reply_email' => $reply_email, 'site' => $site, 'url' => $url], function ($m) use ($user, $blog, $tag, $reply_email, $site) {
-                        $m->from($reply_email, $site);
+                    $mailer->attempt(function () use ($user, $blog, $tag, $reply_email, $site, $url) {
+                        Mail::send('emails.following-thread', ['user' => $user, 'blog' => $blog, 'object' => $tag, 'reply_email' => $reply_email, 'site' => $site, 'url' => $url], function ($m) use ($user, $blog, $tag, $reply_email, $site) {
+                            $m->from($reply_email, $site);
 
-                        $m->to($user->email, $user->name)->subject($site.': '.$tag->name.' :: '.$blog->created_at->format('D F jS').' '.$blog->name);
-                    });
+                            $m->to($user->email, $user->name)->subject($site.': '.$tag->name.' :: '.$blog->created_at->format('D F jS').' '.$blog->name);
+                        });
+                    }, ['blog_id' => $blog->id, 'user_id' => $user->id, 'via' => 'tag']);
                     $users[$user->id] = $tag->name;
                 }
             }
         }
+
+        $mailer->logSummary('BlogsController@notifyFollowing', ['blog_id' => $blog->id]);
 
         return back();
     }

--- a/app/Http/Controllers/EntitiesController.php
+++ b/app/Http/Controllers/EntitiesController.php
@@ -18,6 +18,7 @@ use App\Models\Tag;
 use App\Models\User;
 use App\Mail\EntityUpdateSummary;
 use App\Notifications\EventPublished;
+use App\Services\BestEffortMailer;
 use App\Services\Embeds\OembedExtractor;
 use App\Services\ImageHandler;
 use App\Services\SessionStore\ListParameterSessionStore;
@@ -1708,7 +1709,7 @@ class EntitiesController extends Controller
         // venues frequently performed at
         $frequentlyPerformsAt = $entity->getFrequentlyPerformsAt(10);
 
-        Mail::to($contact->email, $contact->name ?? $entity->name)
+        $sent = (new BestEffortMailer())->attempt(fn () => Mail::to($contact->email, $contact->name ?? $entity->name)
             ->send(new EntityUpdateSummary(
                 $url,
                 $site,
@@ -1719,7 +1720,15 @@ class EntitiesController extends Controller
                 $pastEvents,
                 $frequentlyPerformsWith,
                 $frequentlyPerformsAt
-            ));
+            )), ['entity_id' => $entity->id]);
+
+        // Sending the summary is the point of this action — do not claim it
+        // was delivered when the transport rejected it.
+        if (!$sent) {
+            flash()->error('Email not sent', 'The update summary to ' . $contact->email . ' could not be sent.');
+
+            return back();
+        }
 
         Log::info('Entity update summary sent for entity ' . $entity->id . ' (' . $entity->name . ') to ' . $contact->email);
 

--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -26,6 +26,7 @@ use App\Models\Thread;
 use App\Models\User;
 use App\Models\Visibility;
 use App\Notifications\EventPublished;
+use App\Services\BestEffortMailer;
 use App\Services\EventDateRange;
 use App\Services\ImageHandler;
 use App\Services\RssFeed;
@@ -2035,7 +2036,17 @@ class EventsController extends Controller
         if (Auth::user()->hasGroup('super_admin') && config('app.twitter_consumer_key') !== '999') {
             // only tweet if there is a primary photo
             if ($photo !== null) {
-                $event->notify(new EventPublished());
+                // the event is already saved, so a Twitter API failure must not
+                // fail the request either
+                try {
+                    $event->notify(new EventPublished());
+                } catch (\Throwable $e) {
+                    Log::warning('EventsController@store: failed to post event to Twitter', [
+                        'event_id' => $event->id,
+                        'error' => $e->getMessage(),
+                    ]);
+                    report($e);
+                }
             }
         }
 
@@ -2048,6 +2059,10 @@ class EventsController extends Controller
         $reply_email = config('app.noreplyemail');
         $site = config('app.app_name');
         $url = config('app.url');
+
+        // Follower notification is best-effort — the event is already saved, so
+        // a mail failure must not surface as a 500 on event creation.
+        $mailer = new BestEffortMailer();
 
         // notify users following any of the tags
         $tags = $event->tags()->get();
@@ -2066,8 +2081,11 @@ class EventsController extends Controller
                 // no user_id attribute (it was always null, collapsing every
                 // follower onto one key and skipping all but the first)
                 if (!array_key_exists($user->id, $users)) {
-                    Mail::to($user->email)
-                        ->send(new FollowingUpdate($url, $site, $admin_email, $reply_email, $user, $event, $tag));
+                    $mailer->send(
+                        $user->email,
+                        new FollowingUpdate($url, $site, $admin_email, $reply_email, $user, $event, $tag),
+                        ['event_id' => $event->id, 'user_id' => $user->id, 'via' => 'tag']
+                    );
                     $users[$user->id] = $tag->name;
                 } else {
                     $users[$user->id] = $users[$user->id].', '.$tag->name;
@@ -2087,13 +2105,23 @@ class EventsController extends Controller
                 }
                 // if the user hasn't already been notified, then email them
                 if (!array_key_exists($user->id, $users)) {
-                    Mail::to($user->email)
-                        ->send(new FollowingUpdate($url, $site, $admin_email, $reply_email, $user, $event, $entity));
+                    $mailer->send(
+                        $user->email,
+                        new FollowingUpdate($url, $site, $admin_email, $reply_email, $user, $event, $entity),
+                        ['event_id' => $event->id, 'user_id' => $user->id, 'via' => 'entity']
+                    );
                     $users[$user->id] = $entity->name;
                 } else {
                     $users[$user->id] = $users[$user->id].', '.$entity->name;
                 }
             }
+        }
+
+        $summary = $mailer->summary();
+        if ($summary['failed'] > 0 || $summary['skipped'] > 0) {
+            Log::warning('EventsController@notifyFollowing: some follower notifications were not sent', $summary + [
+                'event_id' => $event->id,
+            ]);
         }
     }
 

--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -2117,12 +2117,7 @@ class EventsController extends Controller
             }
         }
 
-        $summary = $mailer->summary();
-        if ($summary['failed'] > 0 || $summary['skipped'] > 0) {
-            Log::warning('EventsController@notifyFollowing: some follower notifications were not sent', $summary + [
-                'event_id' => $event->id,
-            ]);
-        }
+        $mailer->logSummary('EventsController@notifyFollowing', ['event_id' => $event->id]);
     }
 
     public function edit(Event $event): View|RedirectResponse

--- a/app/Http/Controllers/PagesController.php
+++ b/app/Http/Controllers/PagesController.php
@@ -9,6 +9,7 @@ use App\Models\Menu;
 use App\Models\Series;
 use App\Models\Tag;
 use App\Models\User;
+use App\Services\BestEffortMailer;
 use App\Services\EventDateRange;
 use App\Services\SearchService;
 use App\Services\SessionStore\ListParameterSessionStore;
@@ -445,7 +446,11 @@ class PagesController extends Controller
         }
 
         // email the user
-        $this->inviteUser($email);
+        if (!$this->inviteUser($email)) {
+            flash()->error('Email not sent', 'The invite to '.$email.' could not be sent. Please try again later.');
+
+            return back();
+        }
 
         Log::info('Email '.$email.' was invited to join the site');
 
@@ -455,9 +460,10 @@ class PagesController extends Controller
     }
 
     /**
-     * @return \Illuminate\Http\RedirectResponse
+     * Send the invite. Returns false when the mail transport rejected it, so
+     * the caller can report that honestly rather than claiming it was sent.
      */
-    protected function inviteUser(string $email)
+    protected function inviteUser(string $email): bool
     {
         $admin_email = config('app.admin');
         $reply_email = config('app.admin');
@@ -471,19 +477,19 @@ class PagesController extends Controller
         $events = Event::future()->simplePaginate(10);
 
         // send an email inviting the user to join
-        Mail::send(
-            'emails.invite',
-            ['email' => $email,  'events' => $events, 'url' => $url, 'site' => $site],
-            function ($m) use ($email, $admin_email, $reply_email, $site) {
-                $m->from($reply_email, $site);
+        return (new BestEffortMailer())->attempt(function () use ($email, $events, $url, $site, $admin_email, $reply_email) {
+            Mail::send(
+                'emails.invite',
+                ['email' => $email,  'events' => $events, 'url' => $url, 'site' => $site],
+                function ($m) use ($email, $admin_email, $reply_email, $site) {
+                    $m->from($reply_email, $site);
 
-                $dt = Carbon::now();
-                $m->to($email, $email)
-                    ->bcc($admin_email)
-                    ->subject($site.': Event Tracker Invite - '.$dt->format('l F jS Y'));
-            }
-        );
-
-        return back();
+                    $dt = Carbon::now();
+                    $m->to($email, $email)
+                        ->bcc($admin_email)
+                        ->subject($site.': Event Tracker Invite - '.$dt->format('l F jS Y'));
+                }
+            );
+        }, ['invite_email' => $email]);
     }
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -14,6 +14,7 @@ use App\Models\Tag;
 use App\Models\Thread;
 use App\Models\User;
 use App\Models\Visibility;
+use App\Services\BestEffortMailer;
 use App\Services\SessionStore\ListParameterSessionStore;
 use App\Services\StringHelper;
 use Illuminate\Http\RedirectResponse;
@@ -355,6 +356,10 @@ class PostsController extends Controller
         $tags = $thread->tags()->get();
         $users = [];
 
+        // Follower notification is best-effort — the post is already saved, so
+        // a mail failure must not surface as a 500 on posting.
+        $mailer = new BestEffortMailer();
+
         // notify users who are following this thread
         foreach ($thread->followers() as $user) {
             // if the user does not have this setting, continue
@@ -363,7 +368,11 @@ class PostsController extends Controller
             }
             // if the user hasn't already been notified, then email them
             if (!array_key_exists($user->id, $users)) {
-                Mail::to($user->email)->send(new FollowingPostUpdate($url, $site, $admin_email, $reply_email, $user, $thread, $post));
+                $mailer->send(
+                    $user->email,
+                    new FollowingPostUpdate($url, $site, $admin_email, $reply_email, $user, $thread, $post),
+                    ['post_id' => $post->id, 'user_id' => $user->id, 'via' => 'thread']
+                );
                 $users[$user->id] = $thread->name;
             }
         }
@@ -377,7 +386,11 @@ class PostsController extends Controller
                 }
                 // if the user hasn't already been notified, then email them
                 if (!array_key_exists($user->id, $users)) {
-                    Mail::to($user->email)->send(new FollowingPostUpdate($url, $site, $admin_email, $reply_email, $user, $thread, $post, $tag));
+                    $mailer->send(
+                        $user->email,
+                        new FollowingPostUpdate($url, $site, $admin_email, $reply_email, $user, $thread, $post, $tag),
+                        ['post_id' => $post->id, 'user_id' => $user->id, 'via' => 'tag']
+                    );
                     $users[$user->id] = $tag->name;
                 }
             }
@@ -395,11 +408,17 @@ class PostsController extends Controller
 
                 // if the user hasn't already been notified, then email them
                 if (!array_key_exists($user->id, $users)) {
-                    Mail::to($user->email)->send(new FollowingPostUpdate($url, $site, $admin_email, $reply_email, $user, $thread, $post));
+                    $mailer->send(
+                        $user->email,
+                        new FollowingPostUpdate($url, $site, $admin_email, $reply_email, $user, $thread, $post),
+                        ['post_id' => $post->id, 'user_id' => $user->id, 'via' => 'series']
+                    );
                     $users[$user->id] = $series->name;
                 }
             }
         }
+
+        $mailer->logSummary('PostsController@notifyFollowing', ['post_id' => $post->id]);
 
         return back();
     }

--- a/app/Http/Controllers/ReviewsController.php
+++ b/app/Http/Controllers/ReviewsController.php
@@ -12,6 +12,7 @@ use App\Models\ReviewType;
 use App\Models\Tag;
 use App\Models\User;
 use App\Models\Visibility;
+use App\Services\BestEffortMailer;
 use App\Services\SessionStore\ListParameterSessionStore;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
@@ -313,6 +314,10 @@ class ReviewsController extends Controller
         $site = config('app.app_name');
         $url = config('app.url');
 
+        // Follower notification is best-effort — the review is already saved,
+        // so a mail failure must not surface as a 500.
+        $mailer = new BestEffortMailer();
+
         // notify users following any of the tags
         $tags = $event->tags()->get();
         $users = [];
@@ -322,11 +327,13 @@ class ReviewsController extends Controller
             foreach ($tag->followers() as $user) {
                 // if the user hasn't already been notified, then email them
                 if (!array_key_exists($user->id, $users)) {
-                    Mail::send('emails.following', ['user' => $user, 'event' => $event, 'object' => $tag, 'reply_email' => $reply_email, 'site' => $site], function ($m) use ($user, $event, $tag, $reply_email, $site) {
-                        $m->from($reply_email, $site);
+                    $mailer->attempt(function () use ($user, $event, $tag, $reply_email, $site) {
+                        Mail::send('emails.following', ['user' => $user, 'event' => $event, 'object' => $tag, 'reply_email' => $reply_email, 'site' => $site], function ($m) use ($user, $event, $tag, $reply_email, $site) {
+                            $m->from($reply_email, $site);
 
-                        $m->to($user->email, $user->name)->subject($site.': '.$tag->name.' :: '.$event->start_at->format('D F jS').' '.$event->name);
-                    });
+                            $m->to($user->email, $user->name)->subject($site.': '.$tag->name.' :: '.$event->start_at->format('D F jS').' '.$event->name);
+                        });
+                    }, ['event_id' => $event->id, 'user_id' => $user->id, 'via' => 'tag']);
                     $users[$user->id] = $tag->name;
                 }
             }
@@ -340,15 +347,19 @@ class ReviewsController extends Controller
             foreach ($entity->followers() as $user) {
                 // if the user hasn't already been notified, then email them
                 if (!array_key_exists($user->id, $users)) {
-                    Mail::send('emails.following', ['user' => $user, 'event' => $event, 'object' => $entity, 'reply_email' => $reply_email, 'site' => $site], function ($m) use ($user, $event, $entity, $reply_email, $site) {
-                        $m->from($reply_email, $site);
+                    $mailer->attempt(function () use ($user, $event, $entity, $reply_email, $site) {
+                        Mail::send('emails.following', ['user' => $user, 'event' => $event, 'object' => $entity, 'reply_email' => $reply_email, 'site' => $site], function ($m) use ($user, $event, $entity, $reply_email, $site) {
+                            $m->from($reply_email, $site);
 
-                        $m->to($user->email, $user->name)->subject($site.': '.$entity->name.' :: '.$event->start_at->format('D F jS').' '.$event->name);
-                    });
+                            $m->to($user->email, $user->name)->subject($site.': '.$entity->name.' :: '.$event->start_at->format('D F jS').' '.$event->name);
+                        });
+                    }, ['event_id' => $event->id, 'user_id' => $user->id, 'via' => 'entity']);
                     $users[$user->id] = $entity->name;
                 }
             }
         }
+
+        $mailer->logSummary('ReviewsController@notifyFollowing', ['event_id' => $event->id]);
 
         return back();
     }

--- a/app/Http/Controllers/TagsController.php
+++ b/app/Http/Controllers/TagsController.php
@@ -11,6 +11,7 @@ use App\Models\Follow;
 use App\Models\Series;
 use App\Models\Tag;
 use App\Models\TagType;
+use App\Services\BestEffortMailer;
 use App\Services\StringHelper;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
@@ -624,20 +625,28 @@ class TagsController extends Controller
         $site = config('app.app_name');
         $url = config('app.url');
 
+        // Follower notification is best-effort — the tag is already saved, so
+        // a mail failure must not surface as a 500.
+        $mailer = new BestEffortMailer();
+
         // notify users following any of the tags
         $users = [];
 
         foreach ($tag->followers() as $user) {
             // if the user hasn't already been notified, then email them
             if (!array_key_exists($user->id, $users)) {
-                Mail::send('emails.following-thread', ['user' => $user, 'object' => $tag, 'reply_email' => $reply_email, 'site' => $site], function ($m) use ($user, $tag, $reply_email, $site) {
-                    $m->from($reply_email, $site);
+                $mailer->attempt(function () use ($user, $tag, $reply_email, $site) {
+                    Mail::send('emails.following-thread', ['user' => $user, 'object' => $tag, 'reply_email' => $reply_email, 'site' => $site], function ($m) use ($user, $tag, $reply_email, $site) {
+                        $m->from($reply_email, $site);
 
-                    $m->to($user->email, $user->name)->subject($site.': '.$tag->name.' :: '.$tag->created_at->format('D F jS'));
-                });
+                        $m->to($user->email, $user->name)->subject($site.': '.$tag->name.' :: '.$tag->created_at->format('D F jS'));
+                    });
+                }, ['tag_id' => $tag->id, 'user_id' => $user->id]);
                 $users[$user->id] = $tag->name;
             }
         }
+
+        $mailer->logSummary('TagsController@notifyFollowing', ['tag_id' => $tag->id]);
 
         return back();
     }

--- a/app/Http/Controllers/ThreadsController.php
+++ b/app/Http/Controllers/ThreadsController.php
@@ -19,6 +19,7 @@ use App\Models\Thread;
 use App\Models\ThreadCategory;
 use App\Models\User;
 use App\Models\Visibility;
+use App\Services\BestEffortMailer;
 use App\Services\SessionStore\ListParameterSessionStore;
 use Carbon\Carbon;
 use Illuminate\Http\RedirectResponse;
@@ -721,6 +722,10 @@ class ThreadsController extends Controller
         $tags = $thread->tags()->get();
         $users = [];
 
+        // Follower notification is best-effort — the thread is already saved,
+        // so a mail failure must not surface as a 500 on posting.
+        $mailer = new BestEffortMailer();
+
         // notify users following any tags related to the thread
         foreach ($tags as $tag) {
             foreach ($tag->followers() as $user) {
@@ -734,8 +739,11 @@ class ThreadsController extends Controller
                 }
                 // if the user hasn't already been notified, then email them
                 if (!array_key_exists($user->id, $users)) {
-                    Mail::to($user->email)
-                        ->send(new FollowingThreadUpdate($url, $site, $admin_email, $reply_email, $user, $thread, $tag));
+                    $mailer->send(
+                        $user->email,
+                        new FollowingThreadUpdate($url, $site, $admin_email, $reply_email, $user, $thread, $tag),
+                        ['thread_id' => $thread->id, 'user_id' => $user->id, 'via' => 'tag']
+                    );
 
                     $users[$user->id] = $tag->name;
                 }
@@ -756,12 +764,17 @@ class ThreadsController extends Controller
                 }
                 // if the user hasn't already been notified, then email them
                 if (!array_key_exists($user->id, $users)) {
-                    Mail::to($user->email)
-                        ->send(new FollowingThreadUpdate($url, $site, $admin_email, $reply_email, $user, $thread));
+                    $mailer->send(
+                        $user->email,
+                        new FollowingThreadUpdate($url, $site, $admin_email, $reply_email, $user, $thread),
+                        ['thread_id' => $thread->id, 'user_id' => $user->id, 'via' => 'series']
+                    );
                     $users[$user->id] = $s->name;
                 }
             }
         }
+
+        $mailer->logSummary('ThreadsController@notifyFollowing', ['thread_id' => $thread->id]);
 
         return back();
     }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -18,6 +18,7 @@ use App\Models\Profile;
 use App\Models\User;
 use App\Models\UserStatus;
 use App\Models\Visibility;
+use App\Services\BestEffortMailer;
 use App\Services\ImageHandler;
 use App\Services\SessionStore\ListParameterSessionStore;
 use Carbon\Carbon;
@@ -518,7 +519,11 @@ class UsersController extends Controller
         $site = config('app.app_name');
         $url = config('app.url');
 
-        Mail::to($user->email)->send(new UserActivation($url, $site, $admin_email, $reply_email, $user));
+        // The account is already activated; if the courtesy email cannot be
+        // sent, say so rather than failing the request.
+        if (!(new BestEffortMailer())->send($user->email, new UserActivation($url, $site, $admin_email, $reply_email, $user), ['user_id' => $user->id])) {
+            flash()->error('Email not sent', 'User '.$user->name.' was activated, but the notification email could not be sent.');
+        }
 
         return back();
     }
@@ -557,7 +562,11 @@ class UsersController extends Controller
         $site = config('app.app_name');
         $url = config('app.url');
 
-        Mail::to($user->email)->send(new UserSuspended($url, $site, $admin_email, $reply_email, $user));
+        // The account is already suspended; if the courtesy email cannot be
+        // sent, say so rather than failing the request.
+        if (!(new BestEffortMailer())->send($user->email, new UserSuspended($url, $site, $admin_email, $reply_email, $user), ['user_id' => $user->id])) {
+            flash()->error('Email not sent', 'User '.$user->name.' was suspended, but the notification email could not be sent.');
+        }
 
         return back();
     }
@@ -795,9 +804,13 @@ class UsersController extends Controller
             }
         }
 
-        Mail::to($user->email)->send(new UserUpdate($url, $site, $admin_email, $reply_email, $user, $attendingEvents, $seriesList, $interests));
-
-        flash()->success('Success', 'A daily-style notification email was sent to  '.$user->name.' at '.$user->email);
+        // Sending the email is the whole point of this action, so report the
+        // outcome honestly instead of claiming success unconditionally.
+        if ((new BestEffortMailer())->send($user->email, new UserUpdate($url, $site, $admin_email, $reply_email, $user, $attendingEvents, $seriesList, $interests), ['user_id' => $user->id])) {
+            flash()->success('Success', 'A daily-style notification email was sent to  '.$user->name.' at '.$user->email);
+        } else {
+            flash()->error('Email not sent', 'The daily-style notification email to '.$user->email.' could not be sent.');
+        }
 
         return back();
     }
@@ -876,8 +889,9 @@ class UsersController extends Controller
         // if there are more than 0 events
         if ((null !== $attendingEvents && $attendingEvents->count() > 0) || (null !== $seriesList && count($seriesList) > 0) || (null !== $interests && count($interests) > 0)) {
             // send an email containing that list
-            Mail::to($user->email)
-                ->send(new WeeklyUpdate($url, $site, $admin_email, $reply_email, $user, $attendingEvents, $seriesList, $interests));
+            if (!(new BestEffortMailer())->send($user->email, new WeeklyUpdate($url, $site, $admin_email, $reply_email, $user, $attendingEvents, $seriesList, $interests), ['user_id' => $user->id])) {
+                flash()->error('Email not sent', 'The weekly notification email to '.$user->email.' could not be sent.');
+            }
         }
 
         return back();

--- a/app/Services/BestEffortMailer.php
+++ b/app/Services/BestEffortMailer.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Contracts\Mail\Mailable;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+use Throwable;
+
+/**
+ * Sends notification email without letting a mail failure break the request
+ * that triggered it.
+ *
+ * Follower notifications are best-effort: by the time they are sent the user's
+ * action (creating an event, posting to a thread) has already been committed,
+ * so an unreachable SMTP server should be logged and reported — not turned
+ * into a 500 that tells the user their work failed when it did not.
+ *
+ * A total outage would otherwise cost one SMTP connection attempt per
+ * follower, turning a broken mail server into a hung request. After
+ * MAX_CONSECUTIVE_FAILURES the sender trips and skips the rest of the batch,
+ * so an isolated bad address is still tolerated but a dead transport gives up
+ * quickly.
+ *
+ * One instance is intended per batch — construct it, send through it, then
+ * read the counts for logging.
+ */
+class BestEffortMailer
+{
+    /**
+     * Consecutive failures that trip the breaker for the rest of the batch.
+     */
+    public const MAX_CONSECUTIVE_FAILURES = 3;
+
+    private int $consecutiveFailures = 0;
+
+    private int $sent = 0;
+
+    private int $failed = 0;
+
+    private int $skipped = 0;
+
+    private bool $tripped = false;
+
+    /**
+     * Attempt to send one message. Returns true only if it was handed to the
+     * transport without error.
+     *
+     * @param array<string, mixed> $context extra fields for the failure log
+     */
+    public function send(string $email, Mailable $mailable, array $context = []): bool
+    {
+        if ($this->tripped) {
+            ++$this->skipped;
+
+            return false;
+        }
+
+        try {
+            Mail::to($email)->send($mailable);
+            $this->consecutiveFailures = 0;
+            ++$this->sent;
+
+            return true;
+        } catch (Throwable $e) {
+            ++$this->failed;
+            ++$this->consecutiveFailures;
+
+            Log::warning('BestEffortMailer: notification email failed to send', $context + [
+                'mailable' => $mailable::class,
+                'error' => $e->getMessage(),
+            ]);
+
+            if ($this->consecutiveFailures >= self::MAX_CONSECUTIVE_FAILURES) {
+                $this->tripped = true;
+
+                // Surface the underlying transport error once per batch so it
+                // reaches Sentry, rather than once per follower.
+                report($e);
+
+                Log::error('BestEffortMailer: mail transport looks unavailable, skipping the rest of this batch', $context + [
+                    'consecutive_failures' => $this->consecutiveFailures,
+                    'mailable' => $mailable::class,
+                ]);
+            }
+
+            return false;
+        }
+    }
+
+    /**
+     * True once the breaker has tripped and remaining sends are being skipped.
+     */
+    public function tripped(): bool
+    {
+        return $this->tripped;
+    }
+
+    /**
+     * Counts for the caller to log once the batch is done.
+     *
+     * @return array{sent: int, failed: int, skipped: int, tripped: bool}
+     */
+    public function summary(): array
+    {
+        return [
+            'sent' => $this->sent,
+            'failed' => $this->failed,
+            'skipped' => $this->skipped,
+            'tripped' => $this->tripped,
+        ];
+    }
+}

--- a/app/Services/BestEffortMailer.php
+++ b/app/Services/BestEffortMailer.php
@@ -43,12 +43,27 @@ class BestEffortMailer
     private bool $tripped = false;
 
     /**
-     * Attempt to send one message. Returns true only if it was handed to the
+     * Attempt to send one Mailable. Returns true only if it was handed to the
      * transport without error.
      *
      * @param array<string, mixed> $context extra fields for the failure log
      */
     public function send(string $email, Mailable $mailable, array $context = []): bool
+    {
+        return $this->attempt(
+            fn () => Mail::to($email)->send($mailable),
+            $context + ['mailable' => $mailable::class]
+        );
+    }
+
+    /**
+     * Attempt an arbitrary send. Use for call sites that still build mail with
+     * the Mail::send($view, $data, $closure) form rather than a Mailable.
+     *
+     * @param callable():mixed     $send
+     * @param array<string, mixed> $context extra fields for the failure log
+     */
+    public function attempt(callable $send, array $context = []): bool
     {
         if ($this->tripped) {
             ++$this->skipped;
@@ -57,7 +72,7 @@ class BestEffortMailer
         }
 
         try {
-            Mail::to($email)->send($mailable);
+            $send();
             $this->consecutiveFailures = 0;
             ++$this->sent;
 
@@ -67,7 +82,6 @@ class BestEffortMailer
             ++$this->consecutiveFailures;
 
             Log::warning('BestEffortMailer: notification email failed to send', $context + [
-                'mailable' => $mailable::class,
                 'error' => $e->getMessage(),
             ]);
 
@@ -80,7 +94,6 @@ class BestEffortMailer
 
                 Log::error('BestEffortMailer: mail transport looks unavailable, skipping the rest of this batch', $context + [
                     'consecutive_failures' => $this->consecutiveFailures,
-                    'mailable' => $mailable::class,
                 ]);
             }
 
@@ -94,6 +107,21 @@ class BestEffortMailer
     public function tripped(): bool
     {
         return $this->tripped;
+    }
+
+    /**
+     * Log the batch outcome, but only when something actually went wrong.
+     * Call once after a batch; safe to call when everything succeeded.
+     *
+     * @param array<string, mixed> $context identifying fields for the log line
+     */
+    public function logSummary(string $source, array $context = []): void
+    {
+        if (0 === $this->failed && 0 === $this->skipped) {
+            return;
+        }
+
+        Log::warning($source.': some notification emails were not sent', $context + $this->summary());
     }
 
     /**

--- a/tests/Feature/EventNotifyFollowingTest.php
+++ b/tests/Feature/EventNotifyFollowingTest.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
 use Mockery;
 use ReflectionMethod;
+use Symfony\Component\Mailer\Exception\TransportException;
 use Tests\TestCase;
 
 /**
@@ -207,6 +208,35 @@ class EventNotifyFollowingTest extends TestCase
 
         // Pre-fix this was the (only) case that sent mail.
         $this->assertSame(0, $this->sentTo('second-photo@example.com'));
+    }
+
+    /**
+     * A dead mail transport used to bubble a TransportException out of
+     * notifyFollowing and 500 the request — after the event had already been
+     * saved, so the user saw a failure for work that succeeded and could retry
+     * into duplicates.
+     *
+     * @test
+     */
+    public function a_dead_mail_transport_does_not_break_the_notification_pass(): void
+    {
+        $tag = Tag::factory()->create();
+        $event = Event::factory()->create();
+        $event->tags()->attach($tag->id);
+
+        $follower = $this->follower('transport-down@example.com');
+        $this->follow($follower, 'tag', $tag->id);
+
+        // Replace the faked mailer with one whose transport always fails.
+        $pending = Mockery::mock();
+        $pending->shouldReceive('send')
+            ->andThrow(new TransportException('535 Authentication failed'));
+        Mail::shouldReceive('to')->andReturn($pending);
+
+        $this->notify($event);
+
+        // Reaching here at all is the assertion: pre-fix this threw.
+        $this->assertTrue(true);
     }
 
     /** @test */

--- a/tests/Feature/InviteMailFailureTest.php
+++ b/tests/Feature/InviteMailFailureTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\UserStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Mockery;
+use Symfony\Component\Mailer\Exception\TransportException;
+use Tests\TestCase;
+
+/**
+ * The invite flow is one of the sends where the email IS the deliverable, so
+ * a transport failure must be reported rather than swallowed. Previously the
+ * TransportException escaped as a 500; swallowing it silently would be just as
+ * wrong, because the success flash claims "An email was sent to ...".
+ */
+class InviteMailFailureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function admin(): User
+    {
+        return User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+    }
+
+    public function test_a_failed_invite_does_not_500(): void
+    {
+        Mail::shouldReceive('send')->andThrow(new TransportException('535 Authentication failed'));
+
+        $response = $this->actingAs($this->admin())
+            ->post(route('pages.invite'), ['email' => 'invitee@example.com']);
+
+        $response->assertRedirect();
+        $response->assertSessionHasNoErrors();
+    }
+
+    public function test_a_failed_invite_is_not_reported_as_sent(): void
+    {
+        Mail::shouldReceive('send')->andThrow(new TransportException('535 Authentication failed'));
+
+        $this->actingAs($this->admin())
+            ->post(route('pages.invite'), ['email' => 'invitee@example.com']);
+
+        $flash = session('flash_message');
+
+        $this->assertNotNull($flash, 'expected a flash message after a failed invite');
+        $this->assertSame('Email not sent', $flash['title']);
+        $this->assertStringNotContainsString('was sent', $flash['message']);
+    }
+
+    public function test_a_successful_invite_still_reports_success(): void
+    {
+        Mail::fake();
+
+        $this->actingAs($this->admin())
+            ->post(route('pages.invite'), ['email' => 'invitee@example.com']);
+
+        $flash = session('flash_message');
+
+        $this->assertNotNull($flash);
+        $this->assertSame('Success', $flash['title']);
+    }
+}

--- a/tests/Unit/BestEffortMailerTest.php
+++ b/tests/Unit/BestEffortMailerTest.php
@@ -115,6 +115,48 @@ class BestEffortMailerTest extends TestCase
         $this->assertSame(0, $summary['skipped']);
     }
 
+    public function test_attempt_swallows_failures_from_closure_style_sends(): void
+    {
+        $mailer = new BestEffortMailer();
+
+        $result = $mailer->attempt(function (): void {
+            throw new TransportException('535 Authentication failed');
+        });
+
+        $this->assertFalse($result);
+        $this->assertSame(1, $mailer->summary()['failed']);
+    }
+
+    public function test_attempt_reports_success_for_closure_style_sends(): void
+    {
+        $mailer = new BestEffortMailer();
+
+        $this->assertTrue($mailer->attempt(fn () => null));
+        $this->assertSame(1, $mailer->summary()['sent']);
+    }
+
+    public function test_attempt_shares_the_breaker_with_send(): void
+    {
+        $mailer = new BestEffortMailer();
+
+        for ($i = 0; $i < BestEffortMailer::MAX_CONSECUTIVE_FAILURES; ++$i) {
+            $mailer->attempt(function (): void {
+                throw new TransportException('535 Authentication failed');
+            });
+        }
+
+        $this->assertTrue($mailer->tripped());
+
+        // Once tripped the closure must not run again at all.
+        $ran = false;
+        $mailer->attempt(function () use (&$ran): void {
+            $ran = true;
+        });
+
+        $this->assertFalse($ran);
+        $this->assertSame(1, $mailer->summary()['skipped']);
+    }
+
     public function test_successful_sends_are_counted_and_reported(): void
     {
         $pending = Mockery::mock();

--- a/tests/Unit/BestEffortMailerTest.php
+++ b/tests/Unit/BestEffortMailerTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\BestEffortMailer;
+use Illuminate\Contracts\Mail\Mailable;
+use Illuminate\Support\Facades\Mail;
+use Mockery;
+use Symfony\Component\Mailer\Exception\TransportException;
+use Tests\TestCase;
+
+/**
+ * BestEffortMailer swallows mail-transport failures so that a dead SMTP server
+ * cannot turn an already-committed action (event creation) into a 500.
+ *
+ * The breaker matters as much as the try/catch: with ~640 notification-enabled
+ * users, catching per-recipient without a breaker would attempt one SMTP
+ * connection per follower during an outage and hang the request instead.
+ */
+class BestEffortMailerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function mailable(): Mailable
+    {
+        return Mockery::mock(Mailable::class);
+    }
+
+    /**
+     * Make every Mail::to(...)->send(...) throw a transport error, and count
+     * how many times send() was actually reached.
+     */
+    private function failingMailer(): \Mockery\MockInterface
+    {
+        $pending = Mockery::mock();
+        $pending->shouldReceive('send')
+            ->andThrow(new TransportException('535 Authentication failed'));
+
+        Mail::shouldReceive('to')->andReturn($pending);
+
+        return $pending;
+    }
+
+    public function test_a_transport_failure_does_not_bubble_up(): void
+    {
+        $this->failingMailer();
+
+        $mailer = new BestEffortMailer();
+        $result = $mailer->send('someone@example.com', $this->mailable());
+
+        $this->assertFalse($result);
+        $this->assertSame(1, $mailer->summary()['failed']);
+    }
+
+    public function test_breaker_trips_after_the_failure_threshold(): void
+    {
+        $this->failingMailer();
+
+        $mailer = new BestEffortMailer();
+        for ($i = 0; $i < BestEffortMailer::MAX_CONSECUTIVE_FAILURES; ++$i) {
+            $this->assertFalse($mailer->tripped(), "breaker tripped early on attempt {$i}");
+            $mailer->send("user{$i}@example.com", $this->mailable());
+        }
+
+        $this->assertTrue($mailer->tripped());
+    }
+
+    public function test_sends_stop_hitting_the_transport_once_tripped(): void
+    {
+        $pending = Mockery::mock();
+        // The transport must be reached exactly MAX_CONSECUTIVE_FAILURES times,
+        // not once per recipient — this is the anti-hang guarantee.
+        $pending->shouldReceive('send')
+            ->times(BestEffortMailer::MAX_CONSECUTIVE_FAILURES)
+            ->andThrow(new TransportException('535 Authentication failed'));
+
+        Mail::shouldReceive('to')->andReturn($pending);
+
+        $mailer = new BestEffortMailer();
+        for ($i = 0; $i < 50; ++$i) {
+            $mailer->send("user{$i}@example.com", $this->mailable());
+        }
+
+        $summary = $mailer->summary();
+        $this->assertSame(BestEffortMailer::MAX_CONSECUTIVE_FAILURES, $summary['failed']);
+        $this->assertSame(50 - BestEffortMailer::MAX_CONSECUTIVE_FAILURES, $summary['skipped']);
+        $this->assertSame(0, $summary['sent']);
+    }
+
+    public function test_an_isolated_failure_does_not_trip_the_breaker(): void
+    {
+        $good = Mockery::mock();
+        $good->shouldReceive('send')->andReturnNull();
+
+        $bad = Mockery::mock();
+        $bad->shouldReceive('send')->andThrow(new TransportException('550 no such recipient'));
+
+        // one bad address between good ones — the run of failures never reaches
+        // the threshold, so delivery continues
+        Mail::shouldReceive('to')->andReturn($good, $bad, $good, $bad, $good);
+
+        $mailer = new BestEffortMailer();
+        foreach (range(1, 5) as $i) {
+            $mailer->send("user{$i}@example.com", $this->mailable());
+        }
+
+        $this->assertFalse($mailer->tripped());
+        $summary = $mailer->summary();
+        $this->assertSame(3, $summary['sent']);
+        $this->assertSame(2, $summary['failed']);
+        $this->assertSame(0, $summary['skipped']);
+    }
+
+    public function test_successful_sends_are_counted_and_reported(): void
+    {
+        $pending = Mockery::mock();
+        $pending->shouldReceive('send')->andReturnNull();
+        Mail::shouldReceive('to')->andReturn($pending);
+
+        $mailer = new BestEffortMailer();
+        $this->assertTrue($mailer->send('someone@example.com', $this->mailable()));
+
+        $this->assertSame(
+            ['sent' => 1, 'failed' => 0, 'skipped' => 0, 'tripped' => false],
+            $mailer->summary()
+        );
+    }
+}


### PR DESCRIPTION
## Problem

Creating an event returned a 500 when Mailgun rejected SMTP auth:

```
production.ERROR: Failed to authenticate on SMTP server with username
"postmaster@cutupsmethod.com" ... 535 Authentication failed
#15 app/Http/Controllers/EventsController.php(2070): Illuminate\Mail\PendingMail->send()
#16 app/Http/Controllers/EventsController.php(2030): EventsController->notifyFollowing()
```

The failure mode is worse than a 500: the event is already committed by the time notifications run, so the user got an error page for work that had actually succeeded — and could retry into duplicates.

The same unguarded pattern existed at **every** request-path mail send in the app. While mail is down, posting to a thread, activating a user, sending an invite, or emailing an entity summary all fail the same way.

## Fix

New `App\Services\BestEffortMailer` — catches mail failures, logs them with context, and reports once to Sentry.

**The circuit breaker is the substantive part.** A plain per-recipient `try/catch` would be a trap: with 636 users having `setting_instant_update = 1`, a dead SMTP server means one connection attempt *per follower*, trading a fast 500 for a hung request and a gateway timeout. After 3 consecutive failures it stops trying for the rest of the batch, while an isolated bad address is still skipped without aborting the run.

### The sends are not all the same kind

This is the part worth reviewing. Applying "swallow the error" everywhere would be wrong.

**Follower fan-out — best-effort, swallow and log.** The action is already committed and the email is a side effect.

`EventsController`, `PostsController`, `ThreadsController`, `TagsController`, `BlogsController`, `ReviewsController`, and their `Api\*` twins.

Also guards `$event->notify(new EventPublished())` in `EventsController::store` — a Twitter API call two lines from the original crash site, equally able to fail event creation.

**Sends where the email IS the deliverable — report honestly.** These flashed success *unconditionally*:

| Call site | Flashed, regardless of outcome |
|---|---|
| `UsersController@notifyUser` | "A daily-style notification email was sent to …" |
| `EntitiesController` | "Update summary sent to …" |
| `PagesController@invite` | "An email was sent to … inviting them to join the site" |

Silently swallowing a failure here would replace a 500 with a lie. These now check the result and flash an error when the transport rejected the message. `inviteUser()` returns `bool` for this. `UsersController` activate/suspend flash a secondary error — the account change succeeded, only the courtesy email failed.

**`Api\UsersController` activate/suspend — log only.** The resource change did succeed, so the JSON response should not change shape over a mail failure.

### Supporting additions

- `BestEffortMailer::attempt()` for call sites still using the `Mail::send($view, $data, $closure)` form
- `BestEffortMailer::logSummary()` so batch-outcome logging isn't copy-pasted into 13 controllers

## Verification

- `./vendor/bin/phpstan analyse` — no errors across `app`, baseline untouched
- `tests/Unit/BestEffortMailerTest.php` — 8 tests. The key one asserts the transport is hit exactly 3 times across 50 recipients, which is the anti-hang guarantee
- `tests/Feature/InviteMailFailureTest.php` — 3 tests covering the honest-reporting change: no 500, not reported as sent, and success still reports success
- `tests/Feature/EventNotifyFollowingTest.php` — regression test for the original crash
- 68 tests green across `EntitiesTest`, `ApiUsersControllerTest`, `ApiPostsCrudTest`, `ApiThreadsCrudTest`, `ApiBlogsCrudTest`, `ApiTagsStoreTest`, `ApiEntitiesCrudTest`

## Notes

**This does not fix the underlying SMTP outage.** Production's `MAIL_PASSWORD` is unchanged from its original value, so Mailgun is rejecting a password it previously accepted — the cause is account-side (sending disabled over a plan/payment limit, or the SMTP password reset in the dashboard), not a stale credential. That needs handling in the Mailgun console separately. No notification mail is going out until it is.

**Log context** uses a plain `'via' => 'tag'|'entity'` string rather than the tag/entity name or id. Those relations infer as generic `Model`, and `phpstan-baseline.neon` pins that undefined-property pattern at exactly 4 occurrences — adding accesses would break the count.

**Not covered:** console commands (`Notify`, `NotifyWeekly`, `NotifyEntities`) still send unguarded. A crash there is a failed cron run rather than a user-facing 500, and #2083 reworks those commands anyway.

Related: #2083 — the `ShouldQueue` item there is the durable fix. A running queue worker would have made this a retry instead of an outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
