### PR TITLE
Modernize the mail config for SES and stop BCCing the admin on every email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,13 +47,27 @@ SANCTUM_TOKEN_EXPIRATION=43200
 # Comma-separated extra CORS origins for non-production environments (optional).
 CORS_EXTRA_ORIGINS=
 
-MAIL_DRIVER=smtp
-MAIL_HOST=smtp.mailgun.org
+# Which mailer config/mail.php resolves. "ses" for Amazon SES, "smtp" for a
+# plain SMTP relay, "log" to write mail to the log, "array" to discard it.
+# MAIL_DRIVER is still read as a fallback for older environment files.
+MAIL_MAILER=ses
+
+# Amazon SES. The region must be the one the sending identity is verified in —
+# there is no fallback, so a missing value fails loudly rather than sending to
+# the wrong region and reporting it as an unverified address.
+AWS_ACCESS_KEY_ID=your-ses-access-key-id
+AWS_SECRET_ACCESS_KEY=your-ses-secret-access-key
+AWS_DEFAULT_REGION=us-east-2
+# Optional. Names the SES configuration set that publishes bounce and
+# complaint events to SNS. Omit it and no configuration set is sent.
+SES_CONFIGURATION_SET=
+
+# Only read when MAIL_MAILER=smtp. Port 465 selects implicit TLS, anything
+# else uses STARTTLS; set MAIL_SCHEME only to force it.
+MAIL_HOST=smtp.example.org
 MAIL_PORT=587
 MAIL_USERNAME=postmaster@yourdomain.com
 MAIL_PASSWORD=your-mail-password
-MAIL_DOMAIN=your-domain
-MAIL_SECRET=your-mail-secret
 
 TWITTER_CONSUMER_KEY=999
 TWITTER_CONSUMER_SECRET=

--- a/app/Mail/AdminMailer.php
+++ b/app/Mail/AdminMailer.php
@@ -51,7 +51,6 @@ class AdminMailer extends Mailable
         // markdown
         return $this->markdown('emails.admin-test-markdown')
             ->from($this->reply_email, $this->site)
-             ->subject($this->site.': Admin Mailer Test - '.$dt->format('l F jS Y'))
-             ->bcc($this->admin_email);
+             ->subject($this->site.': Admin Mailer Test - '.$dt->format('l F jS Y'));
     }
 }

--- a/app/Mail/DailyReminder.php
+++ b/app/Mail/DailyReminder.php
@@ -56,7 +56,6 @@ class DailyReminder extends Mailable
 
         return $this->markdown('emails.daily-reminder-markdown')
             ->from($this->reply_email, $this->site)
-            ->subject($this->site.': Daily Reminder - '.$dt->format('l F jS Y'))
-            ->bcc($this->admin_email);
+            ->subject($this->site.': Daily Reminder - '.$dt->format('l F jS Y'));
     }
 }

--- a/app/Mail/FollowingPostUpdate.php
+++ b/app/Mail/FollowingPostUpdate.php
@@ -68,7 +68,6 @@ class FollowingPostUpdate extends Mailable
 
         return $this->markdown('emails.following-post-update-markdown')
             ->from($this->reply_email, $this->site)
-            ->subject($this->site.': New post by '.$this->post?->user?->name.' in thread "'.$this->thread?->name.'"')
-            ->bcc($this->admin_email);
+            ->subject($this->site.': New post by '.$this->post?->user?->name.' in thread "'.$this->thread?->name.'"');
     }
 }

--- a/app/Mail/FollowingThreadUpdate.php
+++ b/app/Mail/FollowingThreadUpdate.php
@@ -56,7 +56,6 @@ class FollowingThreadUpdate extends Mailable
 
         return $this->markdown('emails.following-thread-update-markdown')
             ->from($this->reply_email, $this->site)
