### PR TITLE
Invalidate cached user option lists when a user is created, renamed or deleted

### DIFF
--- a/app/Http/Controllers/BlogsController.php
+++ b/app/Http/Controllers/BlogsController.php
@@ -512,7 +512,7 @@ class BlogsController extends Controller
     protected function getFilterOptions(): array
     {
         return [
-            'userOptions' => ['' => '&nbsp;'] + Cache::remember('filter-opts-users-name', 3600, fn () => User::orderBy('name', 'ASC')->pluck('name', 'name')->all()),
+            'userOptions' => ['' => '&nbsp;'] + Cache::remember(User::FILTER_OPTIONS_CACHE_KEY, 3600, fn () => User::orderBy('name', 'ASC')->pluck('name', 'name')->all()),
             'tagOptions' => ['' => '&nbsp;'] + Cache::remember('filter-opts-tags-slug', 3600, fn () => Tag::orderBy('name', 'ASC')->pluck('name', 'slug')->all()),
         ];
     }

--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -411,7 +411,7 @@ class EventsController extends Controller
             'visibilityOptions' => ['' => ''] + Cache::remember('form-opts-visibilities', 86400, fn () => Visibility::orderBy('name', 'ASC')->pluck('name', 'id')->all()),
             'tagOptions' => Cache::remember('form-opts-tags', 3600, fn () => Tag::orderBy('name', 'ASC')->pluck('name', 'id')->all()),
             'entityOptions' => Cache::remember('form-opts-entities-active', 3600, fn () => Entity::active()->orderBy('name', 'ASC')->pluck('name', 'id')->all()),
-            'userOptions' => ['' => ''] + Cache::remember('form-opts-users', 3600, fn () => User::orderBy('name', 'ASC')->pluck('name', 'id')->all()),
+            'userOptions' => ['' => ''] + Cache::remember(User::FORM_OPTIONS_CACHE_KEY, 3600, fn () => User::orderBy('name', 'ASC')->pluck('name', 'id')->all()),
         ];
     }
 
@@ -2825,7 +2825,7 @@ class EventsController extends Controller
             'occurrenceTypeOptions' => ['' => ''] + Cache::remember('form-opts-occurrence-types', 86400, fn () => OccurrenceType::pluck('name', 'id')->all()),
             'dayOptions' => ['' => ''] + Cache::remember('form-opts-occurrence-days', 86400, fn () => OccurrenceDay::pluck('name', 'id')->all()),
             'weekOptions' => ['' => ''] + Cache::remember('form-opts-occurrence-weeks', 86400, fn () => OccurrenceWeek::pluck('name', 'id')->all()),
-            'userOptions' => Cache::remember('form-opts-users', 3600, fn () => User::orderBy('name', 'ASC')->pluck('name', 'id')->all()),
+            'userOptions' => Cache::remember(User::FORM_OPTIONS_CACHE_KEY, 3600, fn () => User::orderBy('name', 'ASC')->pluck('name', 'id')->all()),
         ];
     }
 

