### PR TITLE
Add an email suppression list and Mailgun import

### DIFF
--- a/app/Console/Commands/ImportEmailSuppressions.php
+++ b/app/Console/Commands/ImportEmailSuppressions.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\EmailSuppression;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Imports a provider suppression export (Mailgun bounces/complaints/
+ * unsubscribes, or any CSV with an address column) into email_suppressions.
+ *
+ * Run this before the SES cutover. SES starts with no knowledge of the
+ * Mailgun sending history, so without an import the first send retries every
+ * address the old provider had already given up on.
+ */
+class ImportEmailSuppressions extends Command
+{
+    protected $signature = 'email:import-suppressions
+        {file : Path to the CSV export}
+        {--reason=bounce : bounce|complaint|unsubscribe|manual}
+        {--source=mailgun : Which provider the export came from}
+        {--dry-run : Parse and report without writing}';
+
+    protected $description = 'Import a provider bounce/complaint/unsubscribe export into the suppression list.';
+
+    /** Columns an address may live under, in order of preference. */
+    private const ADDRESS_COLUMNS = ['address', 'email', 'recipient'];
+
+    public function handle(): int
+    {
+        $path = (string) $this->argument('file');
+        $reason = (string) $this->option('reason');
+        $source = (string) $this->option('source');
+        $dryRun = (bool) $this->option('dry-run');
+
+        $allowed = [
+            EmailSuppression::REASON_BOUNCE,
+            EmailSuppression::REASON_COMPLAINT,
+            EmailSuppression::REASON_UNSUBSCRIBE,
+            EmailSuppression::REASON_MANUAL,
+        ];
+
+        if (!in_array($reason, $allowed, true)) {
+            $this->error('--reason must be one of: '.implode(', ', $allowed));
+
+            return self::FAILURE;
+        }
+
+        if (!is_readable($path)) {
+            $this->error("Cannot read {$path}");
+
+            return self::FAILURE;
+        }
+
+        $handle = fopen($path, 'r');
+        if (false === $handle) {
+            $this->error("Cannot open {$path}");
+
+            return self::FAILURE;
+        }
+
+        $header = fgetcsv($handle, 0, ',', '"', '\\');
+        if (!is_array($header)) {
+            fclose($handle);
+            $this->error('The file has no header row.');
+
+            return self::FAILURE;
+        }
+
+        $header = array_map(static fn ($h) => mb_strtolower(trim((string) $h)), $header);
+
+        $addressIndex = null;
+        foreach (self::ADDRESS_COLUMNS as $candidate) {
+            $found = array_search($candidate, $header, true);
+            if (false !== $found) {
+                $addressIndex = (int) $found;
+                break;
+            }
+        }
+
+        if (null === $addressIndex) {
+            fclose($handle);
+            $this->error('No address column found. Expected one of: '.implode(', ', self::ADDRESS_COLUMNS));
+
+            return self::FAILURE;
+        }
+
+        $codeIndex = array_search('code', $header, true);
+        $errorIndex = array_search('error', $header, true);
+        $dateIndex = array_search('created_at', $header, true);
+
+        $imported = 0;
+        $alreadyPresent = 0;
+        $skipped = 0;
+        $seen = [];
+
+        // Mailgun wraps multi-line SMTP errors in quotes, so a bounce export
+        // has more lines than records — fgetcsv handles the continuation.
+        while (($row = fgetcsv($handle, 0, ',', '"', '\\')) !== false) {
+            $raw = trim((string) ($row[$addressIndex] ?? ''));
+
+            if ('' === $raw || !filter_var($raw, FILTER_VALIDATE_EMAIL)) {
+                ++$skipped;
+                continue;
+            }
+
+            $email = EmailSuppression::normalize($raw);
+            if (isset($seen[$email])) {
+                continue;
+            }
+            $seen[$email] = true;
+
+            if ($dryRun) {
+                ++$imported;
+                continue;
+            }
+
+            $suppressedAt = null;
+            if (false !== $dateIndex && !empty($row[$dateIndex])) {
+                $ts = strtotime((string) $row[$dateIndex]);
+                $suppressedAt = false === $ts ? null : date('Y-m-d H:i:s', $ts);
+            }
+
+            $record = EmailSuppression::suppress($email, $reason, $source, [
+                'code' => false !== $codeIndex ? (substr((string) ($row[$codeIndex] ?? ''), 0, 16) ?: null) : null,
+                'error' => false !== $errorIndex ? (($row[$errorIndex] ?? '') ?: null) : null,
+                'suppressed_at' => $suppressedAt,
+            ]);
+
+            if ($record->wasRecentlyCreated) {
+                ++$imported;
+            } else {
+                ++$alreadyPresent;
+            }
+        }
+
+        fclose($handle);
+
+        $verb = $dryRun ? 'Would import' : 'Imported';
+        $this->info("{$verb}: {$imported}");
+        if (!$dryRun) {
+            $this->line("Already suppressed: {$alreadyPresent}");
+        }
+        $this->line("Skipped (blank or invalid): {$skipped}");
+
+        if (!$dryRun) {
+            Log::info('ImportEmailSuppressions: import complete', [
+                'file' => $path,
+                'reason' => $reason,
+                'source' => $source,
+                'imported' => $imported,
+                'already_present' => $alreadyPresent,
+                'skipped' => $skipped,
+            ]);
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Listeners/BlockSuppressedRecipients.php
+++ b/app/Listeners/BlockSuppressedRecipients.php
@@ -5,7 +5,6 @@ namespace App\Listeners;
 use App\Models\EmailSuppression;
 use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Support\Facades\Log;
-use Symfony\Component\Mime\Address;
 
 /**
  * Drops suppressed addresses from outgoing mail.
@@ -37,7 +36,6 @@ class BlockSuppressedRecipients
         $blocked = [];
 
         foreach ($to as $address) {
-            /* @var Address $address */
             if (EmailSuppression::isSuppressed($address->getAddress())) {
                 $blocked[] = $address->getAddress();
             } else {

--- a/app/Listeners/BlockSuppressedRecipients.php
+++ b/app/Listeners/BlockSuppressedRecipients.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Models\EmailSuppression;
+use Illuminate\Mail\Events\MessageSending;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\Mime\Address;
+
+/**
+ * Drops suppressed addresses from outgoing mail.
+ *
+ * Hooked on MessageSending rather than added to the send call sites because
+ * Mailer::sendSymfonyMessage() treats a false return from this event as
+ * "do not send", which makes it the only hook that covers *every* path —
+ * including the Notify/NotifyWeekly console digests, which account for most
+ * of the volume and never touch BestEffortMailer.
+ *
+ * Partially-suppressed messages have the bad recipients removed and are still
+ * delivered to the rest; a message with nothing left is cancelled outright.
+ */
+class BlockSuppressedRecipients
+{
+    /**
+     * @return bool false cancels the send
+     */
+    public function handle(MessageSending $event): bool
+    {
+        $message = $event->message;
+
+        $to = $message->getTo();
+        if ([] === $to) {
+            return true;
+        }
+
+        $keep = [];
+        $blocked = [];
+
+        foreach ($to as $address) {
+            /* @var Address $address */
+            if (EmailSuppression::isSuppressed($address->getAddress())) {
+                $blocked[] = $address->getAddress();
+            } else {
+                $keep[] = $address;
+            }
+        }
+
+        if ([] === $blocked) {
+            return true;
+        }
+
+        if ([] === $keep) {
+            Log::info('BlockSuppressedRecipients: cancelled a message with no deliverable recipients', [
+                'blocked' => $blocked,
+                'subject' => $message->getSubject(),
+            ]);
+
+            return false;
+        }
+
+        $message->to(...$keep);
+
+        Log::info('BlockSuppressedRecipients: dropped suppressed recipients from a message', [
+            'blocked' => $blocked,
+            'remaining' => count($keep),
+            'subject' => $message->getSubject(),
+        ]);
+
+        return true;
+    }
+}

--- a/app/Models/EmailSuppression.php
+++ b/app/Models/EmailSuppression.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * An address we must not email again.
+ *
+ * @property int         $id
+ * @property string      $email
+ * @property string      $reason
+ * @property string      $source
+ * @property string|null $code
+ * @property string|null $error
+ * @property mixed       $suppressed_at
+ */
+class EmailSuppression extends Model
+{
+    use HasFactory;
+
+    public const REASON_BOUNCE = 'bounce';
+
+    public const REASON_COMPLAINT = 'complaint';
+
+    public const REASON_UNSUBSCRIBE = 'unsubscribe';
+
+    public const REASON_MANUAL = 'manual';
+
+    protected $fillable = ['email', 'reason', 'source', 'code', 'error', 'suppressed_at'];
+
+    protected $casts = [
+        'suppressed_at' => 'datetime',
+    ];
+
+    /**
+     * The single definition of "the same address". Everything that writes or
+     * reads this table goes through here so the unique index and the send-time
+     * lookup cannot disagree.
+     */
+    public static function normalize(string $email): string
+    {
+        return mb_strtolower(trim($email));
+    }
+
+    /**
+     * Is this address suppressed? One indexed lookup — deliberately not
+     * memoised, because the queue worker is long-lived and a cached "not
+     * suppressed" would outlive the bounce that changed the answer.
+     */
+    public static function isSuppressed(string $email): bool
+    {
+        return static::query()->where('email', static::normalize($email))->exists();
+    }
+
+    /**
+     * Suppress an address, keeping the earliest known reason rather than
+     * letting a later import overwrite why it was first blocked.
+     *
+     * @param array<string, mixed> $attributes
+     */
+    public static function suppress(string $email, string $reason, string $source, array $attributes = []): self
+    {
+        return static::query()->firstOrCreate(
+            ['email' => static::normalize($email)],
+            array_merge(['reason' => $reason, 'source' => $source], $attributes)
+        );
+    }
+
+    /** @param Builder<EmailSuppression> $query */
+    public function scopeReason(Builder $query, string $reason): void
+    {
+        $query->where('reason', $reason);
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -6,6 +6,7 @@ use App\Events\EventCreated;
 use App\Events\EventPhotoAdded;
 use App\Events\EventUpdated;
 use App\Listeners\ActivateVerifiedUserListener;
+use App\Listeners\BlockSuppressedRecipients;
 use App\Listeners\LogFailedLogin;
 use App\Listeners\LogSuccessfulLogin;
 use App\Listeners\QueueDiscordEventPost;
@@ -16,6 +17,7 @@ use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Events\Verified;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Routing\Events\RouteMatched;
 
 class EventServiceProvider extends ServiceProvider
@@ -28,6 +30,13 @@ class EventServiceProvider extends ServiceProvider
     protected $listen = [
         RouteMatched::class => [
             RouterMatchedListener::class,
+        ],
+
+        // Suppression enforcement. MessageSending is the only hook that covers
+        // every send path, including the console digests that bypass
+        // BestEffortMailer — returning false from the listener cancels the send.
+        MessageSending::class => [
+            BlockSuppressedRecipients::class,
         ],
         Login::class => [
             LogSuccessfulLogin::class,

--- a/database/migrations/2026_08_17_000000_create_email_suppressions_table.php
+++ b/database/migrations/2026_08_17_000000_create_email_suppressions_table.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Email suppression list.
+ *
+ * The app has never consumed the ESP's bounce/complaint data, so an address
+ * that hard-bounced years ago is still mailed on every digest run. Of the 158
+ * addresses in the Mailgun bounce export, 24 are live users with all
+ * notification settings enabled — guaranteed bounces on every send.
+ *
+ * That matters for the SES migration specifically: SES opens an account review
+ * at a 5% bounce rate, and a first send to the current daily-digest population
+ * would be ~3.7% from known-bad addresses alone, before any unknown address
+ * fails, and with no reputation history to absorb it.
+ *
+ * Addresses are stored lowercased; EmailSuppression::normalize() is the single
+ * place that decides what "same address" means, and the unique index enforces
+ * it. `reason` records why (bounce/complaint/unsubscribe/manual) and `source`
+ * records who told us (mailgun/ses/manual), so a future provider migration can
+ * import a new list without losing the provenance of the old one.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('email_suppressions', function (Blueprint $table) {
+            $table->id();
+
+            // Lowercased address. Unique so imports can upsert idempotently and
+            // so the send-time lookup is a single indexed hit.
+            $table->string('email')->unique();
+
+            $table->string('reason', 32)->default('bounce');
+            $table->string('source', 32)->default('manual');
+
+            // SMTP code and message where the provider gave one. Free-text —
+            // every provider words these differently.
+            $table->string('code', 16)->nullable();
+            $table->text('error')->nullable();
+
+            // When the provider recorded the event, which is not when we
+            // imported it.
+            $table->timestamp('suppressed_at')->nullable();
+
+            $table->timestamps();
+
+            $table->index('reason');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('email_suppressions');
+    }
+};

--- a/tests/Feature/EmailSuppressionTest.php
+++ b/tests/Feature/EmailSuppressionTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\EmailSuppression;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+/**
+ * Suppression enforcement.
+ *
+ * The app never consumed the ESP's bounce data, so addresses that hard-bounced
+ * years ago were still mailed on every digest run — 24 of the 158 Mailgun
+ * bounces are live users with all notification settings on. Enforcement hangs
+ * off MessageSending rather than the send call sites, because that is the only
+ * hook the console digests also pass through.
+ *
+ * NOTE: these tests deliberately do NOT use Mail::fake(). The fake swaps out
+ * the Mailer, so MessageSending never fires and the listener never runs —
+ * every assertion would pass vacuously. phpunit.xml sets the array mailer, so
+ * we drive the real Mailer and inspect the transport instead.
+ */
+class EmailSuppressionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Mail::getSymfonyTransport()->flush();
+    }
+
+    /** @return \Illuminate\Support\Collection<int, \Symfony\Component\Mailer\SentMessage> */
+    private function sentMessages(): \Illuminate\Support\Collection
+    {
+        return Mail::getSymfonyTransport()->messages();
+    }
+
+    private function send(array $to, string $subject = 'Test'): void
+    {
+        Mail::raw('body', function ($m) use ($to, $subject) {
+            $m->to($to)->subject($subject);
+        });
+    }
+
+    /** @return array<int, string> */
+    private function recipientsOfFirstMessage(): array
+    {
+        $messages = $this->sentMessages();
+        $this->assertNotEmpty($messages, 'expected at least one message');
+
+        $to = $messages->first()->getOriginalMessage()->getTo();
+
+        return array_map(static fn ($a) => $a->getAddress(), $to);
+    }
+
+    public function test_the_listener_actually_runs_and_lets_normal_mail_through(): void
+    {
+        $this->send(['fine@example.com']);
+
+        // Guards the rest of this file: if the harness stopped exercising the
+        // real Mailer, this fails instead of the suppression tests silently
+        // passing on zero sends.
+        $this->assertCount(1, $this->sentMessages());
+    }
+
+    public function test_a_suppressed_address_is_not_mailed(): void
+    {
+        EmailSuppression::suppress('bounced@example.com', EmailSuppression::REASON_BOUNCE, 'mailgun');
+
+        $this->send(['bounced@example.com']);
+
+        $this->assertCount(0, $this->sentMessages());
+    }
+
+    public function test_suppression_is_case_and_whitespace_insensitive(): void
+    {
+        EmailSuppression::suppress('  Bounced@Example.COM ', EmailSuppression::REASON_BOUNCE, 'mailgun');
+
+        $this->send(['BOUNCED@example.com']);
+
+        $this->assertCount(0, $this->sentMessages());
+    }
+
+    public function test_a_mixed_recipient_list_keeps_the_deliverable_addresses(): void
+    {
+        EmailSuppression::suppress('bounced@example.com', EmailSuppression::REASON_BOUNCE, 'mailgun');
+
+        $this->send(['bounced@example.com', 'fine@example.com']);
+
+        // One bad address in a batch must not cancel the whole message.
+        $this->assertCount(1, $this->sentMessages());
+        $this->assertSame(['fine@example.com'], $this->recipientsOfFirstMessage());
+    }
+
+    public function test_suppress_keeps_the_original_reason(): void
+    {
+        EmailSuppression::suppress('a@example.com', EmailSuppression::REASON_BOUNCE, 'mailgun');
+        EmailSuppression::suppress('a@example.com', EmailSuppression::REASON_COMPLAINT, 'ses');
+
+        $row = EmailSuppression::query()->where('email', 'a@example.com')->get();
+
+        $this->assertCount(1, $row);
+        $this->assertSame(EmailSuppression::REASON_BOUNCE, $row->first()->reason);
+    }
+
+    public function test_is_suppressed_reflects_writes_immediately(): void
+    {
+        $this->assertFalse(EmailSuppression::isSuppressed('later@example.com'));
+
+        EmailSuppression::suppress('later@example.com', EmailSuppression::REASON_BOUNCE, 'mailgun');
+
+        // Deliberately not memoised — the queue worker is long-lived and a
+        // cached "not suppressed" would outlive the bounce that changed it.
+        $this->assertTrue(EmailSuppression::isSuppressed('later@example.com'));
+    }
+}

--- a/tests/Feature/EmailSuppressionTest.php
+++ b/tests/Feature/EmailSuppressionTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\EmailSuppression;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Mail\Transport\ArrayTransport;
 use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
 
@@ -30,13 +31,24 @@ class EmailSuppressionTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        Mail::getSymfonyTransport()->flush();
+        $this->transport()->flush();
+    }
+
+    /**
+     * phpunit.xml pins the array mailer, so this is always an ArrayTransport.
+     */
+    private function transport(): ArrayTransport
+    {
+        /** @var ArrayTransport $transport */
+        $transport = Mail::getSymfonyTransport();
+
+        return $transport;
     }
 
     /** @return \Illuminate\Support\Collection<int, \Symfony\Component\Mailer\SentMessage> */
     private function sentMessages(): \Illuminate\Support\Collection
     {
-        return Mail::getSymfonyTransport()->messages();
+        return $this->transport()->messages();
     }
 
     private function send(array $to, string $subject = 'Test'): void
@@ -52,7 +64,9 @@ class EmailSuppressionTest extends TestCase
         $messages = $this->sentMessages();
         $this->assertNotEmpty($messages, 'expected at least one message');
 
-        $to = $messages->first()->getOriginalMessage()->getTo();
+        /** @var \Symfony\Component\Mime\Email $original */
+        $original = $messages->first()->getOriginalMessage();
+        $to = $original->getTo();
 
         return array_map(static fn ($a) => $a->getAddress(), $to);
     }


### PR DESCRIPTION
## Why

The app has never consumed the ESP's bounce or complaint data. An address that hard-bounced years ago is still mailed on every digest run.

Measured against the Mailgun export and production:

| | |
|---|---|
| Addresses in the Mailgun bounce export | 158 |
| Of those, **live users** in prod | **24** |
| Of those 24, still have daily/weekly/instant enabled | **all 24** |

This is an SES migration blocker, not just waste. SES opens an account review at a **5% bounce rate**, and SES starts with zero knowledge of the Mailgun history:

| First SES send | Known-bad / recipients | Bounce rate |
|---|---|---|
| As-is | 24 / 642 | **~3.7%** |
| After the #2083 engagement gate | 2 / 225 | ~0.9% |

3.7% before a single *unknown* address fails, with no reputation history to absorb it.

## What

**`email_suppressions` table + `EmailSuppression` model.** Addresses stored lowercased through a single `normalize()`, so the unique index and the send-time lookup cannot disagree. `reason` (bounce/complaint/unsubscribe/manual) and `source` (mailgun/ses/manual) keep provenance, so a later provider's list imports without losing the old one.

**`BlockSuppressedRecipients` on `MessageSending`.** `Mailer::sendSymfonyMessage()` treats a `false` return from that event as "do not send", which makes it the only hook covering *every* path — including the `Notify`/`NotifyWeekly` console digests, which are most of the volume and never touch `BestEffortMailer`. Partially-suppressed messages have the bad recipients stripped and are still delivered to the rest; only a message with nothing left is cancelled.

**`email:import-suppressions`.** Reads a Mailgun bounce/complaint/unsubscribe CSV, handles the multi-line quoted SMTP errors in bounce exports, and upserts so re-running is a no-op.

```bash
php artisan email:import-suppressions bounces.csv    --reason=bounce    --source=mailgun --dry-run
php artisan email:import-suppressions bounces.csv    --reason=bounce    --source=mailgun
php artisan email:import-suppressions complaints.csv --reason=complaint --source=mailgun
```

## Verified against the real exports

Run against the actual Mailgun files on the dev database:

```
bounces.csv     Imported: 158   Already suppressed: 0
complaints.csv  Imported:  59   Already suppressed: 0
re-run bounces  Imported:   0   Already suppressed: 158   <- idempotent
```

158 and 59 match an independent parse of the same files. Note the raw bounce CSV has 291 *lines* but 158 *records* — SMTP error text contains newlines.

## Design notes

**`isSuppressed()` is deliberately not memoised.** The queue worker is long-lived; a cached "not suppressed" would outlive the bounce that changed the answer. It is one indexed lookup, so a 640-recipient digest costs 640 primary-key hits.

**The tests deliberately avoid `Mail::fake()`.** The fake swaps out the Mailer, so `MessageSending` never fires and the listener never runs — my first draft passed on zero sends, vacuously. They now drive the real array-transport Mailer and inspect the transport, with a guard test that fails loudly if that stops being true.

## Verification

- `./vendor/bin/phpstan analyse` — no errors, baseline untouched
- `tests/Feature/EmailSuppressionTest.php` — 6 tests
- 24 tests green across this plus `BestEffortMailerTest`, `EventNotifyFollowingTest`, `InviteMailFailureTest`

## Not included

- Suppression is **enforced** but nothing yet **writes** to the table at runtime. An SES SNS bounce/complaint handler is the follow-up that closes that loop; until then the table is import-only.
- No UI for viewing or un-suppressing addresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