-            ->subject($this->site.': '.$this->tag?->name.' :: '.$this->thread?->created_at->format('D F jS').' '.$this->thread?->name)
-            ->bcc($this->admin_email);
+            ->subject($this->site.': '.$this->tag?->name.' :: '.$this->thread?->created_at->format('D F jS').' '.$this->thread?->name);
     }
 }

--- a/app/Mail/FollowingUpdate.php
+++ b/app/Mail/FollowingUpdate.php
@@ -53,7 +53,6 @@ class FollowingUpdate extends Mailable
 
         return $this->markdown('emails.following-update-markdown')
             ->from($this->reply_email, $this->site)
-            ->subject($this->site.': '.$this->tag?->name.' :: '.$this->event?->start_at->format('D F jS').' '.$this->event?->name)
-            ->bcc($this->admin_email);
+            ->subject($this->site.': '.$this->tag?->name.' :: '.$this->event?->start_at->format('D F jS').' '.$this->event?->name);
     }
 }

--- a/app/Mail/LoginFailure.php
+++ b/app/Mail/LoginFailure.php
@@ -50,6 +50,9 @@ class LoginFailure extends Mailable
         return $this->markdown('emails.user-login-failed-markdown')
             ->from($this->reply_email, $this->site)
             ->subject($this->site.':  Login failure attempts - '.$this->user?->name.' - '.$dt->format('l F jS Y'))
+            // Deliberately kept when the blanket admin bcc was removed from the
+            // other mailables: this bcc is the admin's only signal of repeated
+            // login failures.
             ->bcc($this->admin_email);
     }
 }

--- a/app/Mail/UserActivation.php
+++ b/app/Mail/UserActivation.php
@@ -46,7 +46,6 @@ class UserActivation extends Mailable
 
         return $this->markdown('emails.user-activation-markdown')
             ->from($this->reply_email, $this->site)
-            ->subject($this->site.':  Account activated - '.$this->user?->name.' - '.$dt->format('l F jS Y'))
-            ->bcc($this->admin_email);
+            ->subject($this->site.':  Account activated - '.$this->user?->name.' - '.$dt->format('l F jS Y'));
     }
 }

--- a/app/Mail/UserDataExportReady.php
+++ b/app/Mail/UserDataExportReady.php
@@ -48,7 +48,6 @@ class UserDataExportReady extends Mailable
     {
         return $this->markdown('emails.user-data-export-ready')
             ->from($this->reply_email, $this->site)
-            ->subject($this->site . ': Your Data Export is Ready')
-            ->bcc($this->admin_email);
+            ->subject($this->site . ': Your Data Export is Ready');
     }
 }

--- a/app/Mail/UserSuspended.php
+++ b/app/Mail/UserSuspended.php
@@ -46,7 +46,6 @@ class UserSuspended extends Mailable
 
         return $this->markdown('emails.user-suspended-markdown')
             ->from($this->reply_email, $this->site)
-            ->subject($this->site.':  Account suspended - '.$this->user?->name.' - '.$dt->format('l F jS Y'))
-            ->bcc($this->admin_email);
+            ->subject($this->site.':  Account suspended - '.$this->user?->name.' - '.$dt->format('l F jS Y'));
     }
 }

--- a/app/Mail/UserUpdate.php
+++ b/app/Mail/UserUpdate.php
@@ -58,7 +58,6 @@ class UserUpdate extends Mailable
 
         return $this->markdown('emails.user-update-markdown')
             ->from($this->reply_email, $this->site)
-            ->subject($this->site.': Site updates for '.$this->user?->name.' - '.$dt->format('l F jS Y'))
-            ->bcc($this->admin_email);
+            ->subject($this->site.': Site updates for '.$this->user?->name.' - '.$dt->format('l F jS Y'));
     }
 }

--- a/app/Mail/WeeklyUpdate.php
+++ b/app/Mail/WeeklyUpdate.php
@@ -56,7 +56,6 @@ class WeeklyUpdate extends Mailable
 
         return $this->markdown('emails.weekly-update-markdown')
             ->from($this->reply_email, $this->site)
