### PR TITLE
Recover gracefully from stale-session 419s on login

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Session\TokenMismatchException;
 use Illuminate\Validation\ValidationException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -44,6 +45,15 @@ class Handler extends ExceptionHandler
     {
         if ($e instanceof ModelNotFoundException) {
             abort(404);
+        }
+
+        // A stale page (open past the session lifetime) posts a CSRF token that
+        // no longer matches anything. Instead of a dead-end 419, send the user
+        // back with a fresh session so a retry works without a manual reload.
+        if ($e instanceof TokenMismatchException && !$request->expectsJson()) {
+            return redirect()->back(fallback: route('login'))
+                ->withInput($request->except('password', 'password_confirmation', '_token'))
+                ->with('error', 'Your session expired. Please try again.');
         }
 
         return parent::render($request, $e);

--- a/public/js/csrf-refresh.js
+++ b/public/js/csrf-refresh.js
@@ -1,0 +1,47 @@
+// Refresh the CSRF token when a stale tab becomes visible again, so a form
+// rendered before the session expired can still post successfully.
+(function () {
+    'use strict';
+
+    function refreshToken() {
+        fetch('/csrf-token', {
+            credentials: 'same-origin',
+            headers: { Accept: 'application/json' },
+        })
+            .then(function (response) {
+                return response.ok ? response.json() : null;
+            })
+            .then(function (data) {
+                if (!data || !data.token) {
+                    return;
+                }
+                document.querySelectorAll('input[name="_token"]').forEach(function (input) {
+                    input.value = data.token;
+                });
+                var meta = document.querySelector('meta[name="csrf-token"]');
+                if (meta) {
+                    meta.setAttribute('content', data.token);
+                }
+                if (window.axios) {
+                    window.axios.defaults.headers.common['X-CSRF-TOKEN'] = data.token;
+                }
+            })
+            .catch(function () {
+                // Ignore network errors — the exception handler's 419 redirect
+                // is the fallback path.
+            });
+    }
+
+    document.addEventListener('visibilitychange', function () {
+        if (document.visibilityState === 'visible') {
+            refreshToken();
+        }
+    });
+
+    // bfcache restore (common on mobile Safari) skips normal page load events.
+    window.addEventListener('pageshow', function (event) {
+        if (event.persisted) {
+            refreshToken();
+        }
+    });
+})();

--- a/resources/views/auth/login-tw.blade.php
+++ b/resources/views/auth/login-tw.blade.php
@@ -93,3 +93,7 @@
     </div>
 </div>
 @endsection
+
+@section('scripts.footer')
+<script src="{{ asset('/js/csrf-refresh.js') }}?v={{ @filemtime(public_path('js/csrf-refresh.js')) }}"></script>
+@endsection

--- a/resources/views/errors/419.blade.php
+++ b/resources/views/errors/419.blade.php
@@ -1,0 +1,46 @@
+@extends('layouts.app-tw')
+
+@section('title', '419 - Page Expired')
+
+{{--
+    An error page is not a canonical resource: the layout's default would emit a
+    self-referential <link rel="canonical"> for whatever bad URL was requested,
+    which invites crawlers to index it. Claiming the section suppresses that
+    fallback — the comment is load-bearing, since @hasSection compiles to a
+    check for non-empty content, so an empty section would not override.
+--}}
+@section('canonical')
+<!-- no canonical: error page -->
+@endsection
+
+@section('meta.robots')
+<meta name="robots" content="noindex, follow">
+@endsection
+
+@section('content')
+
+<div class="flex items-center justify-center min-h-[60vh]">
+    <div class="text-center">
+        <div class="mb-8">
+            <i class="bi bi-clock-history text-6xl text-muted-foreground"></i>
+        </div>
+        <h1 class="text-6xl font-bold text-foreground mb-4">419</h1>
+        <p class="text-xl text-muted-foreground mb-8">Page expired</p>
+        <p class="text-muted-foreground mb-8 max-w-md mx-auto">
+            Your session timed out. Please go back and try again.
+        </p>
+        <div class="flex flex-wrap gap-4 justify-center">
+            <a href="{{ URL::previous() }}" class="btn-secondary-tw">
+                <i class="bi bi-arrow-left mr-2"></i>Go Back
+            </a>
+            <a href="{{ url('/') }}" class="btn-primary-tw">
+                <i class="bi bi-house mr-2"></i>Home
+            </a>
+            <a href="{{ route('login') }}" class="btn-primary-tw">
+                <i class="bi bi-box-arrow-in-right mr-2"></i>Log In
+            </a>
+        </div>
+    </div>
+</div>
+
+@stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,6 +42,12 @@ use Illuminate\Support\Facades\Route;
 // apply it, leaving accounts open to verification via crafted URLs.
 Auth::routes();
 
+// Returns a token bound to the caller's (possibly brand-new) session so a
+// stale page can refresh its CSRF token without a full reload (issue #2089).
+Route::get('csrf-token', function () {
+    return response()->json(['token' => csrf_token()]);
+})->name('csrf.token');
+
 // Email verification routes — `verification.verify` MUST be signed.
 Route::get('email/verify', [\App\Http\Controllers\Auth\VerificationController::class, 'show'])
     ->name('verification.notice');

--- a/tests/Feature/Auth/SessionExpired419Test.php
+++ b/tests/Feature/Auth/SessionExpired419Test.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Session\TokenMismatchException;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class SessionExpired419Test extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+
+        // VerifyCsrfToken is a no-op under runningUnitTests(), so throw the
+        // exception it would raise and assert on the handler's rendering.
+        Route::post('test-419', function () {
+            throw new TokenMismatchException('CSRF token mismatch.');
+        })->middleware('web');
+    }
+
+    public function test_token_mismatch_redirects_back_with_message_instead_of_419(): void
+    {
+        $response = $this->from('/login')->post('test-419', [
+            'email' => 'someone@example.com',
+            'password' => 'secret-password',
+        ]);
+
+        $response->assertRedirect('/login');
+        $response->assertSessionHas('error', 'Your session expired. Please try again.');
+        $response->assertSessionHasInput('email', 'someone@example.com');
+        $this->assertNull(session()->getOldInput('password'));
+    }
+
+    public function test_token_mismatch_falls_back_to_login_without_referer(): void
+    {
+        $this->post('test-419')->assertRedirect(route('login'));
+    }
+
+    public function test_json_requests_still_get_a_419(): void
+    {
+        $this->postJson('test-419')->assertStatus(419);
+    }
+
+    public function test_csrf_token_endpoint_returns_a_fresh_token(): void
+    {
+        $response = $this->get('/csrf-token');
+
+        $response->assertOk();
+        $response->assertJsonStructure(['token']);
+        $this->assertNotEmpty($response->json('token'));
+    }
+}


