### PR TITLE
Retire the /events/today time window in favor of /events/tonight

### DIFF
--- a/app/Console/Commands/GenerateSitemap.php
+++ b/app/Console/Commands/GenerateSitemap.php
@@ -50,17 +50,15 @@ class GenerateSitemap extends Command
      *  - /search — Disallow'd in robots.txt
      *  - /activity, /all-modules — churn/internal nav, nothing to rank
      *
-     * The four time-window pages stay despite overlapping: each is a distinct
-     * range with its own title targeting a distinct query. Note that today and
-     * tonight return the same events on roughly 2/3 of the days that have any,
-     * because almost everything here starts after 17:00 — differentiating them
-     * is a content problem, not a reason to drop one from the sitemap.
+     *  - /events/today — now a permanent redirect to /events/tonight
+     *
+     * The three remaining time-window pages stay despite overlapping: each is
+     * a distinct range with its own title targeting a distinct query.
      */
     protected const PAGES = [
         '/',
         '/events',
         '/events/tonight',
-        '/events/today',
         '/events/this-weekend',
         '/events/this-week',
         '/events/week',

--- a/app/Enums/EventTimeWindow.php
+++ b/app/Enums/EventTimeWindow.php
@@ -5,10 +5,15 @@ namespace App\Enums;
 use Carbon\CarbonImmutable;
 
 /**
- * The four time-window landing pages: /events/tonight, /events/today,
- * /events/this-weekend, /events/this-week. Pure date/copy logic only —
- * no queries, no HTTP. See app/Services/EventTimeWindowStats.php for
- * counts and app/Http/Controllers/EventTimeWindowController.php for glue.
+ * The time-window landing pages: /events/tonight, /events/this-weekend,
+ * /events/this-week. Pure date/copy logic only — no queries, no HTTP.
+ * See app/Services/EventTimeWindowStats.php for counts and
+ * app/Http/Controllers/EventTimeWindowController.php for glue.
+ *
+ * There used to be a fourth window, Today (midnight–23:59). It returned the
+ * same events as Tonight on most days — almost nothing here starts before
+ * 17:00 — so it was dropped and /events/today now redirects to
+ * /events/tonight. Daytime events are still covered by This Week.
  *
  * All window math happens in America/New_York wall-clock time. Never use
  * config('app.timezone') here — it's a fixed-offset 'EST' zone and will
@@ -17,7 +22,6 @@ use Carbon\CarbonImmutable;
 enum EventTimeWindow: string
 {
     case Tonight = 'tonight';
-    case Today = 'today';
     case ThisWeekend = 'this-weekend';
     case ThisWeek = 'this-week';
 
@@ -34,7 +38,6 @@ enum EventTimeWindow: string
         $now = $now ?? CarbonImmutable::now(self::TIMEZONE);
 
         [$start, $end] = match ($this) {
-            self::Today => $this->todayBounds($now),
             self::ThisWeek => $this->thisWeekBounds($now),
             self::Tonight => $this->tonightBounds($now),
             self::ThisWeekend => $this->thisWeekendBounds($now),
@@ -44,16 +47,6 @@ enum EventTimeWindow: string
             'start' => $start->format('Y-m-d H:i:s'),
             'end' => $end->format('Y-m-d H:i:s'),
         ];
-    }
-
-    /**
-     * @return array{0: CarbonImmutable, 1: CarbonImmutable}
-     */
-    private function todayBounds(CarbonImmutable $now): array
-    {
-        $date = $now->startOfDay();
-
-        return [$date, $date->setTime(23, 59, 59)];
     }
 
     /**
@@ -122,7 +115,6 @@ enum EventTimeWindow: string
     {
         return match ($this) {
             self::Tonight => 'Events in Pittsburgh Tonight — Live Music, Shows & More',
-            self::Today => 'Events in Pittsburgh Today — Live Music, Shows & More',
             self::ThisWeekend => 'Events in Pittsburgh This Weekend — Live Music, Shows & More',
             self::ThisWeek => 'Events in Pittsburgh This Week — Live Music, Shows & More',
         };
@@ -132,7 +124,6 @@ enum EventTimeWindow: string
     {
         return match ($this) {
             self::Tonight => 'Events in Pittsburgh Tonight',
-            self::Today => 'Events in Pittsburgh Today',
             self::ThisWeekend => 'Events in Pittsburgh This Weekend',
             self::ThisWeek => 'Events in Pittsburgh This Week',
         };
@@ -147,7 +138,6 @@ enum EventTimeWindow: string
     {
         return match ($this) {
             self::Tonight => 'Tonight',
-            self::Today => 'Today',
             self::ThisWeekend => 'This Weekend',
             self::ThisWeek => 'This Week',
         };
@@ -161,7 +151,6 @@ enum EventTimeWindow: string
     {
         return match ($this) {
             self::Tonight => 'tonight',
-            self::Today => 'today',
             self::ThisWeekend => 'this weekend',
             self::ThisWeek => 'this week',
         };

--- a/app/Http/Controllers/EventTimeWindowController.php
+++ b/app/Http/Controllers/EventTimeWindowController.php
@@ -9,7 +9,7 @@ use Illuminate\Contracts\View\View;
 
 /**
  * Stable, crawlable time-window landing pages: /events/tonight,
- * /events/today, /events/this-weekend, /events/this-week.
+ * /events/this-weekend, /events/this-week.
  *
  * Deliberately does NOT use ListParameterSessionStore / ListEntityResultBuilder
  * — these pages must render the same content for every visitor and must not

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -330,7 +330,7 @@ class Event extends Model
     /**
      * Events with a start_at inside the given naive datetime bounds
      * (inclusive), ordered earliest-first. Used by the time-window landing
-     * pages (/events/tonight, /today, /this-weekend, /this-week).
+     * pages (/events/tonight, /this-weekend, /this-week).
      *
      * @param Builder<Event> $query
      */

--- a/app/Services/EventTimeWindowStats.php
+++ b/app/Services/EventTimeWindowStats.php
@@ -9,8 +9,8 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
 /**
- * Live counts backing the /events/tonight, /today, /this-weekend,
- * /this-week landing pages: event count, distinct venue count, and the
+ * Live counts backing the /events/tonight, /this-weekend and /this-week
+ * landing pages: event count, distinct venue count, and the
  * top tags for the window. Counts are computed against public events only
  * so the cached value is safe to share across all visitors regardless of
  * who's signed in.

--- a/routes/web.php
+++ b/routes/web.php
@@ -274,7 +274,9 @@ Route::get('update', function () {
 });
 
 Route::get('events/tonight', [\App\Http\Controllers\EventTimeWindowController::class, 'show'])->defaults('window', 'tonight')->name('events.tonight');
-Route::get('events/today', [\App\Http\Controllers\EventTimeWindowController::class, 'show'])->defaults('window', 'today')->name('events.today');
+// The old /events/today window duplicated /events/tonight on most days; keep
+// the URL alive for existing links and indexed results.
+Route::permanentRedirect('events/today', 'events/tonight')->name('events.today');
 Route::get('events/this-weekend', [\App\Http\Controllers\EventTimeWindowController::class, 'show'])->defaults('window', 'this-weekend')->name('events.thisWeekend');
 Route::get('events/this-week', [\App\Http\Controllers\EventTimeWindowController::class, 'show'])->defaults('window', 'this-week')->name('events.thisWeek');
 Route::get('events/graph', [\App\Http\Controllers\EventGraphController::class, 'graph'])->name('events.graph')->middleware(['auth', 'can:admin']);

--- a/tests/Feature/Console/GenerateSitemapCommandTest.php
+++ b/tests/Feature/Console/GenerateSitemapCommandTest.php
@@ -73,9 +73,10 @@ class GenerateSitemapCommandTest extends TestCase
 
         $base = rtrim(config('app.url'), '/');
         $this->assertStringContainsString($base.'/events/tonight', $content);
-        $this->assertStringContainsString($base.'/events/today', $content);
         $this->assertStringContainsString($base.'/events/this-weekend', $content);
         $this->assertStringContainsString($base.'/events/this-week', $content);
+        // /events/today is a permanent redirect now — redirects don't belong in a sitemap.
+        $this->assertStringNotContainsString($base.'/events/today', $content);
     }
 
     public function test_includes_public_content_and_excludes_non_public(): void

--- a/tests/Feature/Services/EventTimeWindowStatsTest.php
+++ b/tests/Feature/Services/EventTimeWindowStatsTest.php
@@ -35,7 +35,7 @@ class EventTimeWindowStatsTest extends TestCase
 
     public function test_stats_count_public_events_only(): void
     {
-        $window = EventTimeWindow::Today;
+        $window = EventTimeWindow::Tonight;
         $start = $this->insideStart($window);
 
         Event::factory()->create([
@@ -61,7 +61,7 @@ class EventTimeWindowStatsTest extends TestCase
 
     public function test_stats_counts_distinct_venues_and_top_tags(): void
     {
-        $window = EventTimeWindow::Today;
+        $window = EventTimeWindow::Tonight;
         $start = $this->insideStart($window);
 
         $venue = Entity::factory()->create();
@@ -96,15 +96,15 @@ class EventTimeWindowStatsTest extends TestCase
     {
         $stats = app(EventTimeWindowStats::class);
 
-        $today = $stats->stats(EventTimeWindow::Today);
+        $stats->stats(EventTimeWindow::Tonight);
 
-        $todayRange = EventTimeWindow::Today->range();
-        $cacheKey = 'event-window-stats:today:'.substr($todayRange['start'], 0, 10);
+        $tonightRange = EventTimeWindow::Tonight->range();
+        $cacheKey = 'event-window-stats:tonight:'.substr($tonightRange['start'], 0, 10);
 
         $this->assertTrue(Cache::has($cacheKey));
 
-        // A different window (this-week) starts on the same date but is a
-        // distinct cache entry keyed by window value + start date.
+        // A different window (this-week) usually starts on the same date but is
+        // a distinct cache entry keyed by window value + start date.
         $weekRange = EventTimeWindow::ThisWeek->range();
         $weekCacheKey = 'event-window-stats:this-week:'.substr($weekRange['start'], 0, 10);
 

--- a/tests/Feature/Web/EventTimeWindowPagesTest.php
+++ b/tests/Feature/Web/EventTimeWindowPagesTest.php
@@ -35,7 +35,6 @@ class EventTimeWindowPagesTest extends TestCase
     {
         return [
             'tonight' => ['tonight', '/events/tonight', 'Tonight'],
-            'today' => ['today', '/events/today', 'Today'],
             'this-weekend' => ['this-weekend', '/events/this-weekend', 'This Weekend'],
             'this-week' => ['this-week', '/events/this-week', 'This Week'],
         ];
@@ -200,9 +199,16 @@ class EventTimeWindowPagesTest extends TestCase
         $response = $this->get('/events/tonight');
 
         $response->assertOk();
-        $response->assertSee('href="'.url('/events/today').'"', false);
         $response->assertSee('href="'.url('/events/this-weekend').'"', false);
         $response->assertSee('href="'.url('/events/this-week').'"', false);
+        $response->assertDontSee('href="'.url('/events/today').'"', false);
+    }
+
+    public function test_retired_today_window_redirects_to_tonight(): void
+    {
+        $this->get('/events/today')
+            ->assertStatus(301)
+            ->assertRedirect(url('/events/tonight'));
     }
 
     /**

--- a/tests/Feature/Web/EventsControllerSmokeTest.php
+++ b/tests/Feature/Web/EventsControllerSmokeTest.php
@@ -67,11 +67,11 @@ class EventsControllerSmokeTest extends TestCase
         $this->get('/events/past')->assertOk();
     }
 
-    public function test_events_today_renders(): void
+    public function test_events_tonight_renders(): void
     {
         Event::factory()->create(['start_at' => Carbon::now()->setTime(20, 0)]);
 
-        $this->get('/events/today')->assertOk();
+        $this->get('/events/tonight')->assertOk();
     }
 
     public function test_events_day_by_string_renders(): void

--- a/tests/Feature/Web/EventsControllerTest.php
+++ b/tests/Feature/Web/EventsControllerTest.php
@@ -37,9 +37,9 @@ class EventsControllerTest extends TestCase
         $this->get('/events/future')->assertOk();
     }
 
-    public function test_index_today_loads(): void
+    public function test_index_today_redirects_to_tonight(): void
     {
-        $this->get('/events/today')->assertOk();
+        $this->get('/events/today')->assertRedirect(url('/events/tonight'));
     }
 
     public function test_index_week_loads(): void

--- a/tests/Unit/EventTimeWindowTest.php
+++ b/tests/Unit/EventTimeWindowTest.php
@@ -7,7 +7,7 @@ use Carbon\CarbonImmutable;
 use Tests\TestCase;
 
 /**
- * Boundary matrix for the /events/tonight, /today, /this-weekend, /this-week
+ * Boundary matrix for the /events/tonight, /this-weekend, /this-week
  * landing pages. All times are America/New_York wall-clock, expressed as
  * naive 'Y-m-d H:i:s' strings compared against events.start_at.
  */
@@ -16,14 +16,6 @@ class EventTimeWindowTest extends TestCase
     protected function now(string $dateTime): CarbonImmutable
     {
         return CarbonImmutable::parse($dateTime, 'America/New_York');
-    }
-
-    public function test_today_window_is_the_calendar_day(): void
-    {
-        $range = EventTimeWindow::Today->range($this->now('2026-08-04 12:00:00')); // Tuesday
-
-        $this->assertSame('2026-08-04 00:00:00', $range['start']);
-        $this->assertSame('2026-08-04 23:59:59', $range['end']);
     }
 
     public function test_this_week_window_rolls_six_days_forward(): void
@@ -154,7 +146,7 @@ class EventTimeWindowTest extends TestCase
 
     public function test_range_defaults_to_current_time_when_now_is_not_injected(): void
     {
-        $range = EventTimeWindow::Today->range();
+        $range = EventTimeWindow::ThisWeek->range();
 
         $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2} 00:00:00$/', $range['start']);
         $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2} 23:59:59$/', $range['end']);