-            ->subject($this->site.': Weekly Update - '.$dt->format('l F jS Y'))
-            ->bcc($this->admin_email);
+            ->subject($this->site.': Weekly Update - '.$dt->format('l F jS Y'));
     }
 }

--- a/config/mail.php
+++ b/config/mail.php
@@ -3,122 +3,81 @@
 return [
     /*
     |--------------------------------------------------------------------------
-    | Mail Driver
+    | Default Mailer
     |--------------------------------------------------------------------------
     |
-    | Laravel supports both SMTP and PHP's "mail" function as drivers for the
-    | sending of e-mail. You may specify which one you're using throughout
-    | your application here. By default, Laravel is setup for SMTP mail.
+    | MAIL_MAILER is the modern name. MAIL_DRIVER is read as a fallback so an
+    | environment file written against the old flat config keeps working during
+    | the SES cutover; drop that fallback once every environment sets
+    | MAIL_MAILER.
     |
-    | Supported: "smtp", "mail", "sendmail", "mailgun", "mandrill", "log"
+    | This file used to be the pre-Laravel-6 flat format (a top-level "driver"
+    | key, with host/port/username/password beside it). In that format
+    | MailManager::getConfig() hands the *entire* config array to the transport
+    | factory, which is harmless for SMTP but means the SES factory would have
+    | received driver/host/port/from/markdown as SesClient constructor
+    | arguments. Hence the rewrite.
+    |
+    | Do not reintroduce a top-level "driver" key. Its presence at any value
+    | puts MailManager back on that legacy branch and silently ignores the
+    | "mailers" array below.
     |
     */
 
-    'driver' => env('MAIL_DRIVER', 'mailgun'),
+    'default' => env('MAIL_MAILER', env('MAIL_DRIVER', 'smtp')),
 
     /*
     |--------------------------------------------------------------------------
-    | SMTP Host Address
+    | Mailer Configurations
     |--------------------------------------------------------------------------
     |
-    | Here you may provide the host address of the SMTP server used by your
-    | applications. A default option is provided that is compatible with
-    | the Mailgun mail service which will provide reliable deliveries.
+    | Credentials for "ses" live in config/services.php under the key of the
+    | same name, which is where MailManager::createSesV2Transport() reads them.
     |
     */
 
-    'host' => env('MAIL_HOST', 'smtp.mailgun.org'),
+    'mailers' => [
+        'ses' => [
+            // The SES v2 SendEmail API rather than the v1 SendRawEmail one.
+            'transport' => 'ses-v2',
+        ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | SMTP Host Port
-    |--------------------------------------------------------------------------
-    |
-    | This is the SMTP port used by your application to deliver e-mails to
-    | users of the application. Like the host we have set this value to
-    | stay compatible with the Mailgun e-mail application by default.
-    |
-    */
+        'smtp' => [
+            'transport' => 'smtp',
+            'host' => env('MAIL_HOST', '127.0.0.1'),
+            'port' => env('MAIL_PORT', 587),
+            'username' => env('MAIL_USERNAME'),
+            'password' => env('MAIL_PASSWORD'),
+            'timeout' => null,
+            // No "encryption" key: since Laravel 11 the SMTP transport derives
+            // its scheme from "scheme", or from the port (465 = smtps,
+            // anything else = smtp with STARTTLS). The flat config's
+            // hardcoded 'encryption' => 'tls' had already stopped doing
+            // anything. Set MAIL_SCHEME only if a server needs it forced.
+            'scheme' => env('MAIL_SCHEME'),
+        ],
 
-    'port' => env('MAIL_PORT', 587),
+        'log' => [
+            'transport' => 'log',
+            'channel' => env('MAIL_LOG_CHANNEL'),
+        ],
+
+        'array' => [
+            'transport' => 'array',
+        ],
+    ],
 
     /*
     |--------------------------------------------------------------------------
     | Global "From" Address
     |--------------------------------------------------------------------------
     |
-    | You may wish for all e-mails sent by your application to be sent from
-    | the same address. Here, you may specify a name and address that is
-    | used globally for all e-mails that are sent by your application.
+    | Under SES this address is not merely cosmetic: its domain must be a
+    | verified identity in the sending region or the API rejects the message.
     |
     */
 
     'from' => ['address' => env('APP_NOREPLY_EMAIL', 'postmaster@localhost'), 'name' => env('APP_NAME', 'Events Admin')],
-
-    /*
-    |--------------------------------------------------------------------------
-    | E-Mail Encryption Protocol
-    |--------------------------------------------------------------------------
-    |
-    | Here you may specify the encryption protocol that should be used when
-    | the application send e-mail messages. A sensible default using the
-    | transport layer security protocol should provide great security.
-    |
-    */
-
-    'encryption' => 'tls',
-
-    /*
-    |--------------------------------------------------------------------------
-    | SMTP Server Username
-    |--------------------------------------------------------------------------
-    |
-    | If your SMTP server requires a username for authentication, you should
-    | set it here. This will get used to authenticate with your server on
-    | connection. You may also set the "password" value below this one.
-    |
-    */
-
-    'username' => env('MAIL_USERNAME', 'postmaster@localhost'),
-
-    /*
-    |--------------------------------------------------------------------------
-    | SMTP Server Password
-    |--------------------------------------------------------------------------
-    |
-    | Here you may set the password required by your SMTP server to send out
-    | messages from your application. This will be given to the server on
-    | connection so that the application will be able to send messages.
-    |
-    */
-
-    'password' => env('MAIL_PASSWORD', 'secret'),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Sendmail System Path
-    |--------------------------------------------------------------------------
-    |
-    | When using the "sendmail" driver to send e-mails, we will need to know
-    | the path to where Sendmail lives on this server. A default path has
-    | been provided here, which will work well on most of your systems.
-    |
-    */
-
-    'sendmail' => '/usr/sbin/sendmail -bs',
-
-    /*
-    |--------------------------------------------------------------------------
-    | Mail "Pretend"
-    |--------------------------------------------------------------------------
-    |
-    | When this option is enabled, e-mail will not actually be sent over the
-    | web and will instead be written to your application's logs files so
-    | you may inspect the message. This is great for local development.
-    |
-    */
-
-    'pretend' => false,
 
     /*
      * Markdown Config

--- a/config/mail.php
+++ b/config/mail.php
@@ -57,6 +57,12 @@ return [
             'scheme' => env('MAIL_SCHEME'),
         ],
 
+        // Credentials read from config/services.php "mailgun" (MAIL_DOMAIN /
+        // MAIL_SECRET).
+        'mailgun' => [
+            'transport' => 'mailgun',
+        ],
+
         'log' => [
             'transport' => 'log',
             'channel' => env('MAIL_LOG_CHANNEL'),

--- a/config/services.php
+++ b/config/services.php
@@ -20,9 +20,20 @@ return [
 	],
 
 	'ses' => [
-		'key' => '',
-		'secret' => '',
-		'region' => 'us-east-1',
+		'key' => env('AWS_ACCESS_KEY_ID'),
+		'secret' => env('AWS_SECRET_ACCESS_KEY'),
+
+		// Deliberately no fallback region. The verified identity lives in
+		// exactly one region; defaulting to a different one sends there and
+		// fails with "Email address is not verified", which reads as a
+		// verification problem rather than a region problem. Unset fails loudly.
+		'region' => env('AWS_DEFAULT_REGION'),
+
+		// Merged into the SES v2 SendEmail call. array_filter drops the key
+		// when the variable is unset — SES rejects a null ConfigurationSetName.
+		'options' => array_filter([
+			'ConfigurationSetName' => env('SES_CONFIGURATION_SET'),
+		]),
 	],
 
 	'stripe' => [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,14 +11,17 @@
     <env name="SESSION_DRIVER" value="array"/>
     <env name="QUEUE_DRIVER" value="sync"/>
     <!--
-      config/mail.php is the legacy flat format, so the transport is chosen by
-      MAIL_DRIVER, not MAIL_MAILER. Without this the suite inherits the real
-      mailgun credentials from .env and every test that exercises a failure
-      path emails the admin for real. Tests/TestCase.php enforces this again at
-      runtime so it cannot be lost by running phpunit with another config.
+      Without this the suite inherits the real mail credentials from .env and
+      every test that exercises a failure path emails the admin for real.
+      Tests/TestCase.php enforces this again at runtime so it cannot be lost by
+      running phpunit with another config.
+
+      MAIL_MAILER is what config/mail.php reads now that it is no longer the
+      pre-6.x flat format. MAIL_DRIVER is kept because it is still read as the
+      fallback, so the guard holds either way.
     -->
-    <env name="MAIL_DRIVER" value="array"/>
     <env name="MAIL_MAILER" value="array"/>
+    <env name="MAIL_DRIVER" value="array"/>
   </php>
   <source>
     <include>

--- a/tests/Feature/Mail/MailableBuildTest.php
+++ b/tests/Feature/Mail/MailableBuildTest.php
@@ -66,12 +66,6 @@ class MailableBuildTest extends TestCase
         $this->assertSame(self::SITE, $mailable->from[0]['name'], 'From name should be the site name');
     }
 
-    private function assertBccsAdmin(Mailable $mailable): void
-    {
-        $this->assertNotEmpty($mailable->bcc, 'Mailable should bcc the admin address');
-        $this->assertSame(self::ADMIN, $mailable->bcc[0]['address'], 'Mailable should bcc the admin address');
-    }
-
     public function test_user_activation_builds(): void
     {
         $user = User::factory()->create();
@@ -114,7 +108,6 @@ class MailableBuildTest extends TestCase
 
         $this->assertBuilt($mailable, 'emails.user-data-export-ready');
         $this->assertSame(self::SITE . ': Your Data Export is Ready', $mailable->subject);
-        $this->assertBccsAdmin($mailable);
     }
 
     public function test_user_update_builds(): void

--- a/tests/Feature/Mail/MailablesTest.php
+++ b/tests/Feature/Mail/MailablesTest.php
@@ -29,7 +29,7 @@ class MailablesTest extends TestCase
 
         $this->assertStringContainsString('Admin Mailer Test', $built->subject);
         $this->assertSame('noreply@test.app', $built->from[0]['address']);
-        $this->assertSame('admin@test.app', $built->bcc[0]['address']);
+        $this->assertEmpty($built->bcc);
     }
 
     public function test_daily_reminder_builds(): void
@@ -69,7 +69,7 @@ class MailablesTest extends TestCase
         $built = $mail->build();
 
         $this->assertStringContainsString('Weekly Update', $built->subject);
-        $this->assertSame('admin@test.app', $built->bcc[0]['address']);
+        $this->assertEmpty($built->bcc);
     }
 
     public function test_entity_reminder_builds_with_entity_name_in_subject(): void

--- a/tests/Feature/TestsDoNotReachTheOutsideWorldTest.php
+++ b/tests/Feature/TestsDoNotReachTheOutsideWorldTest.php
@@ -32,9 +32,7 @@ class TestsDoNotReachTheOutsideWorldTest extends TestCase
 {
     public function test_the_configured_mail_transport_cannot_deliver(): void
     {
-        // config/mail.php is the legacy flat format; MailManager reads the
-        // transport from mail.driver rather than mail.mailers.*.
-        $this->assertSame('array', config('mail.driver'));
+        $this->assertSame('array', config('mail.default'));
 
         $this->assertInstanceOf(
             ArrayTransport::class,
@@ -67,8 +65,21 @@ class TestsDoNotReachTheOutsideWorldTest extends TestCase
 
     public function test_the_real_mail_credentials_are_not_in_play(): void
     {
-        $this->assertNotSame('mailgun', config('mail.driver'));
-        $this->assertNotSame('smtp', config('mail.driver'));
+        // Asserted positively. The old form checked mail.driver was neither
+        // 'mailgun' nor 'smtp'; once config/mail.php was modernised that key
+        // stopped existing, so both assertions would have passed against null
+        // and quietly stopped guarding anything.
+        $this->assertSame('array', config('mail.default'));
+
+        // A truthy mail.driver sends MailManager down its pre-6.x BC branch,
+        // where mail.mailers is ignored and the flat config is handed to the
+        // transport factory instead — which is how the suite reached the live
+        // mailgun credentials in the first place. Nothing should put that key
+        // back, in config or at runtime.
+        $this->assertNull(
+            config('mail.driver'),
+            'mail.driver is set, which disables mail.mailers and re-enables the legacy transport resolution.'
+        );
     }
 
     public function test_an_unfaked_request_throws_instead_of_leaving_the_machine(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -32,11 +32,12 @@ abstract class TestCase extends BaseTestCase
         // built and rendered, so a broken Blade template in a Mailable still
         // fails the test that exercises it. It just never reaches a transport.
         //
-        // config/mail.php is the pre-6.x flat format, so MailManager resolves
-        // the transport from mail.driver (see its createSymfonyTransport BC
-        // branch). mail.default is set as well in case that file is ever
-        // modernised.
-        config(['mail.driver' => 'array', 'mail.default' => 'array']);
+        // config/mail.php is the modern format, so the transport comes from
+        // mail.default and mail.mailers.*. Do not set mail.driver here: a
+        // truthy value at that key sends MailManager down its pre-6.x BC
+        // branch, where the whole mail config is passed to the transport
+        // factory and mail.mailers is ignored.
+        config(['mail.default' => 'array']);
 
         // No test may reach the network either. Without this the Discord suite
         // sent live requests to discord.com using factory-generated webhook


### PR DESCRIPTION
## Summary
- Rewrite `config/mail.php` from the pre-Laravel-6 flat format (top-level `driver` key) to the modern `mail.mailers` format, so `MAIL_MAILER` selects between `ses` (v2 API), `smtp`, `mailgun`, `log`, and `array` transports. The old flat format put `MailManager` on its legacy branch, which handed the whole config array to the transport factory and blocked the SES transport entirely.
- Wire SES credentials in `config/services.php` (`AWS_*` env vars, deliberately **no** fallback region — a missing `AWS_DEFAULT_REGION` fails loudly instead of silently sending to us-east-1), with optional `SES_CONFIGURATION_SET` support.
- Keep a `mailgun` API mailer entry so the Mailgun rollback path still works (`symfony/mailgun-mailer` is still installed and `services.mailgun` still holds the credentials).
- Pin the test suite to the `array` transport in `phpunit.xml`/`TestCase` and add `TestsDoNotReachTheOutsideWorldTest`, so tests can never deliver real mail or make stray HTTP requests again.
- Stop blanket-BCCing the admin address on ten user-facing mailables (weekly/daily updates, following notifications, user lifecycle mail, data-export mail), roughly halving outbound volume. `LoginFailure` deliberately keeps its BCC — it is the admin's only signal of repeated login failures — and `AdminMailer`'s BCC was a duplicate of its own To recipient.

## Test plan
- [x] `tests/Feature/Mail/MailableBuildTest.php` + `tests/Feature/Mail/MailablesTest.php` (22 tests, 135 assertions) green
- [x] PHPStan clean on `app/Mail`
- [x] Real end-to-end send through SES verified from dev (2026-08-18)
- [ ] After deploy: set `MAIL_MAILER`, `AWS_*` env vars and run `config:clear`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRwjuDiX1jEdXTKx9zRqHb