### PR TITLE
Add an admin-only Today's Preview action for Instagram Stories

### DIFF
--- a/app/Http/Controllers/Api/EventInstagramController.php
+++ b/app/Http/Controllers/Api/EventInstagramController.php
@@ -7,6 +7,7 @@ use App\Filters\EventFilters;
 use App\Http\Controllers\Controller;
 use App\Jobs\Instagram\PostEventStoryToInstagram;
 use App\Jobs\Instagram\PostEventToInstagram;
+use App\Jobs\Instagram\PostTodaysPreviewToInstagram;
 use App\Jobs\Instagram\PostWeekendPreviewToInstagram;
 use App\Models\Event;
 use App\Models\EventShare;
@@ -544,6 +545,27 @@ class EventInstagramController extends Controller
         PostWeekendPreviewToInstagram::dispatch($this->user->id);
 
         return $this->instagramActionResponse(true, 'Queued', 'The weekend preview is being posted to Instagram in the background. You will be notified when it finishes.');
+    }
+
+    /**
+     * Queue today's preview to be posted to Instagram Stories. Event selection
+     * happens inside the queued job. Admin only.
+     */
+    public function postTodaysPreviewToInstagram(Instagram $instagram): RedirectResponse|JsonResponse
+    {
+        // Admin-only guard
+        if (!$this->user || !$this->user->hasGroup('super_admin')) {
+            return $this->instagramActionResponse(false, 'Error', "You must be an admin to post today's preview to Instagram.");
+        }
+
+        // Fail fast when Instagram is not linked; the job re-checks at run time.
+        if ($error = $this->instagramCredentialError($instagram)) {
+            return $this->instagramActionResponse(false, 'Error', $error);
+        }
+
+        PostTodaysPreviewToInstagram::dispatch($this->user->id);
+
+        return $this->instagramActionResponse(true, 'Queued', "Today's preview is being posted to Instagram in the background. You will be notified when it finishes.");
     }
 
 

--- a/app/Jobs/Instagram/PostTodaysPreviewToInstagram.php
+++ b/app/Jobs/Instagram/PostTodaysPreviewToInstagram.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Jobs\Instagram;
+
+use App\Jobs\Concerns\TracksJobStatus;
+use App\Services\Integrations\InstagramEventPoster;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Throwable;
+
+/**
+ * Queued job that posts today's preview (today's top events, each as an
+ * individual story) to Instagram. Event selection happens at run time inside
+ * InstagramEventPoster::postTodaysPreview(), so there is no subject model.
+ */
+class PostTodaysPreviewToInstagram implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use TracksJobStatus;
+
+    // Up to 10 stories, each needing an upload, a status poll, and a publish.
+    public int $timeout = 1200;
+
+    // No retries: a retry after a partial success would double-post the
+    // stories that already published.
+    public int $tries = 1;
+
+    public function __construct(
+        public ?int $userId
+    ) {
+        $this->initJobStatus('instagram_todays_preview', "Instagram today's preview", null, $userId);
+    }
+
+    public function handle(InstagramEventPoster $poster): void
+    {
+        $this->markRunning();
+
+        $result = $poster->postTodaysPreview($this->userId);
+
+        $message = "Today's preview posted: ".$result['posted'].' stor'
+            .($result['posted'] === 1 ? 'y' : 'ies').' published'
+            .($result['skipped'] > 0 ? ', '.$result['skipped'].' skipped (no photo).' : '.');
+
+        $this->markSucceeded($message, $result);
+    }
+
+    public function failed(Throwable $exception): void
+    {
+        $this->markFailed($exception->getMessage());
+    }
+}

