### PR TITLE
Throttle manual Instagram reposts to once per three days

### DIFF
--- a/app/Http/Controllers/Api/EventInstagramController.php
+++ b/app/Http/Controllers/Api/EventInstagramController.php
@@ -10,6 +10,7 @@ use App\Jobs\Instagram\PostEventToInstagram;
 use App\Jobs\Instagram\PostWeekendPreviewToInstagram;
 use App\Models\Event;
 use App\Models\EventShare;
+use App\Models\User;
 use App\Services\Integrations\Instagram;
 use App\Services\ImageHandler;
 use Carbon\Carbon;
@@ -161,6 +162,12 @@ class EventInstagramController extends Controller
             return back();
         }
 
+        if ($error = $this->recentRepostError($event, $this->user)) {
+            flash()->error('Already posted', $error);
+
+            return back();
+        }
+
         PostEventToInstagram::dispatch($event, false, $this->user?->id);
 
         flash()->success('Queued', 'This event is being posted to Instagram in the background. You will be notified when it finishes.');
@@ -183,6 +190,10 @@ class EventInstagramController extends Controller
 
         if ($error = $this->eventPhotoError($event)) {
             return $this->instagramActionResponse(false, 'Error', $error);
+        }
+
+        if ($error = $this->recentRepostError($event, $this->user)) {
+            return $this->instagramActionResponse(false, 'Already posted', $error);
         }
 
         PostEventToInstagram::dispatch($event, true, $this->user?->id);
@@ -224,6 +235,10 @@ class EventInstagramController extends Controller
             return response()->json(['success' => false, 'message' => $error], 422);
         }
 
+        if ($error = $this->recentRepostError($event, $user)) {
+            return response()->json(['success' => false, 'message' => $error], 429);
+        }
+
         // Build the job so we can hand its tracking id back to the caller, then dispatch.
         $job = new PostEventToInstagram($event, true, $user->id);
         dispatch($job);
@@ -247,6 +262,34 @@ class EventInstagramController extends Controller
 
         if (!$instagram->getPageAccessToken()) {
             return 'You must have an Instagram page linked to post to Instagram.';
+        }
+
+        return null;
+    }
+
+    /**
+     * Manual reposts are throttled: an event that already went to Instagram
+     * within the last three days may not be posted again. Admins are exempt.
+     * Returns a user-facing error string, or null when posting may proceed.
+     */
+    private function recentRepostError(Event $event, ?User $user): ?string
+    {
+        if ($user && $user->isAdmin()) {
+            return null;
+        }
+
+        $lastShare = EventShare::where('event_id', $event->id)
+            ->where('platform', 'instagram')
+            ->whereNotNull('posted_at')
+            ->where('posted_at', '>=', Carbon::now()->subDays(3))
+            ->orderBy('posted_at', 'desc')
+            ->first();
+
+        if ($lastShare) {
+            return sprintf(
+                'This event was already posted to Instagram %s. Events can only be reposted three days after the last post.',
+                $lastShare->posted_at->diffForHumans()
+            );
         }
 
         return null;

--- a/tests/Feature/QueuedInstagramPostTest.php
+++ b/tests/Feature/QueuedInstagramPostTest.php
@@ -95,6 +95,94 @@ class QueuedInstagramPostTest extends TestCase
         Queue::assertPushed(PostEventStoryToInstagram::class);
     }
 
