### PR TITLE
Fix: Instagram carousel creation fails ("No data returned") [EVENTREPO-X9]

### DIFF
--- a/app/Services/Integrations/InstagramEventPoster.php
+++ b/app/Services/Integrations/InstagramEventPoster.php
@@ -21,6 +21,14 @@ use Storage;
  */
 class InstagramEventPoster
 {
+    /**
+     * Instagram permits at most 10 items in a single carousel. Handing more
+     * than that to the createCarousel endpoint makes the whole call fail with
+     * an opaque "No data returned" error (EVENTREPO-X9), so the container list
+     * is trimmed to this ceiling before publishing.
+     */
+    private const MAX_CAROUSEL_ITEMS = 10;
+
     public function __construct(private Instagram $instagram)
     {
     }
@@ -107,6 +115,11 @@ class InstagramEventPoster
 
         // Additional photos directly attached to the event.
         foreach ($event->getOtherPhotos() as $otherPhoto) {
+            if (count($igContainerIds) >= self::MAX_CAROUSEL_ITEMS) {
+                Log::info('Carousel item limit (' . self::MAX_CAROUSEL_ITEMS . ') reached for event ' . $event->id . '; skipping remaining photos.');
+                break;
+            }
+
             $otherUrl = Storage::disk('external')->url($otherPhoto->getStoragePath());
             if (!$otherUrl) {
                 continue;
@@ -122,6 +135,11 @@ class InstagramEventPoster
         // Primary photos of related entities — best effort, skip on failure.
         foreach ($event->entities as $entity) {
             foreach ($entity->photos as $photo) {
+                if (count($igContainerIds) >= self::MAX_CAROUSEL_ITEMS) {
+                    Log::info('Carousel item limit (' . self::MAX_CAROUSEL_ITEMS . ') reached for event ' . $event->id . '; skipping remaining entity photos.');
+                    break 2;
+                }
+
                 if (!$photo->is_primary) {
                     continue;
                 }

--- a/tests/Feature/QueuedInstagramPostTest.php
+++ b/tests/Feature/QueuedInstagramPostTest.php
@@ -313,6 +313,48 @@ class QueuedInstagramPostTest extends TestCase
         }
     }
 
+    public function test_carousel_is_trimmed_to_the_instagram_ten_item_limit(): void
+    {
+        $user = User::factory()->create(['user_status_id' => 1]);
+        $event = $this->eventWithPhoto($user);
+
+        // Attach 15 additional (non-primary) photos so the carousel would
+        // otherwise contain 16 items — well over Instagram's limit of 10,
+        // which makes createCarousel fail wholesale (EVENTREPO-X9).
+        for ($i = 0; $i < 15; $i++) {
+            $photo = Photo::factory()->create([
+                'is_primary' => 0,
+                'path' => "extra_{$i}.jpg",
+                'thumbnail' => "extra_{$i}_thumb.jpg",
+                'created_by' => $user->id,
+                'updated_by' => $user->id,
+            ]);
+            $event->photos()->attach($photo->id);
+        }
+
+        Storage::shouldReceive('disk')->with('external')->andReturnSelf()->byDefault();
+        Storage::shouldReceive('url')->andReturn('http://example.com/test.jpg')->byDefault();
+
+        $instagram = Mockery::mock(Instagram::class);
+        $instagram->shouldReceive('getIgUserId')->andReturn(123);
+        $instagram->shouldReceive('getPageAccessToken')->andReturn('token');
+        // No more than 10 containers should ever be uploaded or published.
+        $instagram->shouldReceive('uploadCarouselPhoto')->times(10)->andReturn(111);
+        $instagram->shouldReceive('checkBatchStatus')
+            ->with(Mockery::on(fn ($ids) => is_array($ids) && count($ids) === 10))
+            ->andReturn(true);
+        $instagram->shouldReceive('createCarousel')
+            ->with(Mockery::on(fn ($ids) => is_array($ids) && count($ids) === 10), Mockery::any())
+            ->andReturn(999);
+        $instagram->shouldReceive('checkStatus')->andReturn(true);
+        $instagram->shouldReceive('publishMedia')->andReturn(555);
+
+        $poster = new InstagramEventPoster($instagram);
+        $result = $poster->postCarousel($event, $user->id);
+
+        $this->assertSame(555, $result);
+    }
+
     public function test_job_status_show_endpoint_returns_json_for_owner(): void
     {
         $user = User::factory()->create(['user_status_id' => 1]);


### PR DESCRIPTION
## Sentry issue

[EVENTREPO-X9](https://sentry.io/organizations/geoff-maddock/issues/7640879802/) — `RuntimeException: There was an error posting to Instagram during carousel creation. No data returned. There was an error posting create carousel to Instagram. Please try again.`

- 16 occurrences, still firing (last seen 2026-08-27).
- No user feedback attached.
- Culprit: `App\Services\Integrations\InstagramEventPoster::postCarousel` → `Instagram::createCarousel` (via the queued `PostEventToInstagram` job).

## Error summary

`createCarousel()` posts a `media_type=CAROUSEL` container to the Graph API and throws `No data returned...` whenever the response has no `data.id`. That failure surfaces to Sentry as the opaque "Please try again." message with no underlying Graph error captured.

## Root cause

`postCarousel()` builds the carousel container list from three unbounded sources:

1. the event's primary image,
2. **every** additional (non-primary) photo attached to the event (`getOtherPhotos()`),
3. **every** related entity's primary photo.

The list is never capped. Instagram's Graph API accepts **at most 10 children** in a carousel; handing it more makes `createCarousel` fail wholesale — which matches the "No data returned" error exactly. The codebase already respects this 10-item ceiling elsewhere (the weekend-preview poster explicitly takes the top 10 events), but the per-event carousel path did not.

## What changed

`app/Services/Integrations/InstagramEventPoster.php`
- Added a `MAX_CAROUSEL_ITEMS = 10` constant.
- Stop appending containers once the list reaches 10 (event primary image first, then event photos, then entity photos), logging an info line when photos are skipped. This also avoids uploading containers that would be discarded.

`tests/Feature/QueuedInstagramPostTest.php`
- Added `test_carousel_is_trimmed_to_the_instagram_ten_item_limit`: an event with 16 photos uploads exactly 10 containers and passes an array of exactly 10 to `checkBatchStatus`/`createCarousel`.

## Validation notes

The fix is a minimal, targeted guard. It could not be exercised locally in this environment — dependencies were unavailable (`composer install` was OOM-killed) and no MySQL was reachable, and the feature suite uses `RefreshDatabase` + seeding. `php -l` passes on both files; CI runs the full `composer tests` + PHPStan pipeline.

## Confidence / caveats

The exceeded-item-limit is the clear code-level cause and this fix is correct regardless (a carousel must never exceed 10). Because the raw Graph API response is not captured in the exception, a subset of these occurrences could stem from non-code causes (expired page token, rate limiting, media not ready); those would need log inspection and are outside this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZXEfZG7u11e545gL6G54Y)_