--- a/app/Services/Integrations/InstagramEventPoster.php
+++ b/app/Services/Integrations/InstagramEventPoster.php
@@ -21,6 +21,9 @@ use Storage;
  */
 class InstagramEventPoster
 {
+    // Instagram caps how many stories are worth pushing in one run.
+    private const PREVIEW_STORY_LIMIT = 10;
+
     public function __construct(private Instagram $instagram)
     {
     }
@@ -318,6 +321,71 @@ class InstagramEventPoster
                 $posted++;
             } catch (Exception $e) {
                 Log::info('Weekend preview: skipping event '.$event->id.': '.$e->getMessage());
+                $skipped++;
+            }
+        }
+
+        if ($posted === 0) {
+            throw new RuntimeException('No stories could be posted. Ensure the selected events have photos.');
+        }
+
+        return ['posted' => $posted, 'skipped' => $skipped, 'total' => $selectedEvents->count()];
+    }
+
+    /**
+     * Post a preview of today's events to Instagram Stories: the events
+     * starting today, each as an individual story.
+     *
+     * Selection rules:
+     *  - Rank today's events by attending-response count and take the top 10.
+     *  - Re-sort that selection by start time, so the stories publish in the
+     *    order the events actually happen.
+     *
+     * The window covers the whole day (00:00 through 23:59), so events that
+     * have already started are still included.
+     *
+     * Per-event failures (no photo, upload/status/publish errors) are logged
+     * and skipped; the loop continues. Throws only for terminal cases.
+     *
+     * @return array{posted: int, skipped: int, total: int}
+     */
+    public function postTodaysPreview(?int $userId): array
+    {
+        $this->assertCredentials();
+
+        $dayStart = Carbon::today()->startOfDay();
+        $dayEnd = Carbon::today()->endOfDay();
+
+        // Fetch all of today's events ranked by number of attending responses,
+        // excluding cancelled and non-public events.
+        $todaysEvents = Event::where('start_at', '>=', $dayStart)
+            ->where('start_at', '<=', $dayEnd)
+            ->where('visibility_id', '=', Visibility::VISIBILITY_PUBLIC)
+            ->whereNull('cancelled_at')
+            ->withCount(['eventResponses as response_count'])
+            ->orderBy('response_count', 'desc')
+            ->orderBy('start_at', 'asc')
+            ->get();
+
+        if ($todaysEvents->isEmpty()) {
+            throw new RuntimeException('No events found for today.');
+        }
+
+        // Response count decides which events make the cut; start time decides
+        // the order they go out in.
+        $selectedEvents = $todaysEvents->take(self::PREVIEW_STORY_LIMIT)
+            ->sortBy('start_at')
+            ->values();
+
+        $posted = 0;
+        $skipped = 0;
+
+        foreach ($selectedEvents as $event) {
+            try {
+                $this->postStory($event, $userId);
+                $posted++;
+            } catch (Exception $e) {
+                Log::info("Today's preview: skipping event ".$event->id.': '.$e->getMessage());
                 $skipped++;
             }
         }

--- a/resources/views/events/index-tw.blade.php
+++ b/resources/views/events/index-tw.blade.php
@@ -79,9 +79,13 @@ Pittsburgh Events Calendar — Concerts, Shows & More
 			</a>
 			@if ($signedIn && $user && $user->hasGroup('super_admin'))
 			<div class="border-t border-border my-1"></div>
-			<a href="{!! URL::route('events.instagramWeekendPreview') !!}" data-replace-history class="flex items-center px-4 py-2 text-sm text-muted-foreground hover:bg-accent rounded-b-lg transition-colors">
+			<a href="{!! URL::route('events.instagramWeekendPreview') !!}" data-replace-history class="flex items-center px-4 py-2 text-sm text-muted-foreground hover:bg-accent transition-colors">
 				<i class="bi bi-instagram mr-2"></i>
 				Weekend Preview
+			</a>
+			<a href="{!! URL::route('events.instagramTodaysPreview') !!}" data-replace-history class="flex items-center px-4 py-2 text-sm text-muted-foreground hover:bg-accent rounded-b-lg transition-colors">
+				<i class="bi bi-instagram mr-2"></i>
+				Today's Preview
 			</a>
 			@endif
 		</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -331,6 +331,7 @@ Route::get('events/{id}/instagram-story-post', [\App\Http\Controllers\Api\EventI
 Route::get('events/{id}/instagram-post-single', [\App\Http\Controllers\Api\EventInstagramController::class, 'postToInstagram'])->name('events.instagramPostSingle');
 Route::get('events/instagram-post-week', [\App\Http\Controllers\Api\EventInstagramController::class, 'postWeekToInstagram'])->name('events.instagramPostWeek');
 Route::get('events/instagram-weekend-preview', [\App\Http\Controllers\Api\EventInstagramController::class, 'postWeekendPreviewToInstagram'])->name('events.instagramWeekendPreview');
+Route::get('events/instagram-todays-preview', [\App\Http\Controllers\Api\EventInstagramController::class, 'postTodaysPreviewToInstagram'])->name('events.instagramTodaysPreview');
 
 // POST to Discord (issue #2058). POST, not GET — this leaves the server.
 Route::post('events/{id}/discord-post', [\App\Http\Controllers\EventDiscordController::class, 'store'])

--- a/tests/Feature/QueuedTodaysPreviewTest.php
+++ b/tests/Feature/QueuedTodaysPreviewTest.php
@@ -1,0 +1,392 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\Instagram\PostTodaysPreviewToInstagram;
+use App\Models\Event;
+use App\Models\EventResponse;
+use App\Models\EventShare;
+use App\Models\Group;
+use App\Models\JobStatus;
+use App\Models\Photo;
+use App\Models\ResponseType;
+use App\Models\User;
+use App\Models\Visibility;
+use App\Notifications\JobCompleted;
+use App\Services\Integrations\Instagram;
+use App\Services\Integrations\InstagramEventPoster;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use Mockery;
+use RuntimeException;
+use Tests\TestCase;
+
+class QueuedTodaysPreviewTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected bool $seed = true;
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function todaysEvent(User $user, bool $withPhoto = true, int $hour = 20): Event
+    {
+        $event = Event::factory()->create([
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'created_by' => $user->id,
+            'start_at' => Carbon::today()->addHours($hour),
+            'cancelled_at' => null,
+        ]);
+
+        if ($withPhoto) {
+            $photo = Photo::factory()->create([
+                'is_primary' => 1,
+                'path' => 'test.jpg',
+                'thumbnail' => 'test_thumb.jpg',
+                'created_by' => $user->id,
+                'updated_by' => $user->id,
+            ]);
+            $event->photos()->attach($photo->id);
+        }
+
+        return $event;
+    }
+
+    /**
+     * Give an event a known attending-response count so the top-10 ranking is
+     * deterministic. EventResponse has no factory, and (event_id, user_id) must
+     * stay distinct, so each response gets its own user.
+     */
+    private function withResponses(Event $event, int $count): Event
+    {
+        foreach (range(1, $count) as $ignored) {
+            EventResponse::create([
+                'event_id' => $event->id,
+                'user_id' => User::factory()->create(['user_status_id' => 1])->id,
+                'response_type_id' => ResponseType::ATTENDING,
+            ]);
+        }
+
+        return $event;
+    }
+
+    private function mockStoryPostingInstagram(): Instagram|Mockery\MockInterface
+    {
+        Storage::shouldReceive('disk')->with('external')->andReturnSelf()->byDefault();
+        Storage::shouldReceive('url')->andReturn('http://example.com/test.jpg')->byDefault();
+
+        $instagram = Mockery::mock(Instagram::class);
+        $instagram->shouldReceive('getIgUserId')->andReturn(123)->byDefault();
+        $instagram->shouldReceive('getPageAccessToken')->andReturn('token')->byDefault();
+        $instagram->shouldReceive('uploadStoryPhoto')->andReturn(111)->byDefault();
+        $instagram->shouldReceive('checkStatus')->andReturn(true)->byDefault();
+        $instagram->shouldReceive('publishStoryMedia')->andReturn(555)->byDefault();
+
+        return $instagram;
+    }
+
+    public function test_service_throws_when_no_events_are_scheduled_today(): void
+    {
+        $poster = new InstagramEventPoster($this->mockStoryPostingInstagram());
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No events found for today.');
+
+        $poster->postTodaysPreview(null);
+    }
+
+    public function test_service_posts_stories_and_skips_events_without_photos(): void
+    {
+        $user = User::factory()->create(['user_status_id' => 1]);
+        $withPhoto = $this->todaysEvent($user, true, 20);
+        $this->todaysEvent($user, false, 22); // no photo -> skipped
+
+        $poster = new InstagramEventPoster($this->mockStoryPostingInstagram());
+
+        $result = $poster->postTodaysPreview($user->id);
+
+        $this->assertSame(['posted' => 1, 'skipped' => 1, 'total' => 2], $result);
+        $this->assertDatabaseHas('event_shares', [
+            'event_id' => $withPhoto->id,
+            'platform' => 'instagram',
+            'platform_id' => '555',
+        ]);
+    }
+
+    public function test_service_throws_when_zero_stories_post(): void
+    {
+        $user = User::factory()->create(['user_status_id' => 1]);
+        $this->todaysEvent($user, false, 20); // only event has no photo
+
+        $poster = new InstagramEventPoster($this->mockStoryPostingInstagram());
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No stories could be posted. Ensure the selected events have photos.');
+
+        $poster->postTodaysPreview($user->id);
+    }
+
+    public function test_service_ignores_events_outside_today(): void
+    {
+        $user = User::factory()->create(['user_status_id' => 1]);
+
+        $today = $this->todaysEvent($user, true, 20);
+        $this->todaysEvent($user, true, 48);  // tomorrow
+        $this->todaysEvent($user, true, -12); // yesterday
+
+        $poster = new InstagramEventPoster($this->mockStoryPostingInstagram());
+
+        $result = $poster->postTodaysPreview($user->id);
+
+        $this->assertSame(1, $result['total']);
+        $this->assertDatabaseHas('event_shares', ['event_id' => $today->id]);
+    }
+
+    public function test_service_excludes_cancelled_and_non_public_events(): void
+    {
+        $user = User::factory()->create(['user_status_id' => 1]);
+
+        $visible = $this->todaysEvent($user, true, 20);
+        $this->todaysEvent($user, true, 21)->update(['cancelled_at' => Carbon::now()]);
+        $this->todaysEvent($user, true, 22)->update(['visibility_id' => Visibility::VISIBILITY_PRIVATE]);
+
+        $poster = new InstagramEventPoster($this->mockStoryPostingInstagram());
+
+        $result = $poster->postTodaysPreview($user->id);
+
+        $this->assertSame(1, $result['total']);
+        $this->assertDatabaseHas('event_shares', ['event_id' => $visible->id]);
+    }
+
+    public function test_service_caps_the_run_at_ten_most_popular_events(): void
+    {
+        $user = User::factory()->create(['user_status_id' => 1]);
+
+        // 12 events, none with responses, so the ranking tie-breaks on start
+        // time and the two latest fall outside the cap.
+        $dropped = [];
+        foreach (range(1, 12) as $i) {
+            $event = $this->todaysEvent($user, true, 8 + $i);
+            if ($i > 10) {
+                $dropped[] = $event->id;
+            }
+        }
+
+        $poster = new InstagramEventPoster($this->mockStoryPostingInstagram());
+
+        $result = $poster->postTodaysPreview($user->id);
+
+        $this->assertSame(['posted' => 10, 'skipped' => 0, 'total' => 10], $result);
+        foreach ($dropped as $id) {
+            $this->assertDatabaseMissing('event_shares', ['event_id' => $id]);
+        }
+    }
+
+    public function test_service_posts_the_selection_in_chronological_order(): void
+    {
+        $user = User::factory()->create(['user_status_id' => 1]);
+
+        // Popularity and start time deliberately disagree: the most-responded
+        // event starts last, so ranking order != posting order.
+        $late = $this->withResponses($this->todaysEvent($user, true, 22), 10);
+        $middle = $this->withResponses($this->todaysEvent($user, true, 20), 5);
+        $early = $this->withResponses($this->todaysEvent($user, true, 18), 1);
+
+        $poster = new InstagramEventPoster($this->mockStoryPostingInstagram());
+
+        $poster->postTodaysPreview($user->id);
+
+        $postedOrder = EventShare::orderBy('id')->pluck('event_id')->all();
+
+        $this->assertSame([$early->id, $middle->id, $late->id], $postedOrder);
+    }
+
+    public function test_dispatching_the_job_creates_a_queued_job_status(): void
+    {
+        $user = User::factory()->create(['user_status_id' => 1]);
+
+        $job = new PostTodaysPreviewToInstagram($user->id);
+
+        $this->assertNotNull($job->jobStatusId);
+        $this->assertDatabaseHas('job_statuses', [
+            'id' => $job->jobStatusId,
+            'user_id' => $user->id,
+            'type' => 'instagram_todays_preview',
+            'status' => JobStatus::STATUS_QUEUED,
+        ]);
+    }
+
+    public function test_successful_job_marks_status_succeeded_and_notifies_user(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create(['user_status_id' => 1]);
+
+        $poster = Mockery::mock(InstagramEventPoster::class);
+        $poster->shouldReceive('postTodaysPreview')->once()->with($user->id)
+            ->andReturn(['posted' => 8, 'skipped' => 2, 'total' => 10]);
+
+        $job = new PostTodaysPreviewToInstagram($user->id);
+        $job->handle($poster);
+
+        $this->assertDatabaseHas('job_statuses', [
+            'id' => $job->jobStatusId,
+            'status' => JobStatus::STATUS_SUCCEEDED,
+            'message' => "Today's preview posted: 8 stories published, 2 skipped (no photo).",
+        ]);
+        Notification::assertSentTo($user, JobCompleted::class);
+    }
+
+    public function test_single_story_success_message_is_singular_without_skips(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create(['user_status_id' => 1]);
+
+        $poster = Mockery::mock(InstagramEventPoster::class);
+        $poster->shouldReceive('postTodaysPreview')->once()
+            ->andReturn(['posted' => 1, 'skipped' => 0, 'total' => 1]);
+
+        $job = new PostTodaysPreviewToInstagram($user->id);
+        $job->handle($poster);
+
+        $this->assertDatabaseHas('job_statuses', [
+            'id' => $job->jobStatusId,
+            'message' => "Today's preview posted: 1 story published.",
+        ]);
+    }
+
+    public function test_failed_job_marks_status_failed_and_notifies_user(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create(['user_status_id' => 1]);
+
+        $job = new PostTodaysPreviewToInstagram($user->id);
+        $job->failed(new RuntimeException('No events found for today.'));
+
+        $this->assertDatabaseHas('job_statuses', [
+            'id' => $job->jobStatusId,
+            'status' => JobStatus::STATUS_FAILED,
+            'message' => 'No events found for today.',
+        ]);
+        Notification::assertSentTo($user, JobCompleted::class);
+    }
+
+    private function superAdmin(): User
+    {
+        $group = Group::firstOrCreate(['name' => 'super_admin']);
+        $admin = User::factory()->create(['user_status_id' => 1]);
+        $admin->groups()->attach($group->id);
+
+        return $admin;
+    }
+
+    private function mockInstagramCredentials(): void
+    {
+        $instagram = Mockery::mock(Instagram::class);
+        $instagram->shouldReceive('getIgUserId')->andReturn(123)->byDefault();
+        $instagram->shouldReceive('getPageAccessToken')->andReturn('token')->byDefault();
+        $this->app->instance(Instagram::class, $instagram);
+    }
+
+    public function test_route_queues_the_job_for_super_admins(): void
+    {
+        Queue::fake();
+        $this->mockInstagramCredentials();
+
+        $admin = $this->superAdmin();
+
+        $response = $this->actingAs($admin)->get('/events/instagram-todays-preview');
+
+        $response->assertRedirect();
+        Queue::assertPushed(PostTodaysPreviewToInstagram::class, function ($job) use ($admin) {
+            return $job->userId === $admin->id;
+        });
+    }
+
+    public function test_route_does_not_queue_for_non_admins(): void
+    {
+        Queue::fake();
+        $this->mockInstagramCredentials();
+
+        $user = User::factory()->create(['user_status_id' => 1]);
+
+        $response = $this->actingAs($user)->get('/events/instagram-todays-preview');
+
+        $response->assertRedirect();
+        Queue::assertNothingPushed();
+    }
+
+    public function test_route_does_not_queue_when_instagram_is_not_linked(): void
+    {
+        Queue::fake();
+
+        $instagram = Mockery::mock(Instagram::class);
+        $instagram->shouldReceive('getIgUserId')->andReturn(0);
+        $this->app->instance(Instagram::class, $instagram);
+
+        $admin = $this->superAdmin();
+
+        $response = $this->actingAs($admin)->get('/events/instagram-todays-preview');
+
+        $response->assertRedirect();
+        Queue::assertNothingPushed();
+    }
+
+    public function test_ajax_route_queues_the_job_and_returns_json_toast(): void
+    {
+        Queue::fake();
+        $this->mockInstagramCredentials();
+
+        $admin = $this->superAdmin();
+
+        $response = $this->actingAs($admin)->getJson('/events/instagram-todays-preview');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'success' => true,
+                'title' => 'Queued',
+            ]);
+        Queue::assertPushed(PostTodaysPreviewToInstagram::class, function ($job) use ($admin) {
+            return $job->userId === $admin->id;
+        });
+    }
+
+    public function test_events_index_shows_the_menu_item_to_super_admins_only(): void
+    {
+        $admin = $this->superAdmin();
+        $this->actingAs($admin)->get('/events')
+            ->assertOk()
+            ->assertSee("Today's Preview", false);
+
+        $user = User::factory()->create(['user_status_id' => 1]);
+        $this->actingAs($user)->get('/events')
+            ->assertOk()
+            ->assertDontSee("Today's Preview", false);
+    }
+
+    public function test_ajax_route_returns_json_error_for_non_admins(): void
+    {
+        Queue::fake();
+        $this->mockInstagramCredentials();
+
+        $user = User::factory()->create(['user_status_id' => 1]);
+
+        $response = $this->actingAs($user)->getJson('/events/instagram-todays-preview');
+
+        $response->assertStatus(422)
+            ->assertJson([
+                'success' => false,
+                'title' => 'Error',
+            ]);
+        Queue::assertNothingPushed();
+    }
+}