--- a/app/Http/Controllers/ForumsController.php
+++ b/app/Http/Controllers/ForumsController.php
@@ -430,7 +430,7 @@ class ForumsController extends Controller
     protected function getFilterOptions(): array
     {
         return [
-            'userOptions' => ['' => '&nbsp;'] + Cache::remember('filter-opts-users-name', 3600, fn () => User::orderBy('name', 'ASC')->pluck('name', 'name')->all()),
+            'userOptions' => ['' => '&nbsp;'] + Cache::remember(User::FILTER_OPTIONS_CACHE_KEY, 3600, fn () => User::orderBy('name', 'ASC')->pluck('name', 'name')->all()),
             'tagOptions' => ['' => '&nbsp;'] + Cache::remember('filter-opts-tags-name', 3600, fn () => Tag::orderBy('name', 'ASC')->pluck('name', 'name')->all()),
             'seriesOptions' => ['' => ''] + Series::getFormOptions(),
         ];

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,6 +21,7 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection as SupportCollection;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
 use Laravel\Sanctum\HasApiTokens;
 
 /**
@@ -104,6 +105,16 @@ class User extends Authenticatable implements AuthorizableContract, CanResetPass
      */
     protected $fillable = ['name', 'slug', 'email', 'password', 'user_status_id'];
 
+    /**
+     * Cache key for the id => name user list used by form selects (e.g. event Owner).
+     */
+    public const FORM_OPTIONS_CACHE_KEY = 'form-opts-users';
+
+    /**
+     * Cache key for the name => name user list used by index filter selects.
+     */
+    public const FILTER_OPTIONS_CACHE_KEY = 'filter-opts-users-name';
+
     protected static function booted(): void
     {
         static::creating(function (self $user): void {
@@ -111,6 +122,19 @@ class User extends Authenticatable implements AuthorizableContract, CanResetPass
                 $user->slug = self::generateUniqueSlug($user->name ?? 'user');
             }
         });
+
+        // Any create, rename or delete changes the cached user option lists.
+        static::saved(fn () => self::forgetOptionsCache());
+        static::deleted(fn () => self::forgetOptionsCache());
+    }
+
+    /**
+     * Forget the cached user option lists so new/renamed users show up in selects.
+     */
+    public static function forgetOptionsCache(): void
+    {
+        Cache::forget(self::FORM_OPTIONS_CACHE_KEY);
+        Cache::forget(self::FILTER_OPTIONS_CACHE_KEY);
     }
 
     /**

--- a/tests/Feature/UserOptionsCacheInvalidationTest.php
+++ b/tests/Feature/UserOptionsCacheInvalidationTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\User;
+use App\Models\UserStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class UserOptionsCacheInvalidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    /** @test */
+    public function creating_a_user_forgets_the_cached_user_option_lists(): void
+    {
+        Cache::put(User::FORM_OPTIONS_CACHE_KEY, ['stale'], 3600);
+        Cache::put(User::FILTER_OPTIONS_CACHE_KEY, ['stale'], 3600);
+
+        User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        $this->assertFalse(Cache::has(User::FORM_OPTIONS_CACHE_KEY));
+        $this->assertFalse(Cache::has(User::FILTER_OPTIONS_CACHE_KEY));
+    }
+
+    /** @test */
+    public function renaming_or_deleting_a_user_forgets_the_cached_user_option_lists(): void
+    {
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        Cache::put(User::FORM_OPTIONS_CACHE_KEY, ['stale'], 3600);
+        $user->update(['name' => 'Renamed User']);
+        $this->assertFalse(Cache::has(User::FORM_OPTIONS_CACHE_KEY));
+
+        Cache::put(User::FORM_OPTIONS_CACHE_KEY, ['stale'], 3600);
+        $user->delete();
+        $this->assertFalse(Cache::has(User::FORM_OPTIONS_CACHE_KEY));
+    }
+
+    /** @test */
+    public function newly_registered_user_appears_in_event_owner_select_without_waiting_for_cache_expiry(): void
+    {
+        $this->withExceptionHandling();
+
+        $admin = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+        $event = Event::factory()->create(['created_by' => $admin->id]);
+
+        // Warm the owner-options cache by rendering the edit form once.
+        $this->actingAs($admin)->get(route('events.edit', $event->slug))->assertStatus(200);
+        $this->assertTrue(Cache::has(User::FORM_OPTIONS_CACHE_KEY));
+
+        $newUser = User::factory()->create([
+            'name' => 'Zed Freshly Registered',
+            'user_status_id' => UserStatus::ACTIVE,
+        ]);
+
+        $response = $this->actingAs($admin)->get(route('events.edit', $event->slug));
+        $response->assertStatus(200);
+        $response->assertSee('Zed Freshly Registered');
+        $response->assertSee('value="'.$newUser->id.'"', false);
+    }
+}


### PR DESCRIPTION
## Problem

The Owner select on the event create/edit form is built from `Cache::remember('form-opts-users', 3600, …)` in `EventsController`. The blog and forum index filters use a sibling key, `filter-opts-users-name`. Nothing ever forgot either key, so a newly registered user did not show up as an owner option until the hour-long TTL ran out.

## Change

- `User` gains `FORM_OPTIONS_CACHE_KEY` / `FILTER_OPTIONS_CACHE_KEY` constants and a `forgetOptionsCache()` helper, following the `Series::FORM_OPTIONS_CACHE_KEY` precedent.
- `User::booted()` forgets both keys on `saved` and `deleted`. Hooking the model rather than individual controllers covers every creation path: web registration, API registration, the admin API `users.store`, and factories. Renames and deletes are included so stale names do not linger either.
- The four `Cache::remember` call sites (`EventsController` x2, `BlogsController`, `ForumsController`) now reference the constants instead of string literals.

## Not in scope

The list still includes users of every status (pending, suspended, banned, deleted). Filtering to active users is a separate behavior change.

## Testing

- New `tests/Feature/UserOptionsCacheInvalidationTest.php`: model hook on create/rename/delete, plus an end-to-end check that a user created after the edit form has warmed the cache appears in the Owner select on the next render.
- `UsersTest`, `UserEditUpdateTest`, `ApiUserRegistrationTest`, `ApiUsersControllerTest` still green.
- `composer phpstan` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BsKeQEX6uj25ad3brUJG