### PR TITLE
Add POST /api/{events,entities,series}/{id}/photos/from-url (#2123)

### DIFF
--- a/app/Exceptions/RemoteImageException.php
+++ b/app/Exceptions/RemoteImageException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+/**
+ * A remote image could not be fetched safely. The message is intended to be
+ * shown to the API caller (it never includes internal details).
+ */
+class RemoteImageException extends RuntimeException
+{
+}

--- a/app/Http/Controllers/Api/EntitiesController.php
+++ b/app/Http/Controllers/Api/EntitiesController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Exceptions\RemoteImageException;
 use App\Http\Controllers\Controller;
 use App\Filters\EntityFilters;
 use App\Http\Requests\EntityPatchRequest;
@@ -26,6 +27,7 @@ use App\Models\User;
 use App\Notifications\EventPublished;
 use App\Services\Embeds\OembedExtractor;
 use App\Services\ImageHandler;
+use App\Services\RemoteImageFetcher;
 use App\Services\SessionStore\ListParameterSessionStore;
 use App\Services\StringHelper;
 use Carbon\Carbon;
@@ -823,38 +825,75 @@ class EntitiesController extends Controller
             'file' => 'required|mimes:jpg,jpeg,png,gif,webp',
         ]);
 
-        // only the entity owner (or an admin) may add photos — checked
-        // before any file is written to storage
-        $entity = Entity::find($id);
-        if ($entity
-            && (!$this->user
-                || ($entity->created_by !== $this->user->id && !$this->user->hasGroup('admin') && !$this->user->hasGroup('super_admin')))) {
+        if (!$entity = Entity::find($id)) {
+            return response()->json([], 404);
+        }
+
+        if ($denied = $this->denyUnlessCanAddPhoto($entity)) {
+            return $denied;
+        }
+
+        $photo = $imageHandler->makePhoto($request->file('file'));
+
+        return $this->finishAddingPhoto($entity, $photo);
+    }
+
+    /**
+     * Attach a photo to an entity from a public https URL. Identical to
+     * addPhoto() except that the server downloads the bytes (see
+     * RemoteImageFetcher for the SSRF guards).
+     */
+    public function addPhotoFromUrl(int $id, Request $request, ImageHandler $imageHandler, RemoteImageFetcher $fetcher): JsonResponse
+    {
+        $this->validate($request, [
+            'url' => 'required|url',
+        ]);
+
+        if (!$entity = Entity::find($id)) {
+            return response()->json([], 404);
+        }
+
+        if ($denied = $this->denyUnlessCanAddPhoto($entity)) {
+            return $denied;
+        }
+
+        try {
+            $photo = $fetcher->fetch($request->input('url'), fn (UploadedFile $file) => $imageHandler->makePhoto($file));
+        } catch (RemoteImageException $e) {
+            return response()->json(['message' => $e->getMessage()], 422);
+        }
+
+        return $this->finishAddingPhoto($entity, $photo);
+    }
+
+    /**
+     * Only the entity owner (or an admin) may add photos — checked before
+     * any bytes are fetched or written to storage.
+     */
+    private function denyUnlessCanAddPhoto(Entity $entity): ?JsonResponse
+    {
+        if (!$this->user
+            || ($entity->created_by !== $this->user->id && !$this->user->hasGroup('admin') && !$this->user->hasGroup('super_admin'))) {
             return response()->json(['message' => 'Not authorized.'], 403);
         }
 
-        $fileName = time().'_'.$request->file->getClientOriginalName();
-        $filePath = $request->file('file')->storePubliclyAs('photos', $fileName, 'external');
+        return null;
+    }
 
-        // attach to entity
-        if ($entity = Entity::find($id)) {
-            $photo = $imageHandler->makePhoto($request->file('file'));
-
-            // count existing photos, and if zero, make this primary
-            if (isset($entity->photos) && 0 === count($entity->photos)) {
-                $photo->is_primary = 1;
-            }
-
-            $photo->save();
-
-            // attach to entity
-            $entity->addPhoto($photo);
-
-            $photoData = $photo->getApiResponse();
-
-            return response()->json($photoData, 201);
+    /**
+     * Shared tail of the upload and from-url paths: primary flag and attach.
+     */
+    private function finishAddingPhoto(Entity $entity, Photo $photo): JsonResponse
+    {
+        // count existing photos BEFORE attaching, and if zero, make this primary
+        if (0 === $entity->photos()->count()) {
+            $photo->is_primary = 1;
         }
 
-        return response()->json([], 404);
+        $photo->save();
+        $entity->addPhoto($photo);
+
+        return response()->json($photo->getApiResponse(), 201);
     }
 
     /**

--- a/app/Http/Controllers/Api/EventsController.php
+++ b/app/Http/Controllers/Api/EventsController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Events\EventCreated;
 use App\Events\EventPhotoAdded;
 use App\Events\EventUpdated;
+use App\Exceptions\RemoteImageException;
 use App\Filters\EventFilters;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\EventPatchRequest;
@@ -23,6 +24,7 @@ use App\Models\Follow;
 use App\Models\OccurrenceDay;
 use App\Models\OccurrenceType;
 use App\Models\OccurrenceWeek;
+use App\Models\Photo;
 use App\Models\ResponseType;
 use App\Models\Series;
 use App\Models\Tag;
@@ -33,6 +35,7 @@ use App\Notifications\EventPublished;
 use App\Services\BestEffortMailer;
 use App\Services\Embeds\OembedExtractor;
 use App\Services\ImageHandler;
+use App\Services\RemoteImageFetcher;
 use App\Services\RssFeed;
 use App\Services\SessionStore\ListParameterSessionStore;
 use Carbon\Carbon;
@@ -41,6 +44,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Session;
@@ -1681,42 +1685,88 @@ class EventsController extends Controller
             'file' => 'required|mimes:jpg,jpeg,png,gif,webp',
         ]);
 
-        if ($event = Event::find($id)) {
-
-            // only the event owner (or an admin) may add photos
-            if (!$this->user
-                || (!$event->ownedBy($this->user) && !$this->user->hasGroup('admin') && !$this->user->hasGroup('super_admin'))) {
-                return response()->json(['message' => 'Not authorized.'], 403);
-            }
-
-            $photo = $imageHandler->makePhoto($request->file('file'));
-
-            // count existing photos BEFORE attaching; isset($event->photos)
-            // used to cache the relation here, so the post-attach count read
-            // stale data and the notification fired on the second photo
-            $existingPhotoCount = $event->photos()->count();
-
-            if (0 === $existingPhotoCount) {
-                $photo->is_primary = 1;
-            }
-
-            $photo->save();
-            $event->addPhoto($photo);
-
-            EventPhotoAdded::dispatch($event, 0 === $existingPhotoCount);
-
-            if ($event->start_at >= Carbon::now()) {
-                // notify followers only when this is the event's first photo
-                if (0 === $existingPhotoCount) {
-                    $this->notifyFollowing($event);
-                }
-            }
-
-            $photoData = $photo->getApiResponse();
-
-            return response()->json($photoData, 201);
+        if (!$event = Event::find($id)) {
+            return response()->json([], 404);
         }
 
-        return response()->json([], 404);
+        if ($denied = $this->denyUnlessCanAddPhoto($event)) {
+            return $denied;
+        }
+
+        $photo = $imageHandler->makePhoto($request->file('file'));
+
+        return $this->finishAddingPhoto($event, $photo);
+    }
+
+    /**
+     * Attach a photo to an event from a public https URL. Identical to
+     * addPhoto() except that the server downloads the bytes (see
+     * RemoteImageFetcher for the SSRF guards).
+     */
+    public function addPhotoFromUrl(int $id, Request $request, ImageHandler $imageHandler, RemoteImageFetcher $fetcher): JsonResponse
+    {
+        $this->validate($request, [
+            'url' => 'required|url',
+        ]);
+
+        if (!$event = Event::find($id)) {
+            return response()->json([], 404);
+        }
+
+        if ($denied = $this->denyUnlessCanAddPhoto($event)) {
+            return $denied;
+        }
+
+        try {
+            $photo = $fetcher->fetch($request->input('url'), fn (UploadedFile $file) => $imageHandler->makePhoto($file));
+        } catch (RemoteImageException $e) {
+            return response()->json(['message' => $e->getMessage()], 422);
+        }
+
+        return $this->finishAddingPhoto($event, $photo);
+    }
+
+    /**
+     * Only the event owner (or an admin) may add photos — checked before
+     * any bytes are fetched or written to storage.
+     */
+    private function denyUnlessCanAddPhoto(Event $event): ?JsonResponse
+    {
+        if (!$this->user
+            || (!$event->ownedBy($this->user) && !$this->user->hasGroup('admin') && !$this->user->hasGroup('super_admin'))) {
+            return response()->json(['message' => 'Not authorized.'], 403);
+        }
+
+        return null;
+    }
+
+    /**
+     * Shared tail of the upload and from-url paths: primary flag, attach,
+     * dispatch and follower notification.
+     */
+    private function finishAddingPhoto(Event $event, Photo $photo): JsonResponse
+    {
+        // count existing photos BEFORE attaching; isset($event->photos)
+        // used to cache the relation here, so the post-attach count read
+        // stale data and the notification fired on the second photo
+        $existingPhotoCount = $event->photos()->count();
+
+        if (0 === $existingPhotoCount) {
+            $photo->is_primary = 1;
+        }
+
+        $photo->save();
+        $event->addPhoto($photo);
+
+        EventPhotoAdded::dispatch($event, 0 === $existingPhotoCount);
+
+        if ($event->start_at >= Carbon::now()) {
+            // notify followers only when this is the event's first photo
+            if (0 === $existingPhotoCount) {
+                $this->notifyFollowing($event);
+            }
+        }
+
+        return response()->json($photo->getApiResponse(), 201);
     }
 }