### PR DESCRIPTION
## What

Adds a **Today's Preview** action to the Events page "⋯" dropdown, visible and accessible to admins only. It mirrors the existing Weekend Preview: a queued job posts today's events to Instagram Stories, one story per event.

## How it selects events

Today's public, non-cancelled events (00:00–23:59, so events already underway are included) are ranked by attending-response count and the top 10 are kept. That selection is then re-sorted by `start_at`, so the stories publish in the order the events actually happen — popularity decides *which* events make the cut, start time decides *what order* they go out in.

The weekend method's Friday/Saturday tie-break fallback has no single-day analogue, so it isn't carried over.

## Changes

| File | Change |
|---|---|
| `app/Services/Integrations/InstagramEventPoster.php` | New `postTodaysPreview()`; adds a `PREVIEW_STORY_LIMIT` constant |
| `app/Jobs/Instagram/PostTodaysPreviewToInstagram.php` | New queued job |
| `app/Http/Controllers/Api/EventInstagramController.php` | New `postTodaysPreviewToInstagram()` |
| `routes/web.php` | `GET /events/instagram-todays-preview` → `events.instagramTodaysPreview` |
| `resources/views/events/index-tw.blade.php` | Menu item inside the existing `super_admin` block |
| `tests/Feature/QueuedTodaysPreviewTest.php` | New — 17 tests |

