### PR TITLE
Fix: Instagram carousel upload error is opaque [EVENTREPO-YD]

### DIFF
--- a/app/Services/Integrations/Instagram.php
+++ b/app/Services/Integrations/Instagram.php
@@ -78,7 +78,7 @@ class Instagram
 
         // check if data is not null
         if (!isset($response['data']['id'])) {
-            throw new \Exception('No data returned. There was an error posting to Instagram.  Please try again.');
+            throw new \Exception('There was an error posting to Instagram during photo upload. '.$this->describeApiError($response));
         }
 
         return $response['data']['id'];
@@ -95,7 +95,7 @@ class Instagram
 
         // check if data is not null
         if (!isset($response['data']['id'])) {
-            throw new \Exception('No data returned. There was an error posting to Instagram.  Please try again.');
+            throw new \Exception('There was an error posting to Instagram during story photo upload. '.$this->describeApiError($response));
         }
 
         return $response['data']['id'];
@@ -109,7 +109,7 @@ class Instagram
 
         // check if data is not null
         if (!isset($response['data']['id'])) {
-            throw new \Exception('No data returned. There was an error posting carousel photo to Instagram.  Please try again.');
+            throw new \Exception('There was an error posting carousel photo to Instagram. '.$this->describeApiError($response));
         }
 
         return $response['data']['id'];
@@ -133,7 +133,7 @@ class Instagram
 
         // check if data is not null
         if (!isset($response['data']['id'])) {
-            throw new \Exception('No data returned. There was an error posting create carousel to Instagram.  Please try again.');
+            throw new \Exception('There was an error creating the Instagram carousel. '.$this->describeApiError($response));
         }
 
         return $response['data']['id'];


### PR DESCRIPTION
## Sentry issue

[EVENTREPO-YD](https://geoff-maddock.sentry.io/issues/7719275235/) — `RuntimeException: There was an error posting to Instagram during carousel photo upload. No data returned. There was an error posting carousel photo to Instagram. Please try again.` (2 events)

No user feedback was attached to the issue.

## The error

When posting an event carousel to Instagram, `App\Services\Integrations\Instagram::uploadCarouselPhoto()` calls the Facebook Graph API `/media` endpoint and expects a media-container id back (`$response['data']['id']`). When that key is absent it throws:

> No data returned. There was an error posting carousel photo to Instagram. Please try again.

`InstagramEventPoster::postCarousel()` then re-wraps that via `uploadFailure()` into the `RuntimeException` Sentry recorded.

## Root cause

The Graph API returns a media id **only on success**; on failure it returns an `error` object (rejected image, rate limit, expired/invalid token, aspect-ratio rejection, unreachable `image_url`, etc.). The four container-creation methods — `uploadPhoto`, `uploadStoryPhoto`, `uploadCarouselPhoto`, `createCarousel` — all threw the same hardcoded `"No data returned … Please try again."` string and **discarded the actual error body**, so every distinct upstream cause collapsed into one opaque Sentry bucket with no diagnostic detail. This is the same class of problem already addressed for `publishMedia`/`publishStoryMedia` (which use `describeApiError()`) and for the poster's `uploadFailure()` wrapper (EVENTREPO-VB).

## What changed

`app/Services/Integrations/Instagram.php` — the four `throw new \Exception(...)` sites now include `$this->describeApiError($response)`, the existing private helper that extracts the Graph API `error.message`, `code`, `error_subcode`, and `error_user_msg`. The detail already propagates through `InstagramEventPoster::uploadFailure()` (which surfaces and chains the cause) into Sentry, so future failures group by actual reason and are diagnosable.

This does not change control flow or the success path — it only enriches the failure message. The existing tests mock at the `uploadCarouselPhoto` boundary and assert the poster surfaces the underlying cause, so they remain valid.

## Validation

- `php -l` passes on the changed file.
- PHPUnit/PHPStan were not run in this environment (no `vendor/` present; the suite requires `composer install` + a MySQL database). The change reuses an existing, already-tested pattern in the same class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7b8Z9znLhb1ztsMQCydiZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7b8Z9znLhb1ztsMQCydiZ)_