### PR DESCRIPTION
Fixes #2089

## Problem

On mobile, a login page left open/backgrounded for days outlives the session (`SESSION_LIFETIME=3600` in prod, file driver with GC lottery). The `@csrf` token baked into the page then matches nothing, so submitting the form throws `TokenMismatchException` → Laravel's bare, dead-end **419 Page Expired** screen. The only way out was a manual reload. (Same root cause as the earlier logout report #1668.)

## Fix

Two layers:

**Prevention — the first submit on a stale tab now succeeds**
- New `GET /csrf-token` route returning a token bound to the caller's (possibly brand-new) session.
- New `public/js/csrf-refresh.js`, loaded only on the login page, refetches that token when the tab becomes visible again (`visibilitychange`) or is restored from the back-forward cache (`pageshow` + `persisted` — the common mobile-Safari path), and rewrites the form's `_token` input, the `csrf-token` meta tag, and the axios default header.

**Graceful recovery — if a 419 still happens anywhere**
- `Handler::render()` now catches `TokenMismatchException` for non-JSON requests and redirects back (fallback: login) with a "Your session expired. Please try again." flash and the typed email preserved (passwords explicitly excluded from old input). The redirect carries a fresh session + token, so the retry works. JSON/axios callers still get a plain 419.
- Friendly `resources/views/errors/419.blade.php` styled after the 404 page as a last-resort safety net.

## Testing

- New `tests/Feature/Auth/SessionExpired419Test.php`: redirect with flash + preserved email (no password), login fallback without a referer, JSON requests still 419, token endpoint returns a fresh token. (CSRF middleware is a no-op under `runningUnitTests()`, so the tests throw the exception through a `web`-group route and assert on the handler's rendering.)
- All 32 existing auth tests pass; PHPStan clean; the 419 view renders.
- ESLint errors on the new JS match every existing `public/js` file — that directory is outside the `npm run lint` scope (`resources/assets/js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfBBEXREVi8zYzp3Mm3WVW