--- a/app/Http/Controllers/Api/SeriesController.php
+++ b/app/Http/Controllers/Api/SeriesController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Exceptions\RemoteImageException;
 use App\Http\Controllers\Controller;
 use App\Filters\SeriesFilters;
 use App\Http\Requests\SeriesPatchRequest;
@@ -23,6 +24,7 @@ use App\Models\Tag;
 use App\Models\User;
 use App\Models\Visibility;
 use App\Services\ImageHandler;
+use App\Services\RemoteImageFetcher;
 use Carbon\Carbon;
 use App\Services\RssFeed;
 use App\Services\SessionStore\ListParameterSessionStore;
@@ -775,34 +777,75 @@ class SeriesController extends Controller
             'file' => 'required|mimes:jpg,jpeg,png,gif,webp',
         ]);
 
-        // attach to series
-        if ($series = Series::find($id)) {
-
-            // only the series owner (or an admin) may add photos
-            if (!$this->user
-                || (!$series->ownedBy($this->user) && !$this->user->hasGroup('admin') && !$this->user->hasGroup('super_admin'))) {
-                return response()->json(['message' => 'Not authorized.'], 403);
-            }
-
-            // make the photo object from the file in the request
-            $photo = $imageHandler->makePhoto($request->file('file'));
-
-            // count existing photos, and if zero, make this primary
-            if (isset($series->photos) && 0 === count($series->photos)) {
-                $photo->is_primary = 1;
-            }
-
-            $photo->save();
-
-            // attach to series
-            $series->addPhoto($photo);
-
-            $photoData = $photo->getApiResponse();
-
-            return response()->json($photoData, 201);
+        if (!$series = Series::find($id)) {
+            return response()->json([], 404);
         }
 
-        return response()->json([], 404);
+        if ($denied = $this->denyUnlessCanAddPhoto($series)) {
+            return $denied;
+        }
+
+        $photo = $imageHandler->makePhoto($request->file('file'));
+
+        return $this->finishAddingPhoto($series, $photo);
+    }
+
+    /**
+     * Attach a photo to a series from a public https URL. Identical to
+     * addPhoto() except that the server downloads the bytes (see
+     * RemoteImageFetcher for the SSRF guards).
+     */
+    public function addPhotoFromUrl(int $id, Request $request, ImageHandler $imageHandler, RemoteImageFetcher $fetcher): JsonResponse
+    {
+        $this->validate($request, [
+            'url' => 'required|url',
+        ]);
+
+        if (!$series = Series::find($id)) {
+            return response()->json([], 404);
+        }
+
+        if ($denied = $this->denyUnlessCanAddPhoto($series)) {
+            return $denied;
+        }
+
+        try {
+            $photo = $fetcher->fetch($request->input('url'), fn (UploadedFile $file) => $imageHandler->makePhoto($file));
+        } catch (RemoteImageException $e) {
+            return response()->json(['message' => $e->getMessage()], 422);
+        }
+
+        return $this->finishAddingPhoto($series, $photo);
+    }
+
+    /**
+     * Only the series owner (or an admin) may add photos — checked before
+     * any bytes are fetched or written to storage.
+     */
+    private function denyUnlessCanAddPhoto(Series $series): ?JsonResponse
+    {
+        if (!$this->user
+            || (!$series->ownedBy($this->user) && !$this->user->hasGroup('admin') && !$this->user->hasGroup('super_admin'))) {
+            return response()->json(['message' => 'Not authorized.'], 403);
+        }
+
+        return null;
+    }
+
+    /**
+     * Shared tail of the upload and from-url paths: primary flag and attach.
+     */
+    private function finishAddingPhoto(Series $series, Photo $photo): JsonResponse
+    {
+        // count existing photos BEFORE attaching, and if zero, make this primary
+        if (0 === $series->photos()->count()) {
+            $photo->is_primary = 1;
+        }
+
+        $photo->save();
+        $series->addPhoto($photo);
+
+        return response()->json($photo->getApiResponse(), 201);
     }
 
     protected function makePhoto(UploadedFile $file): ?Photo

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -24,6 +24,8 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        $this->configureRateLimiting();
+
         parent::boot();
     }
 
@@ -80,6 +82,12 @@ class RouteServiceProvider extends ServiceProvider
     {
         RateLimiter::for('api', function (Request $request) {
             return Limit::perMinute(300);
+        });
+
+        // each photos/from-url call makes an outbound request on the caller's
+        // behalf, so it gets a much tighter per-user budget than the rest of the API
+        RateLimiter::for('photo-from-url', function (Request $request) {
+            return Limit::perMinute(20)->by($request->user()?->id ?: $request->ip());
         });
     }
 }