@@ -166,8 +158,6 @@ class EventTimeWindowTest extends TestCase
     {
         $this->assertSame('/events/tonight', EventTimeWindow::Tonight->path());
         $this->assertSame('Tonight', EventTimeWindow::Tonight->label());
-        $this->assertSame('/events/today', EventTimeWindow::Today->path());
-        $this->assertSame('Today', EventTimeWindow::Today->label());
         $this->assertSame('/events/this-weekend', EventTimeWindow::ThisWeekend->path());
         $this->assertSame('This Weekend', EventTimeWindow::ThisWeekend->label());
         $this->assertSame('/events/this-week', EventTimeWindow::ThisWeek->path());
@@ -177,7 +167,6 @@ class EventTimeWindowTest extends TestCase
     public function test_title_has_no_brand_suffix(): void
     {
         $this->assertSame('Events in Pittsburgh Tonight — Live Music, Shows & More', EventTimeWindow::Tonight->title());
-        $this->assertSame('Events in Pittsburgh Today — Live Music, Shows & More', EventTimeWindow::Today->title());
         $this->assertSame('Events in Pittsburgh This Weekend — Live Music, Shows & More', EventTimeWindow::ThisWeekend->title());
         $this->assertSame('Events in Pittsburgh This Week — Live Music, Shows & More', EventTimeWindow::ThisWeek->title());
 
@@ -189,7 +178,6 @@ class EventTimeWindowTest extends TestCase
     public function test_h1(): void
     {
         $this->assertSame('Events in Pittsburgh Tonight', EventTimeWindow::Tonight->h1());
-        $this->assertSame('Events in Pittsburgh Today', EventTimeWindow::Today->h1());
         $this->assertSame('Events in Pittsburgh This Weekend', EventTimeWindow::ThisWeekend->h1());
         $this->assertSame('Events in Pittsburgh This Week', EventTimeWindow::ThisWeek->h1());
     }
@@ -209,13 +197,13 @@ class EventTimeWindowTest extends TestCase
 
     public function test_meta_description_singular_counts(): void
     {
-        $desc = EventTimeWindow::Today->metaDescription([
+        $desc = EventTimeWindow::Tonight->metaDescription([
             'events' => 1,
             'venues' => 1,
             'tags' => ['Jazz'],
         ]);
 
-        $this->assertSame('1 show today across 1 Pittsburgh venue — Jazz & more.', $desc);
+        $this->assertSame('1 show tonight across 1 Pittsburgh venue — Jazz & more.', $desc);
     }
 
     public function test_meta_description_weekend_and_week_phrases(): void


### PR DESCRIPTION
## Why

On `/events/tonight` and its siblings, the sub-page pill row offered four windows: **Tonight · Today · This Weekend · This Week**. Tonight (17:00–03:00) and Today (00:00–23:59) are redundant — almost nothing in this app starts before 17:00, so the two pages return the same events on most days that have any.

Kept **Tonight**: it's the stronger search query for a music/nightlife site and was already the only one of the two in the sidebar nav. Daytime events today are still covered by **This Week**, which starts at midnight.

## What changed

- **`app/Enums/EventTimeWindow.php`** — removed the `Today` case, its `todayBounds()` method, and its `title`/`h1`/`label`/`phrase` match arms.
- **`routes/web.php`** — `events/today` is now `Route::permanentRedirect('events/today', 'events/tonight')`, keeping the `events.today` route name so old links and indexed results 301 instead of 404.
- **`app/Console/Commands/GenerateSitemap.php`** — dropped `/events/today` from `PAGES`; a redirect doesn't belong in a sitemap.
- **Nav** — the pill row, footer, and homepage window links all iterate `EventTimeWindow::cases()`, so they drop to three options with no template edits. The sidebar already listed only Tonight in both of its nav copies, so it already matches.
- **Docblocks** in `EventTimeWindowController`, `EventTimeWindowStats`, and `Event::scopeBetween()` no longer advertise four windows.

## Tests

- Removed the `today` row from the window data provider; re-pointed the Today-specific unit and stats assertions at Tonight.
- Added coverage for the new behavior: `/events/today` returns a 301 to `/events/tonight`, the pill row no longer links to it, and the sitemap excludes it.
- `EventTimeWindowTest`, `EventTimeWindowPagesTest`, `EventTimeWindowStatsTest`, `GenerateSitemapCommandTest`, `EventsControllerTest`, `EventsControllerSmokeTest` all pass locally; `phpstan analyse` reports no errors.

## Deploy notes

- Needs `php artisan route:clear` (new route) and a sitemap regeneration after deploy.
- Search Console will report `/events/today` as a redirect until Google recrawls — expected, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)