### PR TITLE
Warn about same-type entities whose name or alias matches on the entity form

### DIFF
--- a/app/Http/Controllers/EntitiesController.php
+++ b/app/Http/Controllers/EntitiesController.php
@@ -855,16 +855,24 @@ class EntitiesController extends Controller
     }
 
     /**
-     * Check for existing entities with a name similar to the one being quick-added,
-     * so the event form can warn the user about likely duplicates.
+     * Check for existing entities whose name or alias matches the one being entered,
+     * so the event quick-add modal and the entity form can warn about likely duplicates.
      */
     public function quickCheck(Request $request): JsonResponse
     {
         $validated = $request->validate([
             'name' => 'required|string|min:3|max:255',
+            // Restrict matches to one type: the entity form only warns about a
+            // same-name-same-type collision, since the same name legitimately
+            // exists across types (a band and the venue named after it).
+            'entity_type_id' => 'nullable|integer|exists:entity_types,id',
+            // When editing, the entity being edited must not match itself.
+            'exclude_id' => 'nullable|integer',
         ]);
 
         $name = $validated['name'];
+        $typeId = $validated['entity_type_id'] ?? null;
+        $excludeId = $validated['exclude_id'] ?? null;
 
         $candidates = Entity::where(function (Builder $query) use ($name) {
             $query->where('name', 'like', '%'.$name.'%')
@@ -873,21 +881,24 @@ class EntitiesController extends Controller
                     $q->where('name', $name);
                 });
         })