--- a/app/Services/RemoteImageFetcher.php
+++ b/app/Services/RemoteImageFetcher.php
@@ -1,0 +1,381 @@
+<?php
+
+namespace App\Services;
+
+use App\Exceptions\RemoteImageException;
+use GuzzleHttp\Psr7\Uri;
+use GuzzleHttp\Psr7\UriResolver;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+
+/**
+ * Downloads a publicly reachable image so it can be attached as a Photo
+ * exactly like a multipart upload would be.
+ *
+ * This is an SSRF sink (the caller picks the URL, the server makes the
+ * request), so every step is defensive:
+ *
+ *  - https only, on every hop of a redirect chain
+ *  - the host is resolved up front and rejected if any address is
+ *    loopback / link-local / private / otherwise non-global; the request
+ *    is then pinned to the validated address so a DNS rebind between the
+ *    check and the connect cannot redirect it
+ *  - redirects are followed manually (max 3) and re-validated per hop
+ *  - connect and total timeouts
+ *  - a hard download cap, enforced while streaming (and via the curl
+ *    progress callback in production) — not by trusting Content-Length
+ *  - the stored bytes are sniffed and must be a jpg/png/gif/webp image
+ */
+class RemoteImageFetcher
+{
+    public const MAX_BYTES = 5 * 1024 * 1024;   // matches the Dropzone maxFilesize: 5
+    public const MAX_REDIRECTS = 3;
+    public const CONNECT_TIMEOUT = 10;
+    public const TIMEOUT = 20;
+
+    /** Sniffed mime type => extension used for the stored file name. */
+    public const ALLOWED_MIMES = [
+        'image/jpeg' => 'jpg',
+        'image/png' => 'png',
+        'image/gif' => 'gif',
+        'image/webp' => 'webp',
+    ];
+
+    /** @var callable(string): array<int, string> */
+    private $resolver;
+
+    /**
+     * @param  (callable(string): array<int, string>)|null  $resolver  maps a hostname to its
+     *         IP addresses; injectable so tests do not need DNS
+     */
+    public function __construct(?callable $resolver = null)
+    {
+        $this->resolver = $resolver ?? [$this, 'resolveHost'];
+    }
+
+    /**
+     * Download the image at $url, hand it to $callback as an UploadedFile
+     * (test mode, so ImageHandler::makePhoto() works unchanged) and remove
+     * the temp file afterwards whatever happens.
+     *
+     * @template T
+     *
+     * @param  callable(UploadedFile): T  $callback
+     * @return T
+     *
+     * @throws RemoteImageException
+     */
+    public function fetch(string $url, callable $callback): mixed
+    {
+        $tempPath = tempnam(sys_get_temp_dir(), 'remote-image-');
+
+        if ($tempPath === false) {
+            throw new RemoteImageException('Could not create a temporary file for the download.');
+        }
+
+        try {
+            $finalUrl = $this->download($url, $tempPath);
+            $mime = $this->sniffMime($tempPath);
+            $name = $this->originalName($finalUrl, self::ALLOWED_MIMES[$mime]);
+
+            return $callback(new UploadedFile($tempPath, $name, $mime, null, true));
+        } finally {
+            if (is_file($tempPath)) {
+                @unlink($tempPath);
+            }
+        }
+    }
+
+    /**
+     * Follow the (validated) redirect chain and stream the final response
+     * into $tempPath. Returns the URL the bytes actually came from.
+     */
+    private function download(string $url, string $tempPath): string
+    {
+        $current = $url;
+
+        for ($hop = 0; $hop <= self::MAX_REDIRECTS; $hop++) {
+            $response = $this->request($current);
+
+            if ($response->redirect()) {
+                $location = $response->header('Location');
+
+                if ($location === '') {
+                    throw new RemoteImageException('The remote server sent a redirect without a location.');
+                }
+
+                try {
+                    $current = (string) UriResolver::resolve(new Uri($current), new Uri($location));
+                } catch (\InvalidArgumentException $e) {
+                    throw new RemoteImageException('The remote server redirected to an invalid URL.');
+                }
+
+                continue;
+            }
+
+            if (!$response->successful()) {
+                throw new RemoteImageException(sprintf('The remote server responded with HTTP %d.', $response->status()));
+            }
+
+            $this->streamToFile($response, $tempPath);
+
+            return $current;
+        }
+
+        throw new RemoteImageException('The URL redirected too many times.');
+    }
+
+    /**
+     * Validate one URL and issue the request for it, pinned to the address
+     * that passed validation.
+     */
+    private function request(string $url): Response
+    {
+        [$host, $port, $ip] = $this->assertSafeUrl($url);
+
+        $aborted = false;
+
+        $curl = [
+            // pin the connection to the address we validated (DNS rebinding guard);
+            // the Host header / SNI still use the hostname so TLS validates normally
+            CURLOPT_RESOLVE => [sprintf('%s:%d:%s', $host, $port, $ip)],
+            // abort the transfer once it passes the cap; curl 8.4+ also stops
+            // in-flight transfers on MAXFILESIZE but older builds only check
+            // the announced size, hence the progress callback as well
+            CURLOPT_MAXFILESIZE => self::MAX_BYTES,
+            CURLOPT_NOPROGRESS => false,
+            CURLOPT_PROGRESSFUNCTION => static function ($resource, int $downloadSize, int $downloaded) use (&$aborted): int {
+                if ($downloaded > self::MAX_BYTES || $downloadSize > self::MAX_BYTES) {
+                    $aborted = true;
+
+                    return 1;
+                }
+
+                return 0;
+            },
+        ];
+
+        try {
+            return Http::withOptions([
+                    'allow_redirects' => false,
+                    'stream' => true,
+                    'curl' => $curl,
+                ])
+                ->connectTimeout(self::CONNECT_TIMEOUT)
+                ->timeout(self::TIMEOUT)
+                ->withUserAgent('EventsTracker/1.0 (+photo-from-url)')
+                ->accept('image/*,*/*;q=0.5')
+                ->get($url);
+        } catch (ConnectionException|RequestException $e) {
+            if ($aborted) {
+                throw new RemoteImageException($this->tooLargeMessage());
+            }
+
+            throw new RemoteImageException('The image could not be downloaded from that URL.');
+        }
+    }
+
+    /**
+     * Enforce scheme, host and address-space rules for one URL.
+     *
+     * @return array{0: string, 1: int, 2: string} host, port, validated IP
+     */
+    private function assertSafeUrl(string $url): array
+    {
+        $parts = parse_url($url);
+
+        if ($parts === false || empty($parts['host'])) {
+            throw new RemoteImageException('The URL is not valid.');
+        }
+
+        if (strtolower($parts['scheme'] ?? '') !== 'https') {
+            throw new RemoteImageException('Only https URLs are allowed.');
+        }
+
+        if (isset($parts['user']) || isset($parts['pass'])) {
+            throw new RemoteImageException('URLs with credentials are not allowed.');
+        }
+
+        $host = strtolower(trim($parts['host'], '[]'));
+        $port = (int) ($parts['port'] ?? 443);
+
+        if ($port !== 443) {
+            throw new RemoteImageException('Only the standard https port is allowed.');
+        }
+
+        $addresses = filter_var($host, FILTER_VALIDATE_IP) !== false
+            ? [$host]
+            : ($this->resolver)($host);
+
+        if ($addresses === []) {
+            throw new RemoteImageException('The host in the URL could not be resolved.');
+        }
+
+        foreach ($addresses as $address) {
+            if (!$this->isGlobalAddress($address)) {
+                throw new RemoteImageException('The URL must point to a public host.');
+            }
+        }
+
+        return [$host, $port, $addresses[0]];
+    }
+
+    /**
+     * True when $ip is a globally routable unicast address — i.e. not
+     * loopback, link-local (incl. the 169.254.169.254 metadata endpoint),
+     * RFC1918 / ULA, CGNAT, multicast, unspecified or otherwise reserved.
+     */
+    public function isGlobalAddress(string $ip): bool
+    {
+        $flags = FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE | FILTER_FLAG_GLOBAL_RANGE;
+
+        if (filter_var($ip, FILTER_VALIDATE_IP, $flags) === false) {
+            return false;
+        }
+
+        $packed = inet_pton($ip);
+
+        if ($packed === false) {
+            return false;
+        }
+
+        if (strlen($packed) === 4) {
+            $first = ord($packed[0]);
+            $second = ord($packed[1]);
+
+            // 100.64.0.0/10 (CGNAT, used for cloud metadata by some providers), 224.0.0.0/4 multicast
+            return !(($first === 100 && $second >= 64 && $second <= 127) || $first >= 224);
+        }
+
+        // IPv4-mapped (::ffff:a.b.c.d) and IPv4-compatible addresses: judge the embedded IPv4
+        if (substr($packed, 0, 10) === str_repeat("\0", 10) && in_array(substr($packed, 10, 2), ["\xff\xff", "\0\0"], true)) {
+            return $this->isGlobalAddress(inet_ntop(substr($packed, 12)));
+        }
+
+        // ff00::/8 multicast
+        return ord($packed[0]) !== 0xff;
+    }
+
+    /**
+     * Copy the response body into $tempPath in chunks, giving up as soon as
+     * the cap is passed. This is the layer that catches oversized bodies
+     * with no Content-Length (and is what Http::fake() exercises).
+     */
+    private function streamToFile(Response $response, string $tempPath): void
+    {
+        $announced = $response->header('Content-Length');
+
+        if ($announced !== '' && (int) $announced > self::MAX_BYTES) {
+            throw new RemoteImageException($this->tooLargeMessage());
+        }
+
+        $body = $response->toPsrResponse()->getBody();
+
+        if ($body->isSeekable()) {
+            $body->rewind();
+        }
+
+        $handle = fopen($tempPath, 'wb');
+
+        if ($handle === false) {
+            throw new RemoteImageException('Could not write the downloaded image.');
+        }
+
+        $total = 0;
+
+        try {
+            while (!$body->eof()) {
+                $chunk = $body->read(65536);
+
+                if ($chunk === '') {
+                    break;
+                }
+
+                $total += strlen($chunk);
+
+                if ($total > self::MAX_BYTES) {
+                    throw new RemoteImageException($this->tooLargeMessage());
+                }
+
+                fwrite($handle, $chunk);
+            }
+        } finally {
+            fclose($handle);
+        }
+
+        if ($total === 0) {
+            throw new RemoteImageException('The URL returned an empty response.');
+        }
+    }
+
+    /**
+     * Determine the real image type from the downloaded bytes — never from
+     * the URL extension or the Content-Type header.
+     */
+    private function sniffMime(string $path): string
+    {
+        $finfo = new \finfo(FILEINFO_MIME_TYPE);
+        $mime = $finfo->file($path) ?: '';
+
+        // getimagesize() must agree, which rules out e.g. an HTML page or a
+        // polyglot that only carries an image signature
+        $info = @getimagesize($path);
+        $imageMime = $info['mime'] ?? '';
+
+        if (!isset(self::ALLOWED_MIMES[$mime]) || $imageMime !== $mime) {
+            throw new RemoteImageException('The URL did not return a supported image (jpg, jpeg, png, gif, webp).');
+        }
+
+        return $mime;
+    }
+
+    /**
+     * Build a client-style original file name from the last path segment of
+     * the URL, sanitized and forced to the sniffed extension; falls back to a
+     * generated name when the path gives nothing usable.
+     */
+    private function originalName(string $url, string $extension): string
+    {
+        $path = parse_url($url, PHP_URL_PATH) ?: '';
+        $segment = rawurldecode(basename($path));
+        $base = pathinfo($segment, PATHINFO_FILENAME);
+
+        $slug = Str::of($base)->ascii()->replaceMatches('/[^A-Za-z0-9._-]+/', '-')->trim('-._')->limit(80, '')->toString();
+
+        if ($slug === '') {
+            $slug = 'remote-'.Str::random(12);
+        }
+
+        return $slug.'.'.$extension;
+    }
+
+    /** Default resolver: A and AAAA records for the host. */
+    private function resolveHost(string $host): array
+    {
+        $addresses = [];
+
+        foreach (@dns_get_record($host, DNS_A | DNS_AAAA) ?: [] as $record) {
+            $ip = $record['ip'] ?? $record['ipv6'] ?? null;
+
+            if ($ip !== null) {
+                $addresses[] = $ip;
+            }
+        }
+
+        // dns_get_record ignores /etc/hosts; gethostbynamel covers that case
+        if ($addresses === []) {
+            $addresses = gethostbynamel($host) ?: [];
+        }
+
+        return array_values(array_unique($addresses));
+    }
+
+    private function tooLargeMessage(): string
+    {
+        return sprintf('The image is larger than the %d MB limit.', self::MAX_BYTES / 1024 / 1024);
+    }
+}