+    private function shareEventToInstagram(Event $event, ?\Carbon\Carbon $postedAt): EventShare
+    {
+        return EventShare::create([
+            'event_id' => $event->id,
+            'platform' => 'instagram',
+            'platform_id' => '555',
+            'created_by' => $event->created_by,
+            'posted_at' => $postedAt,
+        ]);
+    }
+
+    public function test_recent_instagram_post_blocks_manual_repost(): void
+    {
+        Queue::fake();
+        $this->mockInstagramCredentials();
+
+        $user = User::factory()->create(['user_status_id' => 1]);
+        $event = $this->eventWithPhoto($user);
+        $this->shareEventToInstagram($event, now()->subDay());
+
+        $response = $this->actingAs($user)->getJson('/events/' . $event->id . '/instagram-post');
+
+        $response->assertStatus(422)
+            ->assertJson(['success' => false, 'title' => 'Already posted']);
+        Queue::assertNotPushed(PostEventToInstagram::class);
+    }
+
+    public function test_post_older_than_three_days_does_not_block_repost(): void
+    {
+        Queue::fake();
+        $this->mockInstagramCredentials();
+
+        $user = User::factory()->create(['user_status_id' => 1]);
+        $event = $this->eventWithPhoto($user);
+        $this->shareEventToInstagram($event, now()->subDays(4));
+
+        $this->actingAs($user)->getJson('/events/' . $event->id . '/instagram-post')
+            ->assertStatus(200);
+        Queue::assertPushed(PostEventToInstagram::class);
+    }
+
+    public function test_failed_share_attempt_does_not_block_repost(): void
+    {
+        Queue::fake();
+        $this->mockInstagramCredentials();
+
+        $user = User::factory()->create(['user_status_id' => 1]);
+        $event = $this->eventWithPhoto($user);
+        // posted_at is null when a share attempt failed — that should not throttle
+        $this->shareEventToInstagram($event, null);
+
+        $this->actingAs($user)->getJson('/events/' . $event->id . '/instagram-post')
+            ->assertStatus(200);
+        Queue::assertPushed(PostEventToInstagram::class);
+    }
+
+    public function test_admin_is_exempt_from_repost_throttle(): void
+    {
+        Queue::fake();
+        $this->mockInstagramCredentials();
+
+        $adminGroup = Group::firstOrCreate(['name' => 'admin']);
+        $admin = User::factory()->create(['user_status_id' => 1]);
+        $admin->groups()->attach($adminGroup->id);
+        $event = $this->eventWithPhoto($admin);
+        $this->shareEventToInstagram($event, now()->subDay());
+
+        $this->actingAs($admin)->getJson('/events/' . $event->id . '/instagram-post')
+            ->assertStatus(200);
+        Queue::assertPushed(PostEventToInstagram::class);
+    }
+
+    public function test_api_carousel_blocks_recent_repost_with_429(): void
+    {
+        Queue::fake();
+        $this->mockInstagramCredentials();
+
+        $user = User::factory()->create(['user_status_id' => 1]);
+        $this->actingAs($user, 'sanctum');
+        $event = $this->eventWithPhoto($user);
+        $this->shareEventToInstagram($event, now()->subDay());
+
+        $this->postJson('/api/events/' . $event->id . '/instagram-post')
+            ->assertStatus(429)
+            ->assertJson(['success' => false]);
+        Queue::assertNotPushed(PostEventToInstagram::class);
+    }
+
     public function test_api_carousel_returns_job_status_id(): void
     {
         Queue::fake();


### PR DESCRIPTION
## Summary
- If an event was successfully posted to Instagram within the last three days, manual reposting is now blocked and the user is told when the last post went out (e.g. "This event was already posted to Instagram 1 day ago. Events can only be reposted three days after the last post.")
- Admins are exempt: the check uses the canonical `User::isAdmin()`, covering both the `admin` and `super_admin` groups.
- Applies to all three manual feed-post entry points: `postToInstagram` (single photo, flash + redirect), `postCarouselToInstagram` (the event page action — flash, or the 422 JSON shape its AJAX handler expects), and `postCarouselToInstagramApi` (returns 429). The story and weekend-preview endpoints are already `super_admin`-only, so the exemption would make the guard a no-op there and they're left unchanged.

## Implementation
- New `recentRepostError()` helper in `EventInstagramController` queries `event_shares` for `platform = 'instagram'` with a non-null `posted_at` in the last 3 days — the same shape as `EventDiscordController::postedRecently()`. Rows with null `posted_at` are failed attempts and don't count against the window.

## Testing
- 5 new feature tests in `QueuedInstagramPostTest`: recent post blocks with 422 + no job queued; a 4-day-old post doesn't block; a failed attempt (null `posted_at`) doesn't block; admin is exempt; API returns 429.
- Full `QueuedInstagramPostTest` (16 tests) and `ApiEventInstagramTest` (7 tests) pass; PHPStan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWtqu6VGJLRLGPrWjkFDEH