### PR TITLE
Add tag drill-down pills to the time-window landing pages

### DIFF
--- a/app/Http/Controllers/EventTimeWindowController.php
+++ b/app/Http/Controllers/EventTimeWindowController.php
@@ -4,12 +4,16 @@ namespace App\Http\Controllers;
 
 use App\Enums\EventTimeWindow;
 use App\Models\Event;
+use App\Models\Tag;
 use App\Services\EventTimeWindowStats;
 use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
 
 /**
  * Stable, crawlable time-window landing pages: /events/tonight,
- * /events/this-weekend, /events/this-week.
+ * /events/this-weekend, /events/this-week. An optional ?tag={slug} narrows
+ * the window to one tag (the drill-down pills); those variants are
+ * noindexed via SeoMeta::NOINDEX_PARAMS and canonicalize to the clean path.
  *
  * Deliberately does NOT use ListParameterSessionStore / ListEntityResultBuilder
  * — these pages must render the same content for every visitor and must not
@@ -17,22 +21,45 @@ use Illuminate\Contracts\View\View;
  */
 class EventTimeWindowController extends Controller
 {
-    public function show(string $window, EventTimeWindowStats $stats): View
+    public function show(Request $request, string $window, EventTimeWindowStats $stats): View
     {
         $timeWindow = EventTimeWindow::tryFrom($window) ?? abort(404);
 
         $range = $timeWindow->range();
 
+        $activeTag = $this->activeTag($request);
+
         $events = Event::query()
             ->visible($this->user)
             ->between($range['start'], $range['end'])
+            ->when($activeTag, function ($query) use ($activeTag) {
+                $query->whereHas('tags', function ($q) use ($activeTag) {
+                    $q->where('tags.id', $activeTag->id);
+                });
+            })
             ->with(EventsController::cardEventEagerLoad($this->user))
             ->paginate(48);
+
+        if ($activeTag) {
+            $events->appends(['tag' => $activeTag->slug]);
+        }
 
         return view('events.time-window-tw', [
             'window' => $timeWindow,
             'events' => $events,
             'stats' => $stats->stats($timeWindow),
+            'activeTag' => $activeTag,
         ]);
+    }
+
+    protected function activeTag(Request $request): ?Tag
+    {
+        $slug = $request->query('tag');
+
+        if (! is_string($slug) || $slug === '') {
+            return null;
+        }
+
+        return Tag::where('slug', $slug)->first() ?? abort(404);
     }
 }

