### PR TITLE
Fix: Instagram carousel creation fails ("No data returned") [EVENTREPO-X9]

### DIFF
--- a/app/Services/Integrations/Instagram.php
+++ b/app/Services/Integrations/Instagram.php
@@ -78,7 +78,7 @@ class Instagram
 
         // check if data is not null
         if (!isset($response['data']['id'])) {
-            throw new \Exception('No data returned. There was an error posting to Instagram.  Please try again.');
+            throw new \Exception('There was an error posting to Instagram. '.$this->describeApiError($response));
         }
 
         return $response['data']['id'];
@@ -95,7 +95,7 @@ class Instagram
 
         // check if data is not null
         if (!isset($response['data']['id'])) {
-            throw new \Exception('No data returned. There was an error posting to Instagram.  Please try again.');
+            throw new \Exception('There was an error posting a story to Instagram. '.$this->describeApiError($response));
         }
 
         return $response['data']['id'];
@@ -109,7 +109,7 @@ class Instagram
 
         // check if data is not null
         if (!isset($response['data']['id'])) {
-            throw new \Exception('No data returned. There was an error posting carousel photo to Instagram.  Please try again.');
+            throw new \Exception('There was an error posting a carousel photo to Instagram. '.$this->describeApiError($response));
         }
 
         return $response['data']['id'];
@@ -133,7 +133,7 @@ class Instagram
 
         // check if data is not null
         if (!isset($response['data']['id'])) {
-            throw new \Exception('No data returned. There was an error posting create carousel to Instagram.  Please try again.');
+            throw new \Exception('There was an error creating the carousel on Instagram. '.$this->describeApiError($response));
         }
 
         return $response['data']['id'];


### PR DESCRIPTION
## Sentry issue

[EVENTREPO-X9](https://geoff-maddock.sentry.io/issues/7640879802/) — `RuntimeException: There was an error posting to Instagram during carousel creation. No data returned. ... Please try again.`

- **Events:** 25 · **First seen:** 2026-07-29 · **Last seen:** 2026-09-04 (still recurring)
- **User feedback:** none attached.

## Error summary

When an Instagram Graph API media create/upload call returns a response body without a media id, the service throws a fixed, generic message and discards the actual API response:

```php
if (!isset($response['data']['id'])) {
    throw new \Exception('No data returned. There was an error posting create carousel to Instagram.  Please try again.');
}
```

Because the real Graph error (rejected image, expired page token, rate limit, transient Graph error, …) is thrown away, every distinct cause collapses into one opaque Sentry issue that can't be triaged or grouped by cause.

## Root cause

A prior fix (PR #2099, now in `main`) added `MAX_CAROUSEL_ITEMS = 10` and trims the container list, which addressed the **>10-items** cause. But X9 keeps recurring (last seen 2026-09-04) from the **other** causes, which remain hidden behind the generic message. This class already has a `describeApiError()` helper — used by `checkStatus()` — that extracts `message` / `code` / `error_subcode` / `error_user_msg` from the Graph error body, but the create/upload throw-paths never used it.

## What changed

`app/Services/Integrations/Instagram.php` — the four media create/upload methods (`uploadPhoto`, `uploadStoryPhoto`, `uploadCarouselPhoto`, `createCarousel`) now append `describeApiError($response)` to the thrown exception instead of a fixed "Please try again." string. This surfaces the underlying Graph cause so Sentry groups by real cause and the failures become actionable. This mirrors the earlier EVENTREPO-VB fix that surfaced real causes at the `InstagramEventPoster` wrapper level.

This is a **diagnosability** fix: it makes the remaining failures triageable rather than claiming to eliminate an external API failure whose specific cause is currently hidden.

## Testing

The sandbox could not install Composer dependencies (`composer install` timed out) and has no provisioned MySQL DB, so the PHPUnit/PHPStan suite could not be run here. `php -l` passes; the change is purely additive, calls an existing same-class helper (`describeApiError(array): string`) already used by `checkStatus()`, and no test asserts the old message strings. Please let CI run the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019tS6b4z6s6aeEwxWSMENp2

---
_Generated by [Claude Code](https://claude.ai/code/session_019tS6b4z6s6aeEwxWSMENp2)_