### PR TITLE
Move flyer analysis to claude-sonnet-5 and handle thinking blocks

### DIFF
--- a/app/Services/FlyerAnalysisService.php
+++ b/app/Services/FlyerAnalysisService.php
@@ -67,7 +67,16 @@ class FlyerAnalysisService
         }
 
         $responseData = $response->json();
-        $text = $responseData['content'][0]['text'] ?? '';
+
+        // The response may lead with thinking blocks (adaptive thinking on
+        // Sonnet 5 / Opus 5), so take the first text block, not content[0].
+        $text = '';
+        foreach ($responseData['content'] ?? [] as $block) {
+            if (($block['type'] ?? null) === 'text') {
+                $text = $block['text'] ?? '';
+                break;
+            }
+        }
 
         // Strip any markdown fences the model may include despite instructions
         $text = preg_replace('/^```(?:json)?\s*/i', '', trim($text));

--- a/config/ai.php
+++ b/config/ai.php
@@ -24,8 +24,10 @@ return [
         'api_key' => env('ANTHROPIC_API_KEY', ''),
         'api_url' => 'https://api.anthropic.com/v1/messages',
         'api_version' => '2023-06-01',
-        'model' => env('ANTHROPIC_MODEL', 'claude-opus-4-5'),
-        'max_tokens' => 2048,
+        'model' => env('ANTHROPIC_MODEL', 'claude-sonnet-5'),
+        // Adaptive thinking (Sonnet 5 / Opus 5) counts against max_tokens,
+        // so leave headroom above the expected JSON payload size.
+        'max_tokens' => 8192,
     ],
 
     /*

--- a/tests/Feature/Services/FlyerAnalysisServiceTest.php
+++ b/tests/Feature/Services/FlyerAnalysisServiceTest.php
@@ -27,7 +27,7 @@ class FlyerAnalysisServiceTest extends TestCase
     {
         Http::fake([
             'api.anthropic.com/*' => Http::response([
-                'content' => [['text' => '{"name":"Test Event","start_at":"2026-08-15 20:00"}']],
+                'content' => [['type' => 'text', 'text' => '{"name":"Test Event","start_at":"2026-08-15 20:00"}']],
             ], 200),
         ]);
 
@@ -41,13 +41,29 @@ class FlyerAnalysisServiceTest extends TestCase
     {
         Http::fake([
             'api.anthropic.com/*' => Http::response([
-                'content' => [['text' => "```json\n{\"name\":\"Fenced Event\"}\n```"]],
+                'content' => [['type' => 'text', 'text' => "```json\n{\"name\":\"Fenced Event\"}\n```"]],
             ], 200),
         ]);
 
         $result = (new FlyerAnalysisService())->analyze($this->flyer());
 
         $this->assertSame('Fenced Event', $result['name']);
+    }
+
+    public function test_skips_leading_thinking_block_and_reads_text_block(): void
+    {
+        Http::fake([
+            'api.anthropic.com/*' => Http::response([
+                'content' => [
+                    ['type' => 'thinking', 'thinking' => ''],
+                    ['type' => 'text', 'text' => '{"name":"Thoughtful Event"}'],
+                ],
+            ], 200),
+        ]);
+
+        $result = (new FlyerAnalysisService())->analyze($this->flyer());
+
+        $this->assertSame('Thoughtful Event', $result['name']);
     }
 
     public function test_api_failure_throws_runtime_exception(): void
@@ -66,7 +82,7 @@ class FlyerAnalysisServiceTest extends TestCase
     {
         Http::fake([
             'api.anthropic.com/*' => Http::response([
-                'content' => [['text' => 'this is not json']],
+                'content' => [['type' => 'text', 'text' => 'this is not json']],
             ], 200),
         ]);
 


### PR DESCRIPTION
## Summary
- Switch the flyer analysis default model from the stale `claude-opus-4-5` fallback / `claude-sonnet-4-6` env setting to `claude-sonnet-5` — a generation newer than Sonnet 4.6, currently cheaper (intro pricing $2/$10 per 1M tokens through 2026-08-31), and the same price ($3/$15) afterward.
- Parse the API response by selecting the first `text` content block instead of `content[0]`. Sonnet 5 / Opus 5 run adaptive thinking by default, so the content array can lead with a `thinking` block — the old indexing would have returned an empty string and failed every analysis.
- Raise `max_tokens` from 2048 to 8192, since thinking output now counts against the cap and could otherwise truncate the JSON payload. Only generated tokens are billed, so the higher ceiling costs nothing on typical calls.

## Deploy notes
Code must deploy **before or with** the prod env flip:
1. Merge + deploy this change.
2. In prod `.env`: `ANTHROPIC_MODEL=claude-sonnet-5`
3. `php artisan config:clear && php artisan config:cache`

## Test plan
- [x] `./vendor/bin/phpunit tests/Feature/Services/FlyerAnalysisServiceTest.php` — 7 passing, including a new test for a thinking-led response
- [x] `composer phpstan` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C2K8Z8rAbFAPkpWuCrc5xw