### PR TITLE
Fix: Incorrect datetime value for entity started_at [EVENTREPO-Y7]

### DIFF
--- a/app/Http/Requests/EntityRequest.php
+++ b/app/Http/Requests/EntityRequest.php
@@ -32,6 +32,9 @@ class EntityRequest extends Request
             'description' => 'required',
             'entity_type_id' => 'required',
             'entity_status_id' => 'required',
+            // started_at is stored in a MySQL TIMESTAMP column (valid range 1970–2038),
+            // so keep it inside safe bounds to avoid a 500 from out-of-range dates.
+            'started_at' => 'nullable|date|after_or_equal:1971-01-01|before_or_equal:2037-12-31',
         ];
     }
 }


### PR DESCRIPTION
## Sentry issue

[EVENTREPO-Y7](https://sentry.io/organizations/geoff-maddock/issues/7685235665/) — `Illuminate\Database\QueryException: SQLSTATE[22007]: Invalid datetime format: 1292 Incorrect datetime value: '1918-01-01 13:49:00' for column 'started_at'`

Occurs on `POST /entities` when creating an entity. No user feedback attached.

## Error

```
SQLSTATE[22007]: Invalid datetime format: 1292 Incorrect datetime value:
'1918-01-01 13:49:00' for column 'started_at' at row 1
(insert into `entities` (..., `started_at`, ...) values (..., 1918-01-01 13:49:00, ...))
```

## Root cause

The entity create/update form (`resources/views/entities/form.blade.php`) exposes `started_at` as a free `datetime-local` input, and `EntitiesController::store()`/`update()` pass `$request->all()` straight into the model. `EntityRequest` did **not** validate `started_at`.

The `entities.started_at` column is a MySQL `TIMESTAMP`, whose valid range is roughly `1970-01-01` to `2038-01-19`. When a user submits a date outside that range (here `1918-01-01`), MySQL rejects the insert under strict mode with error 1292, which surfaces as an unhandled HTTP 500 instead of a friendly form error.

## What changed

Added a validation rule to `EntityRequest`:

```php
'started_at' => 'nullable|date|after_or_equal:1971-01-01|before_or_equal:2037-12-31',
```

Out-of-range (or malformed) dates now produce a normal validation message on the form instead of a 500. Bounds are kept a little inside the raw `TIMESTAMP` limits so timezone conversion (app timezone is `EST`) can't push a boundary value past the column's real min/max. Because `store()` and `update()` share `EntityRequest`, both paths are covered.

## Validation

`php -l` passes on the changed file. PHPStan/PHPUnit were not run in this environment (no `vendor/` install and no MySQL DB available); the change is a single standard Laravel validation rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1BVUgBE5PK59CrqjdW3sZ)_