--- a/docs/api_notes.md
+++ b/docs/api_notes.md
@@ -45,3 +45,31 @@ You can apply filters to routes using the following:
 - Names are slugged and matched to an existing tag by slug, so `"diy"`, `"DIY"` and `"Diy"` all resolve to the existing `Diy` tag.
 - A tag is created only when no id or slug matches. Sending an existing tag's name never creates a duplicate.
 - `PUT /api/events/{event}` with `tag_list` is a full sync (a missing key detaches all tags); `PATCH` only syncs when `tag_list` is present.
+
+### Attaching Photos by URL
+
+`POST /api/events/{id}/photos` (and the entity / series equivalents) take a multipart `file` upload. Each has a sibling that accepts a public https URL instead, for callers that cannot hold the bytes themselves (browser automation blocked by CORS, sandboxed agents, importers):
+
+```
+POST /api/events/{id}/photos/from-url
+POST /api/entities/{id}/photos/from-url
+POST /api/series/{id}/photos/from-url
+
+{ "url": "https://example.com/flyer.jpg" }
+```
+
+Behaviour matches the upload endpoint: same ownership rule (owner or admin), first photo becomes primary, followers are notified on an event's first photo, `201` with the photo's API representation. The differences are the guards on the fetch itself, all of which return `422` with a `message`:
+
+- `https` only, on every hop; at most 3 redirects.
+- The host must resolve to a public address. Loopback, link-local (including cloud metadata), RFC1918 / ULA and other reserved ranges are refused, and every redirect target is re-checked.
+- 5 MB cap (the same as the web uploader), enforced while downloading rather than from `Content-Length`.
+- The downloaded bytes are sniffed and must be a jpg, jpeg, png, gif or webp image, regardless of the URL extension or `Content-Type` header.
+- 10 s connect / 20 s total timeout.
+
+The stored file name is derived from the last path segment of the final URL, sanitized and given the sniffed extension. The route is rate limited to 20 requests per minute per user, separately from the rest of the API.
+
+```bash
+curl -u user:pass -H 'Accept: application/json' \
+  -d 'url=https://example.com/flyer.jpg' \
+  https://arcane.city/api/events/123/photos/from-url
+```

--- a/docs/feature_notes.md
+++ b/docs/feature_notes.md
@@ -2,6 +2,21 @@
 
 A more detailed description of new features and changes to the application.
 
+## 2026.09.08
+
+### Attach photos by URL (#2123)
+`POST /api/{events,entities,series}/{id}/photos/from-url` with `{ "url": "https://…" }`
+attaches a photo the server downloads itself, so importers and browser automation that
+cannot hold the image bytes (CORS, sandboxes, native file dialogs) can still add flyer
+art. It behaves exactly like the multipart upload — same ownership check, first photo
+becomes primary, follower notification on an event's first photo — and only differs in
+where the bytes come from. The download lives in `RemoteImageFetcher` and is written as
+an SSRF sink: https only, host resolved and rejected for private / reserved address
+space on every redirect hop (max 3) with the connection pinned to the validated IP,
+5 MB cap enforced mid-transfer, bytes sniffed for jpg/png/gif/webp, timeouts, and a
+tighter per-user rate limit. The three `addPhoto` methods were refactored so the upload
+and URL paths share one tail; the entity upload no longer stores the file twice.
+
 ## 2026.09.04
 
 ### Tag list de-duplication (#2120)