--- a/app/Services/EventTimeWindowStats.php
+++ b/app/Services/EventTimeWindowStats.php
@@ -20,17 +20,23 @@ class EventTimeWindowStats
     protected const CACHE_TTL = 900;
 
     /**
-     * @return array{events: int, venues: int, tags: string[]}
+     * How many tags tagLinks carries. The page shows the first
+     * TAG_LINKS_VISIBLE and folds the rest behind a "…" toggle.
+     */
+    public const TAG_LINKS_LIMIT = 24;
+
+    public const TAG_LINKS_VISIBLE = 8;
+
+    /**
+     * tagLinks: the window's tags by frequency, for the drill-down pills.
+     * tags: the top 3 names, for the meta description.
+     *
+     * @return array{events: int, venues: int, tags: string[], tagLinks: array<int, array{name: string, slug: string, count: int}>}
      */
     public function stats(EventTimeWindow $window): array
     {
+        $cacheKey = $this->cacheKey($window);
         $range = $window->range();
-
-        $cacheKey = sprintf(
-            'event-window-stats:%s:%s',
-            $window->value,
-            substr($range['start'], 0, 10)
-        );
 
         return Cache::remember($cacheKey, self::CACHE_TTL, function () use ($range): array {
             $counts = Event::query()
@@ -40,24 +46,46 @@ class EventTimeWindowStats
                 ->toBase()
                 ->first();
 
-            $tags = DB::table('event_tag')
+            $tagLinks = DB::table('event_tag')
                 ->join('events', 'events.id', '=', 'event_tag.event_id')
                 ->join('tags', 'tags.id', '=', 'event_tag.tag_id')
                 ->where('events.visibility_id', Visibility::VISIBILITY_PUBLIC)
                 ->whereBetween('events.start_at', [$range['start'], $range['end']])
-                ->select('tags.name')
+                ->select('tags.name', 'tags.slug')
                 ->selectRaw('COUNT(*) as frequency')
-                ->groupBy('tags.name')
+                ->groupBy('tags.name', 'tags.slug')
                 ->orderByDesc('frequency')
-                ->limit(3)
-                ->pluck('tags.name')
+                ->orderBy('tags.name')
+                ->limit(self::TAG_LINKS_LIMIT)
+                ->get()
+                ->map(fn ($row) => [
+                    'name' => $row->name,
+                    'slug' => $row->slug,
+                    'count' => (int) $row->frequency,
+                ])
                 ->all();
 
             return [
                 'events' => $counts ? (int) $counts->event_count : 0,
                 'venues' => $counts ? (int) $counts->venue_count : 0,
-                'tags' => $tags,
+                'tags' => array_column(array_slice($tagLinks, 0, 3), 'name'),
+                'tagLinks' => $tagLinks,
             ];
         });
+    }
+
+    /**
+     * Versioned so a deploy that changes the payload shape never serves a
+     * stale entry missing the new keys.
+     */
+    protected function cacheKey(EventTimeWindow $window): string
+    {
+        $range = $window->range();
+
+        return sprintf(
+            'event-window-stats:v2:%s:%s',
+            $window->value,
+            substr($range['start'], 0, 10)
+        );
     }
 }

--- a/app/Services/SeoMeta.php
+++ b/app/Services/SeoMeta.php
@@ -26,6 +26,7 @@ class SeoMeta
         'tabs',
         'day_offset',
         'page',