The service method reuses `assertCredentials()` and `postStory()` unchanged, so photo lookup, upload/publish, and the `Activity` + `EventShare` share-logging all come for free. The job uses `tries = 1` for the same reason as the weekend job: a retry after a partial success would double-post the stories that already published.

`rounded-b-lg` moves from Weekend Preview to the new last menu item. No JavaScript change was needed — the existing fire-and-toast handler already binds every `a[data-replace-history]` on the page.

## Notes for review

- **Admin check is `super_admin`, not `isAdmin()`.** This matches Weekend Preview exactly, so the two Instagram items in the same dropdown behave identically. It is stricter than the app-wide `User::isAdmin()` (`admin` OR `super_admin`) — happy to widen both if you'd prefer.
- **No repost throttle.** `recentRepostError()` (the three-day guard) is applied only to the single-event and carousel actions, not the preview actions. Today's Preview inherits that, so running it twice in a day will re-post. Deliberate consistency with existing behavior, but a reasonable follow-up.
- **No CHANGELOG entry.** That file is only touched at release time (last edit was the 2026.05.01 release commit) and Weekend Preview itself was never changelogged, so adding an out-of-band `[Unreleased]` section would break the convention.
- **The cap test doesn't seed response counts.** `EventResponse` has no `HasFactory` trait, so realistic counts mean one user per response (78 users for a 12-event ranking test). Since the query tie-breaks on `start_at` when counts are equal, twelve response-less events give a fully deterministic top 10. The chronological-ordering test does create real responses, because there popularity has to genuinely disagree with start time for the assertion to mean anything.

## Verification

```
./vendor/bin/phpunit tests/Feature/QueuedTodaysPreviewTest.php tests/Feature/QueuedWeekendPreviewTest.php
OK (29 tests, 62 assertions)

./vendor/bin/phpstan analyse
[OK] No errors
```

`tests/Feature/QueuedInstagramPostTest.php` and `tests/Feature/EventsTest.php` also pass unchanged. Coverage includes the day-window bounds, cancelled/non-public exclusion, the 10-event cap, chronological posting order, job status + notification on success and failure, the route's admin and credential guards in both HTML and AJAX modes, and that the menu item renders for a `super_admin` but not for a regular user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