+            ->when($typeId, fn (Builder $query) => $query->where('entity_type_id', $typeId))
+            ->when($excludeId, fn (Builder $query) => $query->where('id', '!=', $excludeId))
             ->with(['entityType', 'aliases'])
             ->limit(25)
             ->get();
 
         $matches = $candidates
             ->map(function (Entity $entity) use ($name) {
-                $aliasMatch = $entity->aliases->contains(
+                $matchedAlias = $entity->aliases->first(
                     fn ($alias) => 0 === strcasecmp($alias->name, $name)
                 );
                 similar_text(mb_strtolower($name), mb_strtolower($entity->name), $percent);
 
                 return [
                     'entity' => $entity,
-                    'score' => $aliasMatch ? 100.0 : $percent,
-                    'keep' => $aliasMatch
+                    'alias' => $matchedAlias?->name,
+                    'score' => $matchedAlias ? 100.0 : $percent,
+                    'keep' => $matchedAlias
                         || $percent >= 60
                         || false !== mb_stripos($entity->name, $name)
                         || false !== mb_stripos($name, $entity->name),
@@ -902,6 +913,9 @@ class EntitiesController extends Controller
                 'name' => $match['entity']->name,
                 'slug' => $match['entity']->slug,
                 'entity_type' => $match['entity']->entityType?->name,
+                // Set when the input matched one of the entity's aliases rather
+                // than its name, so the UI can explain why it surfaced.
+                'alias' => $match['alias'],
             ]);
 
         return response()->json(['data' => $matches]);

--- a/docs/feature_notes.md
+++ b/docs/feature_notes.md
@@ -4,6 +4,14 @@ A more detailed description of new features and changes to the application.
 
 ## 2026.09.08
 
+### Duplicate-entity warning on the entity form
+The entity create and edit forms now warn, as you type, when another entity of the
+**same type** already has that name or lists it as an alias, so aliases stop turning
+into separate concrete entities. The same name across different types (a band and the
+venue named after it) does not warn. Matches link to the existing entity and say which
+alias matched; the form can still be submitted. `GET /entities/quick-check` gained
+optional `entity_type_id` and `exclude_id` filters and an `alias` field per match.
+
 ### Attach photos by URL (#2123)
 `POST /api/{events,entities,series}/{id}/photos/from-url` with `{ "url": "https://…" }`
 attaches a photo the server downloads itself, so importers and browser automation that

--- a/public/js/image-analyze.js
+++ b/public/js/image-analyze.js
@@ -320,6 +320,8 @@
         if (coerced === '') return;
 
         el.value = coerced;
+        // Let field listeners (e.g. the entity duplicate check) see the prefill.
+        el.dispatchEvent(new Event('input', { bubbles: true }));
     }
 
     function matchSelectByName(selectId, name) {

--- a/resources/views/entities/form.blade.php
+++ b/resources/views/entities/form.blade.php
@@ -107,6 +107,24 @@
     </div>
 </div>
 
+{{-- Possible duplicate warning: an entity of the same type whose name or alias matches --}}
+<div id="entity-duplicate-warning"
+     class="hidden rounded-md border border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-700 p-4 text-sm"
+     role="alert">
+    <div class="flex items-start gap-2">
+        <i class="bi bi-exclamation-triangle-fill text-amber-600 dark:text-amber-400 mt-0.5 flex-shrink-0"></i>
+        <div class="min-w-0">
+            <p class="font-medium text-amber-800 dark:text-amber-300 mb-2">
+                An entity of this type with a matching name or alias already exists:
+            </p>
+            <ul id="entity-duplicate-list" class="space-y-1 text-amber-700 dark:text-amber-400 list-disc list-inside"></ul>
+            <p class="mt-2 text-amber-600 dark:text-amber-500 text-xs">
+                If this is the same entity, edit it instead of creating a new one. If it is genuinely different, you can still submit this form.
+            </p>
+        </div>
+    </div>
+</div>
+
 {{-- Started At, FB Username, and Instagram Username --}}
 <div class="grid grid-cols-12 gap-4">
     <div class="col-span-12 md:col-span-4">
@@ -250,3 +268,80 @@
         {{ isset($action) && $action == 'update' ? 'Update Entity' : 'Add Entity' }}
     </x-ui.button>
 </div>
+
+@section('footer')
+<script>
+// Duplicate check: warn when an entity of the selected type already has this
+// name or alias, so aliases don't get re-created as separate entities.
+(function () {
+    const nameInput = document.getElementById('name');
+    const typeSelect = document.getElementById('entity_type_id');
+    const warning = document.getElementById('entity-duplicate-warning');
+    const list = document.getElementById('entity-duplicate-list');
+    if (!nameInput || !typeSelect || !warning || !list) return;
+
+    const checkUrl = '{{ route('entities.quickCheck') }}';
+    const excludeId = {{ (int) ($entity->id ?? 0) }};
+    let timer = null;
+    let seq = 0;
+
+    function hide() {
+        warning.classList.add('hidden');
+        list.textContent = '';
+    }
+
+    function render(matches) {
+        hide();
+        if (!matches.length) return;
+        matches.forEach(function (match) {
+            const li = document.createElement('li');
+            const a = document.createElement('a');
+            a.href = '/entities/' + encodeURIComponent(match.slug);
+            a.target = '_blank';
+            a.rel = 'noopener';
+            a.className = 'underline hover:no-underline';
+            a.textContent = match.name;
+            li.appendChild(a);
+            if (match.entity_type) {
+                li.appendChild(document.createTextNode(' (' + match.entity_type + ')'));
+            }
+            if (match.alias) {
+                li.appendChild(document.createTextNode(' \u2014 matched alias \u201c' + match.alias + '\u201d'));
+            }
+            list.appendChild(li);
+        });
+        warning.classList.remove('hidden');
+    }
+
+    function check() {
+        clearTimeout(timer);
+        const name = nameInput.value.trim();
+        const typeId = typeSelect.value;
+        if (name.length < 3 || !typeId) {
+            hide();
+            return;
+        }
+        timer = setTimeout(function () {
+            const current = ++seq;
+            const params = new URLSearchParams({ name: name, entity_type_id: typeId });
+            if (excludeId) params.set('exclude_id', excludeId);
+            fetch(checkUrl + '?' + params.toString(), { headers: { 'Accept': 'application/json' } })
+                .then(function (response) { return response.ok ? response.json() : { data: [] }; })
+                .then(function (result) {
+                    // Ignore out-of-order responses from earlier keystrokes
+                    if (current === seq) render(result.data || []);
+                })
+                .catch(function () { /* advisory only; ignore failures */ });
+        }, 400);
+    }
+
+    nameInput.addEventListener('input', check);
+    nameInput.addEventListener('change', check);
+    // Select2 fires change through jQuery, which native listeners don't see.
+    $(typeSelect).on('change', check);
+
+    // Re-check when a validation round-trip repopulates the form.
+    if (nameInput.value.trim().length >= 3 && typeSelect.value) check();
+})();
+</script>
+@endsection

--- a/tests/Feature/EntityQuickCheckTest.php
+++ b/tests/Feature/EntityQuickCheckTest.php
@@ -122,6 +122,106 @@ class EntityQuickCheckTest extends TestCase
     }
 
     /** @test */
+    public function quick_check_reports_which_alias_matched()
+    {
+        $entity = $this->makeEntity('Spirit Lodge');
+        $alias = Alias::create(['name' => 'The Lodge PGH']);
+        $entity->aliases()->attach($alias->id);
+
+        $response = $this->actingAs($this->activeUser())
+            ->getJson('/entities/quick-check?name=the lodge pgh')
+            ->assertStatus(200);
+
+        $match = collect($response->json('data'))->firstWhere('id', $entity->id);
+        $this->assertNotNull($match);
+        $this->assertSame('The Lodge PGH', $match['alias']);
+
+        $byName = $this->actingAs($this->activeUser())
+            ->getJson('/entities/quick-check?name=Spirit Lodge')
+            ->json('data');
+        $this->assertNull(collect($byName)->firstWhere('id', $entity->id)['alias']);
+    }
+
+    /** @test */
+    public function quick_check_can_be_restricted_to_one_entity_type()
+    {
+        $space = $this->makeEntity('Spirit Lodge', EntityType::SPACE);
+        $group = $this->makeEntity('Spirit Lodge', EntityType::GROUP);
+
+        $ids = collect($this->actingAs($this->activeUser())
+            ->getJson('/entities/quick-check?name=Spirit Lodge&entity_type_id='.EntityType::GROUP)
+            ->assertStatus(200)
+            ->json('data'))->pluck('id');
+
+        $this->assertTrue($ids->contains($group->id));
+        $this->assertFalse($ids->contains($space->id));
+    }
+
+    /** @test */
+    public function quick_check_type_filter_still_matches_aliases()
+    {
+        $entity = $this->makeEntity('Spirit Lodge', EntityType::SPACE);
+        $alias = Alias::create(['name' => 'The Lodge PGH']);
+        $entity->aliases()->attach($alias->id);
+
+        $user = $this->activeUser();
+
+        $this->actingAs($user)
+            ->getJson('/entities/quick-check?name=The Lodge PGH&entity_type_id='.EntityType::SPACE)
+            ->assertStatus(200)
+            ->assertJsonFragment(['id' => $entity->id]);
+
+        $this->actingAs($user)
+            ->getJson('/entities/quick-check?name=The Lodge PGH&entity_type_id='.EntityType::GROUP)
+            ->assertStatus(200)
+            ->assertJsonMissing(['id' => $entity->id]);
+    }
+
+    /** @test */
+    public function quick_check_rejects_an_unknown_entity_type()
+    {
+        $this->actingAs($this->activeUser())
+            ->getJson('/entities/quick-check?name=Spirit Lodge&entity_type_id=9999')
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('entity_type_id');
+    }
+
+    /** @test */
+    public function quick_check_can_exclude_the_entity_being_edited()
+    {
+        $self = $this->makeEntity('Spirit Lodge');
+        $other = $this->makeEntity('Spirit Lodge Annex');
+
+        $ids = collect($this->actingAs($this->activeUser())
+            ->getJson('/entities/quick-check?name=Spirit Lodge&exclude_id='.$self->id)
+            ->assertStatus(200)
+            ->json('data'))->pluck('id');
+
+        $this->assertFalse($ids->contains($self->id));
+        $this->assertTrue($ids->contains($other->id));
+    }
+
+    /** @test */
+    public function entity_create_and_edit_forms_render_the_duplicate_warning()
+    {
+        $user = $this->activeUser();
+        $entity = $this->makeEntity('Spirit Lodge');
+        $entity->update(['created_by' => $user->id]);
+
+        $this->actingAs($user)
+            ->get('/entities/create')
+            ->assertStatus(200)
+            ->assertSee('id="entity-duplicate-warning"', false)
+            ->assertSee('const excludeId = 0;', false);
+
+        $this->actingAs($user)
+            ->get('/entities/'.$entity->slug.'/edit')
+            ->assertStatus(200)
+            ->assertSee('id="entity-duplicate-warning"', false)
+            ->assertSee('const excludeId = '.$entity->id.';', false);
+    }
+
+    /** @test */
     public function quick_check_returns_nothing_for_an_unrelated_name()
     {
         $this->makeEntity('Spirit Lodge');


### PR DESCRIPTION
## Summary
- The entity create/edit forms now warn, as you type, when another entity of the **same type** already has that name or lists it as an alias. Same name across different types (a band and the venue named after it) does not warn.
- Matches link to the existing entity (new tab) and say which alias matched, e.g. *Spednar (Individual) — matched alias “Ii-go”*. The form can still be submitted.
- `GET /entities/quick-check` gains optional `entity_type_id` and `exclude_id` filters (edit mode excludes the entity itself) and an `alias` field per match. The event quick-add modal keeps its existing untyped behaviour.
- `image-analyze.js` now dispatches an `input` event after pre-filling a text field, so the check also fires after AI pre-fill.

## Test plan
- [x] `tests/Feature/EntityQuickCheckTest.php` — 15 tests: type filter, alias match under type filter, alias hint, unknown type → 422, `exclude_id`, create/edit page render
- [x] phpstan clean on `EntitiesController`
- [x] Verified on dev in a browser: typing "Spirit" + Space lists the three Space matches, switching to Group swaps to the Group matches, clearing the type hides the panel, typing an alias ("ii-go") surfaces the aliased entity with the alias hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9BsKeQEX6uj25ad3brUJG