+        'tag',
     ];
 
     /**

--- a/resources/views/events/time-window-tw.blade.php
+++ b/resources/views/events/time-window-tw.blade.php
@@ -1,15 +1,17 @@
 @extends('layouts.app-tw')
 
-@section('title', $window->title())
+@section('title', $window->title() . ($activeTag ? ' — ' . $activeTag->name : ''))
 
 @php
     $desc = $window->metaDescription($stats);
+    $tagLinks = $stats['tagLinks'] ?? [];
+    $visibleTagCount = \App\Services\EventTimeWindowStats::TAG_LINKS_VISIBLE;
 @endphp
 
 @section('description', $desc)
 @section('og-description', $desc)
 
-@if ($events->isNotEmpty())
+@if ($events->isNotEmpty() && ! $activeTag)
 @section('page.json')
 @include('events.index-json-ld', [
     'pageUrl' => url($window->path()),
@@ -23,12 +25,12 @@
 
 <!-- Page Header -->
 <div class="mb-6">
-	<h1 class="text-3xl font-bold text-primary mb-2">{{ $window->h1() }}</h1>
+	<h1 class="text-3xl font-bold text-primary mb-2">{{ $window->h1() }}{{ $activeTag ? ' — ' . $activeTag->name : '' }}</h1>
 	<p class="text-muted-foreground">{{ $desc }}</p>
 </div>
 
 <!-- Other windows -->
-<div class="mb-6 flex flex-wrap gap-2">
+<div class="mb-4 flex flex-wrap gap-2">
 	@foreach (\App\Enums\EventTimeWindow::cases() as $otherWindow)
 	<a href="{{ url($otherWindow->path()) }}"
 		class="inline-flex items-center px-3 py-1 rounded-full text-sm border transition-colors {{ $otherWindow === $window ? 'bg-primary text-primary-foreground border-primary' : 'border-border text-muted-foreground hover:bg-accent' }}">
@@ -36,6 +38,35 @@
 	</a>
 	@endforeach
 </div>
+
+<!-- Tag drill-down pills -->
+@if (! empty($tagLinks))
+<div class="mb-6 flex flex-wrap items-center gap-2" x-data="{ expanded: false }">
+	@foreach ($tagLinks as $index => $tagLink)
+	@php
+		$isActive = $activeTag && $activeTag->slug === $tagLink['slug'];
+		$isFolded = $index >= $visibleTagCount && ! $isActive;
+	@endphp
+	<a href="{{ $isActive ? url($window->path()) : url($window->path()) . '?tag=' . urlencode($tagLink['slug']) }}"
+		@if ($isFolded) x-show="expanded" style="display: none;" @endif
+		title="{{ $isActive ? 'Clear tag filter' : 'Only ' . $tagLink['name'] . ' events' }}"
+		class="inline-flex items-center gap-1 px-3 py-1 rounded-full text-xs border transition-colors {{ $isActive ? 'bg-primary text-primary-foreground border-primary' : 'border-border text-muted-foreground hover:bg-accent' }}">
+		{{ $tagLink['name'] }}
+		<span class="{{ $isActive ? 'text-primary-foreground/80' : 'text-muted-foreground/70' }}">{{ $tagLink['count'] }}</span>
+		@if ($isActive)
+		<i class="bi bi-x ml-0.5" aria-hidden="true"></i>
+		@endif
+	</a>
+	@endforeach
+	@if (count($tagLinks) > $visibleTagCount)
+	<button type="button" x-show="! expanded" @click="expanded = true"
+		class="inline-flex items-center px-3 py-1 rounded-full text-xs border border-border text-muted-foreground hover:bg-accent transition-colors"
+		aria-label="Show all tags">
+		&hellip;
+	</button>
+	@endif
+</div>
+@endif
 
 @if ($events->isNotEmpty())
 <div class="mb-4">
@@ -54,11 +85,19 @@
 @else
 <div class="text-center py-12">
 	<i class="bi bi-calendar-x text-6xl text-muted-foreground/60 mb-4"></i>
+	@if ($activeTag)
+	<p class="text-muted-foreground">No {{ $activeTag->name }} events found for this window yet.</p>
+	<a href="{{ url($window->path()) }}" class="mt-4 inline-flex items-center text-primary hover:text-primary/90">
+		<i class="bi bi-arrow-left mr-2"></i>
+		View all {{ strtolower($window->label()) }} events
+	</a>
+	@else
 	<p class="text-muted-foreground">No events found for this window yet.</p>
 	<a href="{{ url('/events') }}" class="mt-4 inline-flex items-center text-primary hover:text-primary/90">
 		<i class="bi bi-arrow-left mr-2"></i>
 		View all events
 	</a>
+	@endif
 </div>
 @endif
 

--- a/tests/Feature/Services/EventTimeWindowStatsTest.php
+++ b/tests/Feature/Services/EventTimeWindowStatsTest.php
@@ -90,6 +90,36 @@ class EventTimeWindowStatsTest extends TestCase
         $this->assertSame(1, $stats['venues']); // same venue for both events
         $this->assertSame('Techno', $stats['tags'][0]); // most frequent first
         $this->assertContains('Punk', $stats['tags']);
+
+        // tagLinks carries name/slug/count for the drill-down pills, in the
+        // same frequency order the meta-description tags are derived from.
+        $this->assertSame(
+            ['name' => 'Techno', 'slug' => $tagA->slug, 'count' => 2],
+            $stats['tagLinks'][0]
+        );
+        $this->assertContains(
+            ['name' => 'Punk', 'slug' => $tagB->slug, 'count' => 1],
+            $stats['tagLinks']
+        );
+    }
+
+    public function test_tag_links_exclude_non_public_events(): void
+    {
+        $window = EventTimeWindow::Tonight;
+        $start = $this->insideStart($window);
+
+        $tag = Tag::factory()->create(['name' => 'Private Only Tag']);
+
+        $private = Event::factory()->create([
+            'visibility_id' => Visibility::VISIBILITY_PRIVATE,
+            'start_at' => $start,
+            'created_by' => User::factory()->create()->id,
+        ]);
+        $private->tags()->attach($tag->id);
+
+        $stats = app(EventTimeWindowStats::class)->stats($window);
+
+        $this->assertNotContains('Private Only Tag', array_column($stats['tagLinks'], 'name'));
     }
 
     public function test_cache_key_varies_by_window_start_date(): void
@@ -99,14 +129,14 @@ class EventTimeWindowStatsTest extends TestCase
         $stats->stats(EventTimeWindow::Tonight);
 
         $tonightRange = EventTimeWindow::Tonight->range();
-        $cacheKey = 'event-window-stats:tonight:'.substr($tonightRange['start'], 0, 10);
+        $cacheKey = 'event-window-stats:v2:tonight:'.substr($tonightRange['start'], 0, 10);
 
         $this->assertTrue(Cache::has($cacheKey));
 
         // A different window (this-week) usually starts on the same date but is
         // a distinct cache entry keyed by window value + start date.
         $weekRange = EventTimeWindow::ThisWeek->range();
-        $weekCacheKey = 'event-window-stats:this-week:'.substr($weekRange['start'], 0, 10);
+        $weekCacheKey = 'event-window-stats:v2:this-week:'.substr($weekRange['start'], 0, 10);
 
         $this->assertNotSame($cacheKey, $weekCacheKey);
     }

--- a/tests/Feature/Web/EventTimeWindowPagesTest.php
+++ b/tests/Feature/Web/EventTimeWindowPagesTest.php
@@ -194,6 +194,108 @@ class EventTimeWindowPagesTest extends TestCase
         }
     }
 
+    /**
+     * @dataProvider windowProvider
+     */
+    public function test_tag_pills_render_for_in_window_tags(string $windowValue, string $path, string $phrase): void
+    {
+        $window = EventTimeWindow::from($windowValue);
+
+        $tag = \App\Models\Tag::factory()->create(['name' => 'Pill Render Tag']);
+        $this->eventInside($window)->tags()->attach($tag->id);
+
+        $response = $this->get($path);
+
+        $response->assertOk();
+        $response->assertSee('Pill Render Tag');
+        $response->assertSee($path.'?tag='.$tag->slug, false);
+    }
+
+    /**
+     * @dataProvider windowProvider
+     */
+    public function test_tag_param_filters_the_window_to_that_tag(string $windowValue, string $path, string $phrase): void
+    {
+        $window = EventTimeWindow::from($windowValue);
+
+        $tag = \App\Models\Tag::factory()->create(['name' => 'Drilldown Tag']);
+        $tagged = $this->eventInside($window, ['name' => 'Tagged Window Event']);
+        $tagged->tags()->attach($tag->id);
+        $this->eventInside($window, ['name' => 'Untagged Window Event']);
+
+        $response = $this->get($path.'?tag='.$tag->slug);
+
+        $response->assertOk();
+        $response->assertSee('Tagged Window Event');
+        $response->assertDontSee('Untagged Window Event');
+        // The active pill clears the filter back to the clean window path.
+        $response->assertSee('Clear tag filter', false);
+    }
+
+    /**
+     * @dataProvider windowProvider
+     */
+    public function test_unknown_tag_slug_is_a_404(string $windowValue, string $path, string $phrase): void
+    {
+        $this->get($path.'?tag=no-such-tag-slug')->assertNotFound();
+    }
+
+    /**
+     * @dataProvider windowProvider
+     */
+    public function test_tag_param_variant_is_noindexed(string $windowValue, string $path, string $phrase): void
+    {
+        $window = EventTimeWindow::from($windowValue);
+
+        $tag = \App\Models\Tag::factory()->create();
+        $this->eventInside($window)->tags()->attach($tag->id);
+
+        $response = $this->get($path.'?tag='.$tag->slug);
+
+        $response->assertOk();
+        $response->assertSee('<meta name="robots" content="noindex, follow">', false);
+        // ItemList JSON-LD is only emitted for the unfiltered page.
+        $response->assertDontSee('"@type": "ItemList"', false);
+    }
+
+    public function test_more_than_eight_tags_fold_behind_an_ellipsis_toggle(): void
+    {
+        $window = EventTimeWindow::from('this-week');
+
+        $event = $this->eventInside($window);
+        $tags = \App\Models\Tag::factory()->count(9)->create();
+        $event->tags()->attach($tags->pluck('id')->all());
+
+        $response = $this->get('/events/this-week');
+
+        $response->assertOk();
+        $response->assertSee('Show all tags', false);
+        $response->assertSee('x-show="expanded"', false);
+    }
+
+    public function test_eight_or_fewer_tags_have_no_ellipsis_toggle(): void
+    {
+        $window = EventTimeWindow::from('this-week');
+
+        $event = $this->eventInside($window);
+        $tags = \App\Models\Tag::factory()->count(3)->create();
+        $event->tags()->attach($tags->pluck('id')->all());
+
+        // The seeder can leave its own tagged events inside this real-time
+        // window; only assert the toggle is absent when the window really has
+        // eight or fewer tags.
+        $stats = app(EventTimeWindowStats::class)->stats($window);
+
+        $response = $this->get('/events/this-week');
+        $response->assertOk();
+
+        if (count($stats['tagLinks']) <= EventTimeWindowStats::TAG_LINKS_VISIBLE) {
+            $response->assertDontSee('Show all tags', false);
+        } else {
+            $response->assertSee('Show all tags', false);
+        }
+    }
+
     public function test_other_window_pill_links_are_present(): void
     {
         $response = $this->get('/events/tonight');


### PR DESCRIPTION
Closes #2093.

Under the Tonight / This Weekend / This Week window pills, each landing page now lists the tags attached to that window's events, ordered by frequency with a count badge. Clicking a tag filters the page to that tag **and** the window's date range via `?tag={slug}` on the same stable URL; the active pill highlights and clears back to the unfiltered page. The first 8 tags show inline; the rest fold behind a "…" button (Alpine toggle, per the issue's cutoff spec).

## Implementation

- **`EventTimeWindowStats`** — the tag query now returns `tagLinks` (`name`/`slug`/`count`, top 24, public events only) and derives the existing top-3 `tags` names for the meta description from it. Same single cached query; the cache key is versioned (`:v2:`) so a deploy never serves the old payload shape from a warm cache.
- **`EventTimeWindowController`** — resolves `?tag=` by slug (404 on unknown), applies a `whereHas('tags')` constraint on top of the window range, and appends the tag to pagination links. Still deliberately stateless — no session filter store.
- **View** — pill row under the window links; active-tag heading suffix ("… This Week — Punk"); tag-aware empty state that clears the filter instead of leaving the page.
- **SEO** — `tag` added to `SeoMeta::NOINDEX_PARAMS`, so filtered variants are `noindex, follow` and canonicalize to the clean window path (query strings were already stripped from canonicals). ItemList JSON-LD is only emitted on the unfiltered page. No other route reads a bare `tag` query param, so nothing else is affected.

## Testing

- New feature tests: pills render, `?tag=` filters in/out correctly, unknown slug 404s, filtered variant is noindexed and JSON-LD-free, >8 tags renders the fold toggle (seeder-tolerant assertions where the live window can carry seeded data).
- Stats tests extended for `tagLinks` shape/order and public-only visibility; cache-key test updated for v2.
- `composer phpstan` clean; both time-window suites + SeoMeta suites green (84 tests).
- Verified live on dev: collapsed/expanded pills, filtered page heading + canonical + robots, bogus slug 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfBBEXREVi8zYzp3Mm3WVW