--- a/routes/api.php
+++ b/routes/api.php
@@ -83,6 +83,7 @@ Route::middleware('auth.either')->name('api.')->group(function () {
     Route::get('events/{event}/photos', ['as' => 'events.photos', 'uses' => '\App\Http\Controllers\Api\EventsController@photos']);
     Route::get('events/{event}/all-photos', ['as' => 'events.allPhotos', 'uses' => '\App\Http\Controllers\Api\EventsController@allPhotos']);
     Route::post('events/{id}/photos', [\App\Http\Controllers\Api\EventsController::class, 'addPhoto']);
+    Route::post('events/{id}/photos/from-url', [\App\Http\Controllers\Api\EventsController::class, 'addPhotoFromUrl'])->middleware('throttle:photo-from-url');
     Route::post('events/{id}/instagram-post', [\App\Http\Controllers\Api\EventInstagramController::class, 'postCarouselToInstagramApi']);
     Route::get('events/{event}/embeds', ['as' => 'events.embeds', 'uses' => '\App\Http\Controllers\Api\EventsController@embeds']);
     Route::get('events/{event}/minimal-embeds', ['as' => 'events.minimalEmbeds', 'uses' => '\App\Http\Controllers\Api\EventsController@minimalEmbeds']);
@@ -101,6 +102,7 @@ Route::middleware('auth.either')->name('api.')->group(function () {
     Route::get('entities/{entity}/embeds', ['as' => 'entities.embeds', 'uses' => '\App\Http\Controllers\Api\EntitiesController@embeds']);
     Route::get('entities/{entity}/minimal-embeds', ['as' => 'entities.minimalEmbeds', 'uses' => '\App\Http\Controllers\Api\EntitiesController@minimalEmbeds']);
     Route::post('entities/{id}/photos', [\App\Http\Controllers\Api\EntitiesController::class, 'addPhoto']);
+    Route::post('entities/{id}/photos/from-url', [\App\Http\Controllers\Api\EntitiesController::class, 'addPhotoFromUrl'])->middleware('throttle:photo-from-url');
     Route::post('entities/{id}/links', [\App\Http\Controllers\Api\EntitiesController::class, 'addLink']);
     Route::post('entities/{id}/locations', [\App\Http\Controllers\Api\EntitiesController::class, 'addLocation']);
     Route::post('entities/{id}/contacts', [\App\Http\Controllers\Api\EntitiesController::class, 'addContact']);
@@ -179,6 +181,7 @@ Route::middleware('auth.either')->name('api.')->group(function () {
     Route::get('series/{series}/photos', ['as' => 'series.photos', 'uses' => '\App\Http\Controllers\Api\SeriesController@photos']);
     Route::get('series/{series}/all-photos', ['as' => 'series.allPhotos', 'uses' => '\App\Http\Controllers\Api\SeriesController@allPhotos']);
     Route::post('series/{id}/photos', [\App\Http\Controllers\Api\SeriesController::class, 'addPhoto']);
+    Route::post('series/{id}/photos/from-url', [\App\Http\Controllers\Api\SeriesController::class, 'addPhotoFromUrl'])->middleware('throttle:photo-from-url');
     Route::post('series/{series}/follow', [\App\Http\Controllers\Api\SeriesController::class, 'followJson'])->middleware('auth:sanctum');
     Route::post('series/{series}/unfollow', [\App\Http\Controllers\Api\SeriesController::class, 'unfollowJson'])->middleware('auth:sanctum');
     Route::get('series/popular', ['as' => 'series.popular', 'uses' => '\App\Http\Controllers\Api\SeriesController@popular']);

--- a/tests/Feature/ApiPhotoFromUrlTest.php
+++ b/tests/Feature/ApiPhotoFromUrlTest.php
@@ -1,0 +1,328 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Mail\FollowingUpdate;
+use App\Models\Entity;
+use App\Models\Event;
+use App\Models\Follow;
+use App\Models\Photo;
+use App\Models\Profile;
+use App\Models\Series;
+use App\Models\Tag;
+use App\Models\User;
+use App\Models\UserStatus;
+use App\Services\RemoteImageFetcher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+/**
+ * POST /api/{events,entities,series}/{id}/photos/from-url (issue #2123):
+ * attach a photo the server downloads from a public https URL. Must behave
+ * exactly like the multipart upload apart from where the bytes come from.
+ */
+class ApiPhotoFromUrlTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    private User $owner;
+    private User $attacker;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+        Storage::fake('external');
+        Mail::fake();
+
+        // no DNS in the sandbox: cdn.example.com is public, internal.example.com is loopback
+        $this->app->bind(RemoteImageFetcher::class, fn () => new RemoteImageFetcher(fn (string $host) => match ($host) {
+            'cdn.example.com' => ['93.184.216.34'],
+            'internal.example.com' => ['127.0.0.1'],
+            default => [],
+        }));
+
+        $this->owner = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $this->attacker = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+    }
+
+    private function png(): string
+    {
+        $img = imagecreatetruecolor(8, 8);
+        ob_start();
+        imagepng($img);
+
+        return (string) ob_get_clean();
+    }
+
+    private function fakeCdn(): void
+    {
+        Http::fake(['https://cdn.example.com/*' => Http::response($this->png(), 200, ['Content-Type' => 'image/png'])]);
+    }
+
+    private function postUrl(string $path, ?string $url, ?User $as = null): \Illuminate\Testing\TestResponse
+    {
+        $this->actingAs($as ?? $this->owner, 'sanctum');
+
+        return $this->postJson($path, $url === null ? [] : ['url' => $url]);
+    }
+
+    private function existingPhoto(): Photo
+    {
+        return Photo::factory()->create([
+            'name' => 'existing.webp',
+            'path' => 'photos/existing.webp',
+            'thumbnail' => 'photos/tn-existing.webp',
+            'is_primary' => 1,
+            'created_by' => $this->owner->id,
+            'updated_by' => null,
+        ]);
+    }
+
+    private function followerOfTag(Tag $tag): User
+    {
+        $follower = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        Profile::factory()->create(['user_id' => $follower->id, 'setting_instant_update' => 1]);
+        Follow::create(['user_id' => $follower->id, 'object_type' => 'tag', 'object_id' => $tag->id]);
+
+        return $follower;
+    }
+
+    // ---- events -----------------------------------------------------------
+
+    /** @test */
+    public function event_first_photo_from_url_is_attached_primary_and_notifies_followers(): void
+    {
+        $this->fakeCdn();
+
+        $tag = Tag::factory()->create();
+        $event = Event::factory()->create(['created_by' => $this->owner->id, 'start_at' => now()->addDays(2)]);
+        $event->tags()->attach($tag->id);
+        $follower = $this->followerOfTag($tag);
+
+        $response = $this->postUrl('/api/events/'.$event->id.'/photos/from-url', 'https://cdn.example.com/flyers/Show%20Flyer.png?v=2');
+
+        $response->assertStatus(201)
+            ->assertJsonPath('is_primary', 1);
+
+        $photo = $event->photos()->first();
+        $this->assertNotNull($photo);
+        $this->assertSame(1, $photo->is_primary);
+        $this->assertSame($this->owner->id, $photo->created_by);
+        $this->assertStringEndsWith('_Show-Flyer.webp', $photo->name);
+        $this->assertSame($response->json('id'), $photo->id);
+
+        Storage::disk('external')->assertExists($photo->path);
+        Storage::disk('external')->assertExists($photo->thumbnail);
+
+        $this->assertSame(1, Mail::sent(FollowingUpdate::class)->filter(fn (FollowingUpdate $m) => $m->hasTo($follower->email))->count());
+    }
+
+    /** @test */
+    public function event_second_photo_from_url_is_not_primary_and_does_not_renotify(): void
+    {
+        $this->fakeCdn();
+
+        $tag = Tag::factory()->create();
+        $event = Event::factory()->create(['created_by' => $this->owner->id, 'start_at' => now()->addDays(2)]);
+        $event->tags()->attach($tag->id);
+        $event->addPhoto($this->existingPhoto());
+        $this->followerOfTag($tag);
+
+        $this->postUrl('/api/events/'.$event->id.'/photos/from-url', 'https://cdn.example.com/second.png')
+            ->assertStatus(201)
+            ->assertJsonPath('is_primary', fn ($v) => !$v);
+
+        $this->assertSame(2, $event->photos()->count());
+        $this->assertSame(1, $event->photos()->where('photos.is_primary', 1)->count());
+        Mail::assertNothingSent();
+    }
+
+    /** @test */
+    public function event_from_url_rejects_non_owner(): void
+    {
+        $this->fakeCdn();
+        $event = Event::factory()->create(['created_by' => $this->owner->id]);
+
+        $this->postUrl('/api/events/'.$event->id.'/photos/from-url', 'https://cdn.example.com/a.png', $this->attacker)
+            ->assertStatus(403);
+
+        $this->assertSame(0, $event->photos()->count());
+        Http::assertNothingSent();
+    }
+
+    /** @test */
+    public function event_from_url_requires_authentication(): void
+    {
+        $this->fakeCdn();
+        $event = Event::factory()->create(['created_by' => $this->owner->id]);
+
+        $this->postJson('/api/events/'.$event->id.'/photos/from-url', ['url' => 'https://cdn.example.com/a.png'])
+            ->assertStatus(401);
+
+        Http::assertNothingSent();
+    }
+
+    /** @test */
+    public function event_from_url_returns_404_for_an_unknown_event(): void
+    {
+        $this->fakeCdn();
+
+        $this->postUrl('/api/events/999999/photos/from-url', 'https://cdn.example.com/a.png')
+            ->assertStatus(404);
+
+        Http::assertNothingSent();
+    }
+
+    /** @test */
+    public function event_from_url_validates_the_url_field(): void
+    {
+        $this->fakeCdn();
+        $event = Event::factory()->create(['created_by' => $this->owner->id]);
+
+        $this->postUrl('/api/events/'.$event->id.'/photos/from-url', null)
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['url']);
+
+        $this->postUrl('/api/events/'.$event->id.'/photos/from-url', 'not a url')
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['url']);
+
+        Http::assertNothingSent();
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider unsafeUrls
+     */
+    public function event_from_url_returns_422_for_unsafe_or_invalid_sources(string $url, string $message): void
+    {
+        Http::fake([
+            'https://cdn.example.com/redirect-private' => Http::response('', 302, ['Location' => 'https://internal.example.com/secret.png']),
+            'https://cdn.example.com/huge.jpg' => Http::response(str_repeat('x', RemoteImageFetcher::MAX_BYTES + 1), 200, ['Content-Type' => 'image/jpeg']),
+            'https://cdn.example.com/page.jpg' => Http::response('<html><body>hi</body></html>', 200, ['Content-Type' => 'image/jpeg']),
+            'https://internal.example.com/*' => Http::response($this->png(), 200, ['Content-Type' => 'image/png']),
+        ]);
+
+        $event = Event::factory()->create(['created_by' => $this->owner->id]);
+
+        $this->postUrl('/api/events/'.$event->id.'/photos/from-url', $url)
+            ->assertStatus(422)
+            ->assertJsonPath('message', fn ($m) => str_contains($m, $message));
+
+        $this->assertSame(0, $event->photos()->count());
+        $this->assertSame(0, Photo::count());
+        Http::assertNotSent(fn (Request $request) => str_contains($request->url(), 'internal.example.com'));
+    }
+
+    public static function unsafeUrls(): array
+    {
+        return [
+            'http scheme' => ['http://cdn.example.com/a.png', 'Only https'],
+            'loopback literal' => ['https://127.0.0.1/a.png', 'public host'],
+            'host resolving to loopback' => ['https://internal.example.com/a.png', 'public host'],
+            'redirect to private' => ['https://cdn.example.com/redirect-private', 'public host'],
+            'over 5 MB' => ['https://cdn.example.com/huge.jpg', '5 MB limit'],
+            'html served as jpeg' => ['https://cdn.example.com/page.jpg', 'supported image'],
+        ];
+    }
+
+    /** @test */
+    public function event_from_url_is_rate_limited(): void
+    {
+        $this->fakeCdn();
+        $event = Event::factory()->create(['created_by' => $this->owner->id]);
+
+        $this->postUrl('/api/events/'.$event->id.'/photos/from-url', 'https://cdn.example.com/a.png')
+            ->assertStatus(201)
+            ->assertHeader('X-RateLimit-Limit', '20');
+    }
+
+    // ---- entities ---------------------------------------------------------
+
+    /** @test */
+    public function entity_photo_from_url_is_attached(): void
+    {
+        $this->fakeCdn();
+        $entity = Entity::factory()->create(['created_by' => $this->owner->id]);
+
+        $this->postUrl('/api/entities/'.$entity->id.'/photos/from-url', 'https://cdn.example.com/venue.png')
+            ->assertStatus(201)
+            ->assertJsonPath('is_primary', 1);
+
+        $photo = $entity->photos()->first();
+        $this->assertNotNull($photo);
+        $this->assertSame($this->owner->id, $photo->created_by);
+        Storage::disk('external')->assertExists($photo->path);
+
+        // a second one is not primary
+        $this->postUrl('/api/entities/'.$entity->id.'/photos/from-url', 'https://cdn.example.com/venue-2.png')
+            ->assertStatus(201)
+            ->assertJsonPath('is_primary', fn ($v) => !$v);
+        $this->assertSame(2, $entity->photos()->count());
+    }
+
+    /** @test */
+    public function entity_from_url_rejects_non_owner_and_unknown_ids(): void
+    {
+        $this->fakeCdn();
+        $entity = Entity::factory()->create(['created_by' => $this->owner->id]);
+
+        $this->postUrl('/api/entities/'.$entity->id.'/photos/from-url', 'https://cdn.example.com/a.png', $this->attacker)
+            ->assertStatus(403);
+        $this->postUrl('/api/entities/999999/photos/from-url', 'https://cdn.example.com/a.png')
+            ->assertStatus(404);
+        $this->postUrl('/api/entities/'.$entity->id.'/photos/from-url', 'https://internal.example.com/a.png')
+            ->assertStatus(422);
+
+        $this->assertSame(0, $entity->photos()->count());
+        Http::assertNothingSent();
+    }
+
+    // ---- series -----------------------------------------------------------
+
+    /** @test */
+    public function series_photo_from_url_is_attached(): void
+    {
+        $this->fakeCdn();
+        $series = Series::factory()->create(['created_by' => $this->owner->id]);
+
+        $this->postUrl('/api/series/'.$series->id.'/photos/from-url', 'https://cdn.example.com/series.png')
+            ->assertStatus(201)
+            ->assertJsonPath('is_primary', 1);
+
+        $photo = $series->photos()->first();
+        $this->assertNotNull($photo);
+        $this->assertSame($this->owner->id, $photo->created_by);
+        Storage::disk('external')->assertExists($photo->path);
+
+        $this->postUrl('/api/series/'.$series->id.'/photos/from-url', 'https://cdn.example.com/series-2.png')
+            ->assertStatus(201)
+            ->assertJsonPath('is_primary', fn ($v) => !$v);
+        $this->assertSame(2, $series->photos()->count());
+    }
+
+    /** @test */
+    public function series_from_url_rejects_non_owner_and_unknown_ids(): void
+    {
+        $this->fakeCdn();
+        $series = Series::factory()->create(['created_by' => $this->owner->id]);
+
+        $this->postUrl('/api/series/'.$series->id.'/photos/from-url', 'https://cdn.example.com/a.png', $this->attacker)
+            ->assertStatus(403);
+        $this->postUrl('/api/series/999999/photos/from-url', 'https://cdn.example.com/a.png')
+            ->assertStatus(404);
+        $this->postUrl('/api/series/'.$series->id.'/photos/from-url', 'https://internal.example.com/a.png')
+            ->assertStatus(422);
+
+        $this->assertSame(0, $series->photos()->count());
+        Http::assertNothingSent();
+    }
+}

--- a/tests/Unit/Services/RemoteImageFetcherTest.php
+++ b/tests/Unit/Services/RemoteImageFetcherTest.php
@@ -1,0 +1,316 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Exceptions\RemoteImageException;
+use App\Services\RemoteImageFetcher;
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+/**
+ * RemoteImageFetcher (issue #2123) is an SSRF sink: the caller picks the
+ * URL and the server fetches it. These tests pin down the guards — scheme,
+ * address space (per redirect hop), redirect cap, size cap, content
+ * sniffing — and the UploadedFile it hands back.
+ */
+class RemoteImageFetcherTest extends TestCase
+{
+    private const PUBLIC_IP = '93.184.216.34';
+
+    /** Hostnames the fake resolver knows; anything else resolves to nothing. */
+    private array $hosts = [
+        'cdn.example.com' => [self::PUBLIC_IP],
+        'other.example.com' => ['198.51.100.7', self::PUBLIC_IP], // first address is TEST-NET-2, non-global
+        'internal.example.com' => ['127.0.0.1'],
+        'metadata.example.com' => ['169.254.169.254'],
+        'v6.example.com' => ['2606:2800:220:1:248:1893:25c8:1946'],
+    ];
+
+    private function fetcher(): RemoteImageFetcher
+    {
+        return new RemoteImageFetcher(fn (string $host) => $this->hosts[$host] ?? []);
+    }
+
+    private function png(): string
+    {
+        $img = imagecreatetruecolor(4, 4);
+        ob_start();
+        imagepng($img);
+
+        return (string) ob_get_clean();
+    }
+
+    private function jpeg(): string
+    {
+        $img = imagecreatetruecolor(4, 4);
+        ob_start();
+        imagejpeg($img);
+
+        return (string) ob_get_clean();
+    }
+
+    private function image(string $bytes, string $contentType = 'image/png', array $headers = []): \GuzzleHttp\Promise\PromiseInterface
+    {
+        return Http::response($bytes, 200, ['Content-Type' => $contentType] + $headers);
+    }
+
+    /** Run fetch() and return [originalName, mime, size, pathAtCallbackTime]. */
+    private function fetchInfo(string $url): array
+    {
+        return $this->fetcher()->fetch($url, fn (UploadedFile $file) => [
+            $file->getClientOriginalName(),
+            $file->getMimeType(),
+            $file->getSize(),
+            $file->getPathname(),
+            $file->isValid(),
+        ]);
+    }
+
+    private function assertRejected(string $url, string $messageFragment): void
+    {
+        try {
+            $this->fetcher()->fetch($url, fn () => null);
+        } catch (RemoteImageException $e) {
+            $this->assertStringContainsString($messageFragment, $e->getMessage());
+
+            return;
+        }
+
+        $this->fail('Expected RemoteImageException for '.$url);
+    }
+
+    /** @test */
+    public function it_downloads_a_public_image_and_hands_back_an_uploaded_file(): void
+    {
+        Http::fake(['https://cdn.example.com/*' => $this->image($this->png())]);
+
+        [$name, $mime, $size, $path, $valid] = $this->fetchInfo('https://cdn.example.com/uploads/Flyer%20Final.png?w=800');
+
+        $this->assertSame('Flyer-Final.png', $name);
+        $this->assertSame('image/png', $mime);
+        $this->assertSame(strlen($this->png()), $size);
+        $this->assertTrue($valid);
+        $this->assertFileDoesNotExist($path, 'The temp file must be removed after the callback runs.');
+
+        Http::assertSent(fn (Request $request) => $request->url() === 'https://cdn.example.com/uploads/Flyer%20Final.png?w=800');
+    }
+
+    /** @test */
+    public function it_returns_whatever_the_callback_returns(): void
+    {
+        Http::fake(['https://cdn.example.com/*' => $this->image($this->png())]);
+
+        $this->assertSame('done', $this->fetcher()->fetch('https://cdn.example.com/a.png', fn () => 'done'));
+    }
+
+    /** @test */
+    public function the_extension_follows_the_sniffed_type_not_the_url(): void
+    {
+        Http::fake(['https://cdn.example.com/*' => $this->image($this->jpeg(), 'image/png')]);
+
+        [$name, $mime] = $this->fetchInfo('https://cdn.example.com/flyer.png');
+
+        $this->assertSame('flyer.jpg', $name);
+        $this->assertSame('image/jpeg', $mime);
+    }
+
+    /** @test */
+    public function it_generates_a_name_when_the_url_has_no_usable_path(): void
+    {
+        Http::fake(['https://cdn.example.com/*' => $this->image($this->png())]);
+
+        [$name] = $this->fetchInfo('https://cdn.example.com/');
+
+        $this->assertMatchesRegularExpression('/^remote-[A-Za-z0-9]{12}\.png$/', $name);
+    }
+
+    /** @test */
+    public function it_cleans_up_the_temp_file_when_the_callback_throws(): void
+    {
+        Http::fake(['https://cdn.example.com/*' => $this->image($this->png())]);
+
+        $path = null;
+
+        try {
+            $this->fetcher()->fetch('https://cdn.example.com/a.png', function (UploadedFile $file) use (&$path) {
+                $path = $file->getPathname();
+                throw new \RuntimeException('boom');
+            });
+        } catch (\RuntimeException $e) {
+        }
+
+        $this->assertNotNull($path);
+        $this->assertFileDoesNotExist($path);
+    }
+
+    /** @test */
+    public function it_only_allows_https(): void
+    {
+        Http::fake();
+
+        $this->assertRejected('http://cdn.example.com/a.png', 'Only https');
+        $this->assertRejected('ftp://cdn.example.com/a.png', 'Only https');
+        $this->assertRejected('file:///etc/passwd', 'not valid');
+        $this->assertRejected('data:image/png;base64,AAAA', 'not valid');
+        $this->assertRejected('https://user:pw@cdn.example.com/a.png', 'credentials');
+        $this->assertRejected('https://cdn.example.com:8443/a.png', 'standard https port');
+
+        Http::assertNothingSent();
+    }
+
+    /** @test */
+    public function it_rejects_hosts_in_private_or_reserved_address_space(): void
+    {
+        Http::fake();
+
+        $this->assertRejected('https://127.0.0.1/a.png', 'public host');
+        $this->assertRejected('https://[::1]/a.png', 'public host');
+        $this->assertRejected('https://10.1.2.3/a.png', 'public host');
+        $this->assertRejected('https://169.254.169.254/latest/meta-data', 'public host');
+        $this->assertRejected('https://internal.example.com/a.png', 'public host');
+        $this->assertRejected('https://metadata.example.com/a.png', 'public host');
+        // one non-global address among several is enough to reject
+        $this->assertRejected('https://other.example.com/a.png', 'public host');
+        $this->assertRejected('https://does-not-resolve.example.com/a.png', 'could not be resolved');
+
+        Http::assertNothingSent();
+    }
+
+    /** @test */
+    public function is_global_address_classifies_the_edge_cases(): void
+    {
+        $fetcher = $this->fetcher();
+
+        foreach (['127.0.0.1', '10.0.0.1', '172.16.5.5', '192.168.1.1', '169.254.169.254', '100.64.0.1', '0.0.0.0',
+            '224.0.0.1', '255.255.255.255', '::1', '::', 'fe80::1', 'fc00::1', 'fd12::1', '::ffff:127.0.0.1', '::ffff:10.0.0.1', 'ff02::1'] as $ip) {
+            $this->assertFalse($fetcher->isGlobalAddress($ip), "$ip should not be treated as global");
+        }
+
+        foreach (['93.184.216.34', '8.8.8.8', '2606:2800:220:1:248:1893:25c8:1946', '2001:4860:4860::8888'] as $ip) {
+            $this->assertTrue($fetcher->isGlobalAddress($ip), "$ip should be global");
+        }
+    }
+
+    /** @test */
+    public function it_follows_redirects_but_revalidates_every_hop(): void
+    {
+        Http::fake([
+            'https://cdn.example.com/start' => Http::response('', 302, ['Location' => '/moved']),
+            'https://cdn.example.com/moved' => Http::response('', 301, ['Location' => 'https://v6.example.com/final.png']),
+            'https://v6.example.com/final.png' => $this->image($this->png()),
+        ]);
+
+        [$name] = $this->fetchInfo('https://cdn.example.com/start');
+
+        $this->assertSame('final.png', $name);
+        Http::assertSentCount(3);
+    }
+
+    /** @test */
+    public function it_rejects_a_redirect_chain_that_lands_on_a_private_address(): void
+    {
+        Http::fake([
+            'https://cdn.example.com/start' => Http::response('', 302, ['Location' => 'https://internal.example.com/secret.png']),
+            'https://internal.example.com/*' => $this->image($this->png()),
+        ]);
+
+        $this->assertRejected('https://cdn.example.com/start', 'public host');
+
+        Http::assertSentCount(1);
+        Http::assertNotSent(fn (Request $request) => str_contains($request->url(), 'internal.example.com'));
+    }
+
+    /** @test */
+    public function it_rejects_a_redirect_to_a_non_https_scheme(): void
+    {
+        Http::fake([
+            'https://cdn.example.com/start' => Http::response('', 302, ['Location' => 'http://cdn.example.com/plain.png']),
+        ]);
+
+        $this->assertRejected('https://cdn.example.com/start', 'Only https');
+        Http::assertSentCount(1);
+    }
+
+    /** @test */
+    public function it_caps_the_redirect_chain(): void
+    {
+        Http::fake([
+            'https://cdn.example.com/1' => Http::response('', 302, ['Location' => '/2']),
+            'https://cdn.example.com/2' => Http::response('', 302, ['Location' => '/3']),
+            'https://cdn.example.com/3' => Http::response('', 302, ['Location' => '/4']),
+            'https://cdn.example.com/4' => Http::response('', 302, ['Location' => '/5']),
+            'https://cdn.example.com/5' => $this->image($this->png()),
+        ]);
+
+        $this->assertRejected('https://cdn.example.com/1', 'too many times');
+        Http::assertSentCount(RemoteImageFetcher::MAX_REDIRECTS + 1);
+    }
+
+    /** @test */
+    public function it_rejects_a_body_over_the_cap_even_without_content_length(): void
+    {
+        Http::fake(['https://cdn.example.com/*' => $this->image(str_repeat('x', RemoteImageFetcher::MAX_BYTES + 1), 'image/jpeg')]);
+
+        $this->assertRejected('https://cdn.example.com/huge.jpg', 'larger than the 5 MB limit');
+    }
+
+    /** @test */
+    public function it_rejects_an_announced_size_over_the_cap(): void
+    {
+        Http::fake(['https://cdn.example.com/*' => $this->image($this->png(), 'image/png', ['Content-Length' => (string) (RemoteImageFetcher::MAX_BYTES + 1)])]);
+
+        $this->assertRejected('https://cdn.example.com/huge.png', 'larger than the 5 MB limit');
+    }
+
+    /** @test */
+    public function it_accepts_a_body_exactly_at_the_cap(): void
+    {
+        // a real PNG padded to exactly MAX_BYTES; trailing bytes are ignored by decoders
+        $png = $this->png();
+        $bytes = $png.str_repeat("\0", RemoteImageFetcher::MAX_BYTES - strlen($png));
+        Http::fake(['https://cdn.example.com/*' => $this->image($bytes)]);
+
+        [, , $size] = $this->fetchInfo('https://cdn.example.com/big.png');
+
+        $this->assertSame(RemoteImageFetcher::MAX_BYTES, $size);
+    }
+
+    /** @test */
+    public function it_rejects_bodies_that_are_not_images_whatever_the_headers_say(): void
+    {
+        Http::fake([
+            'https://cdn.example.com/html.jpg' => $this->image('<html><body>not a flyer</body></html>', 'image/jpeg'),
+            'https://cdn.example.com/photo.heic' => $this->image("\x00\x00\x00\x18ftypheic\x00\x00\x00\x00mif1heic".str_repeat("\0", 64), 'image/heic'),
+            'https://cdn.example.com/doc.svg' => $this->image('<svg xmlns="http://www.w3.org/2000/svg"><script>1</script></svg>', 'image/svg+xml'),
+            'https://cdn.example.com/empty.png' => $this->image('', 'image/png'),
+        ]);
+
+        $this->assertRejected('https://cdn.example.com/html.jpg', 'supported image');
+        $this->assertRejected('https://cdn.example.com/photo.heic', 'supported image');
+        $this->assertRejected('https://cdn.example.com/doc.svg', 'supported image');
+        $this->assertRejected('https://cdn.example.com/empty.png', 'empty');
+    }
+
+    /** @test */
+    public function it_reports_non_success_statuses(): void
+    {
+        Http::fake(['https://cdn.example.com/*' => Http::response('gone', 404)]);
+
+        $this->assertRejected('https://cdn.example.com/missing.png', 'HTTP 404');
+    }
+
+    /** @test */
+    public function it_reports_connection_failures_without_leaking_details(): void
+    {
+        Http::fake(['https://cdn.example.com/*' => fn () => throw new \Illuminate\Http\Client\ConnectionException('cURL error 28: timed out at 10.0.0.1')]);
+
+        try {
+            $this->fetcher()->fetch('https://cdn.example.com/slow.png', fn () => null);
+            $this->fail('Expected RemoteImageException');
+        } catch (RemoteImageException $e) {
+            $this->assertSame('The image could not be downloaded from that URL.', $e->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Closes #2123

## Summary

Adds a sibling to each `addPhoto` route that attaches a photo from a public https URL instead of a multipart upload:

```
POST /api/events/{id}/photos/from-url
POST /api/entities/{id}/photos/from-url
POST /api/series/{id}/photos/from-url
{ "url": "https://example.com/flyer.jpg" }
```

Behaviour is identical to the upload path (ownership check, first photo becomes primary, follower notification on an event's first photo, `201` + `getApiResponse()`); only the source of the bytes differs.

## `RemoteImageFetcher`

New `app/Services/RemoteImageFetcher.php`, written as an SSRF sink per the issue:

- https only, on every hop; redirects followed manually, max 3, re-validated per hop
- host resolved and rejected for loopback, link-local (incl. `169.254.169.254`), RFC1918/ULA, CGNAT, multicast, IPv4-mapped IPv6 equivalents; the connection is then pinned to the validated address with `CURLOPT_RESOLVE` so a DNS rebind between check and connect is inert
- 5 MB cap enforced by a curl progress callback that aborts the transfer, a `Content-Length` short circuit, and the streaming copy loop (which is also what `Http::fake()` exercises)
- bytes sniffed with `finfo` and `getimagesize`; HTML-as-jpeg, SVG and HEIC are refused
- 10 s connect / 20 s total timeout; temp file removed in a `finally`
- original name derived from the final URL's last path segment, sanitized and given the sniffed extension

Failures raise `RemoteImageException`, whose message becomes the `422` body.

## Refactors

- `addPhoto` on all three controllers now shares private `denyUnlessCanAddPhoto()` / `finishAddingPhoto()` helpers with the new method, so the paths cannot drift. The existing count-before-attach fix lives in one place.
- The entity upload previously wrote the file to storage twice (once directly, once inside `makePhoto`); the duplicate store is gone.
- `RouteServiceProvider::configureRateLimiting()` was never called, so named limiters did not exist. It is now invoked from `boot()`. The routes use a new `photo-from-url` limiter (20/min per user); the pre-existing `api` limiter it also defines is not referenced by any middleware, so nothing else changes.

## Tests

- `tests/Unit/Services/RemoteImageFetcherTest.php` (18): scheme/credential/port rejection, private and reserved address classification, per-hop redirect validation, redirect cap, size cap with and without `Content-Length`, exact-cap acceptance, content sniffing, error mapping, temp-file cleanup, name derivation.
- `tests/Feature/ApiPhotoFromUrlTest.php` (17): happy path for all three types, primary flag and follower notification on first photo only, 401/403/404, validation, the six 422 cases from the issue, rate-limit header.
- Full suite: 1723 tests green. Larastan clean.

Also smoke-tested against real hosts from tinker (not possible under `Http::fake()`): png/jpeg/webp fetched from httpbin, https redirect followed, http redirect / loopback / HTML body rejected, and a 100 MB file refused in 0.4 s, confirming the curl-level abort.

## Docs

`docs/api_notes.md` gains an "Attaching Photos by URL" section; `docs/feature_notes.md` has a 2026.09.08 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKQEnZ7nhkboySVE4q1mS9
