### PR TITLE
Emit every recommended Event JSON-LD field with fallbacks (Search Console)

### DIFF
--- a/app/Http/Controllers/EntitiesController.php
+++ b/app/Http/Controllers/EntitiesController.php
@@ -696,7 +696,9 @@ class EntitiesController extends Controller
             ->with([
                 'venue.locations',
                 'venue.links',
+                'venue.photos',
                 'promoter.links',
+                'series.photos',
                 'photos',
                 'entities.roles',
                 'entities.links',
@@ -969,7 +971,9 @@ class EntitiesController extends Controller
             ->with([
                 'venue.locations',
                 'venue.links',
+                'venue.photos',
                 'promoter.links',
+                'series.photos',
                 'photos',
                 'entities.roles',
                 'entities.links',

--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -374,9 +374,10 @@ class EventsController extends Controller
         // built by App\Services\EventSchema: performerEntities() and primaryLink() both fall back
         // to a query per event (per entity, for links) unless these are loaded. Four extra eager
         // loads per page, constant in the number of events, against ~150 N+1 queries on a full page.
+        // venue.photos/series.photos feed EventSchema's image fallback for an event with no flyer.
         $eager = [
-            'visibility', 'venue.locations', 'venue.links', 'eventType', 'tags', 'photos',
-            'entities', 'entities.roles', 'entities.links', 'promoter.links', 'threads',
+            'visibility', 'venue.locations', 'venue.links', 'venue.photos', 'eventType', 'tags', 'photos',
+            'entities', 'entities.roles', 'entities.links', 'promoter.links', 'series.photos', 'threads',
         ];
 
         if ($user) {

--- a/app/Http/Controllers/SeriesController.php
+++ b/app/Http/Controllers/SeriesController.php
@@ -662,7 +662,7 @@ class SeriesController extends Controller
         // Each event renders through events/card-tw, which touches venue, eventType,
         // visibility, tags, photos (getPrimaryPhoto), entities and threads per card —
         // eager-load them so the grid is a fixed number of queries, not N per event.
-        $eventEager = ['venue', 'eventType', 'visibility', 'tags', 'photos', 'entities', 'threads'];
+        $eventEager = ['venue.photos', 'eventType', 'visibility', 'tags', 'photos', 'entities', 'series.photos', 'threads'];
         if ($this->user) {
             // The attend/unattend button reads getEventResponse($user)->responseType per card.
             $eventEager['eventResponses'] = function ($query) {

--- a/app/Services/EventSchema.php
+++ b/app/Services/EventSchema.php
@@ -4,6 +4,8 @@ namespace App\Services;
 
 use App\Models\Entity;
 use App\Models\Event;
+use App\Models\Location;
+use Illuminate\Support\Facades\Storage;
 
 /**
  * The one place that maps an Event onto a schema.org Event node.
@@ -14,6 +16,13 @@ use App\Models\Event;
  * dozen, which is what Search Console reports as missing fields on
  * /events/this-week. They also disagreed about whether a Guarded venue's street
  * address is publishable. Every caller now shares this builder instead.
+ *
+ * Every recommended Event property Google lists is emitted for every event,
+ * falling back to the best available stand-in rather than omitting the key.
+ * Search Console counts each missing recommended field as an enrichment
+ * warning per indexed item; the September 2026 export had ~3,300 of them,
+ * almost all from organizers with no external link and venues with no
+ * street address on file. The fallbacks are documented at each helper.
  *
  * Dates go through App\Services\EventTime rather than reading the cast Carbon
  * directly. config('app.timezone') is 'EST', a fixed UTC-5 offset that never
@@ -33,6 +42,13 @@ class EventSchema
     public const DETAIL_PERFORMER_LIMIT = 10;
 
     /**
+     * The site-wide promo image, already the default og:image in the layout.
+     * Last resort for an event with no flyer whose series and venue have no
+     * photo either.
+     */
+    public const DEFAULT_IMAGE_PATH = '/images/arcane-city-promo.jpg';
+
+    /**
      * A standalone Event document, for a page whose subject is one event.
      *
      * @return array<string, mixed>
@@ -50,6 +66,9 @@ class EventSchema
      * promoter.links, entities.roles, entities.links. The helpers this calls
      * all short-circuit on relationLoaded(), so callers rendering many events
      * should eager load them — see EventsController::cardEventEagerLoad().
+     * The series relation (and venue/series photos) are only read on the
+     * fallback paths for an event with no photo or no promoter and venue,
+     * which is rare enough not to warrant an eager load of its own.
      *
      * @return array<string, mixed>
      */
@@ -76,15 +95,8 @@ class EventSchema
 
         $node['eventAttendanceMode'] = self::CONTEXT.'/OfflineEventAttendanceMode';
         $node['eventStatus'] = self::eventStatus($event);
-
-        if ($image = $event->getPrimaryPhotoPath()) {
-            $node['image'] = [$image];
-        }
-
-        if ($description = self::description($event)) {
-            $node['description'] = $description;
-        }
-
+        $node['image'] = [self::image($event)];
+        $node['description'] = self::description($event);
         $node['location'] = self::location($event->venue);
         $node['offers'] = self::offers($event, $url);
         $node['performer'] = self::performers($event, $performerLimit);
@@ -109,24 +121,66 @@ class EventSchema
     }
 
     /**
-     * Prefer the short blurb; fall back to the long description. Both may hold
-     * markup, which schema.org descriptions should not.
+     * The event's own flyer, else the series' image, else the venue's, else
+     * the site promo image. Google wants a relevant image on every Event and
+     * a generic one only clears the warning — the flyer is what improves the
+     * result — but an absent image is the worst of the options.
      */
-    protected static function description(Event $event): ?string
+    protected static function image(Event $event): string
     {
-        $text = $event->short ?: $event->description;
-
-        if (null === $text || '' === trim($text)) {
-            return null;
+        if ($path = $event->getPrimaryPhotoPath()) {
+            return $path;
         }
 
-        return trim(preg_replace('/\s+/', ' ', strip_tags($text)) ?? '') ?: null;
+        $photo = $event->series?->getPrimaryPhoto() ?? $event->venue?->getPrimaryPhoto();
+
+        if ($photo) {
+            return Storage::disk('external')->url($photo->getStoragePath());
+        }
+
+        return url(self::DEFAULT_IMAGE_PATH);
     }
 
     /**
+     * Prefer the short blurb; fall back to the long description. Both may hold
+     * markup, which schema.org descriptions should not. An event with no copy
+     * at all gets a sentence built from what is known about it, so the field
+     * is never absent.
+     */
+    protected static function description(Event $event): string
+    {
+        $text = $event->short ?: $event->description;
+
+        if (null !== $text && '' !== trim($text)) {
+            $clean = trim(preg_replace('/\s+/', ' ', strip_tags($text)) ?? '');
+
+            if ('' !== $clean) {
+                return $clean;
+            }
+        }
+
+        $sentence = $event->name;
+
+        if ($event->venue) {
+            $sentence .= ' at '.$event->venue->name;
+        }
+
+        if ($startsAt = EventTime::startsAt($event)) {
+            $sentence .= ' on '.$startsAt->format('l, F j, Y');
+        }
+
+        return $sentence.'.';
+    }
+
+    /**
+     * The venue as a Place. Always carries a PostalAddress: the full street
+     * address when one is on file and publishable, otherwise the city level,
+     * which is still what Google asks for and beats nothing. Roughly a fifth
+     * of listed venues have no Location row at all.
+     *
      * @return array<string, mixed>
      */
-    protected static function location(?Entity $venue): array
+    public static function location(?Entity $venue): array
     {
         if (null === $venue) {
             // Everything published here is a Pittsburgh event, so a venueless
@@ -134,12 +188,7 @@ class EventSchema
             return [
                 '@type'   => 'Place',
                 'name'    => 'TBA',
-                'address' => [
-                    '@type'           => 'PostalAddress',
-                    'addressLocality' => 'Pittsburgh',
-                    'addressRegion'   => 'PA',
-                    'addressCountry'  => 'US',
-                ],
+                'address' => self::postalAddress(null),
             ];
         }
 
@@ -152,39 +201,100 @@ class EventSchema
         $location = $venue->getPrimaryLocation();
 
         // A Guarded address is deliberately withheld from crawlers — same rule
-        // Entity::getJsonLd() applies to the venue's own page.
-        if ($location && !$location->isAddressGuarded() && !empty($location->address_one)) {
-            $place['address'] = [
-                '@type'           => 'PostalAddress',
-                'streetAddress'   => $location->address_one,
-                'addressLocality' => $location->city ?? 'Pittsburgh',
-                'addressRegion'   => $location->state ?? 'PA',
-                'postalCode'      => $location->postcode ?? '',
-                'addressCountry'  => $location->country ?? 'US',
-            ];
+        // Entity::getJsonLd() applies to the venue's own page. Nothing about
+        // it is published, not even the city, so the node cannot be used to
+        // narrow the venue down.
+        if ($location && $location->isAddressGuarded()) {
+            return $place;
         }
+
+        $place['address'] = self::postalAddress($location);
 
         return $place;
     }
 
     /**
+     * A PostalAddress from a Location, or the city-level default when there
+     * is no Location or it carries no street. Empty parts are omitted rather
+     * than emitted as empty strings.
+     *
+     * @return array<string, string>
+     */
+    protected static function postalAddress(?Location $location): array
+    {
+        $address = ['@type' => 'PostalAddress'];
+
+        if ($location && !empty($location->address_one)) {
+            $address['streetAddress'] = $location->address_one;
+        }
+
+        $address['addressLocality'] = $location?->city ?: 'Pittsburgh';
+        $address['addressRegion'] = $location?->state ?: 'PA';
+
+        if ($location && !empty($location->postcode)) {
+            $address['postalCode'] = $location->postcode;
+        }
+
+        $address['addressCountry'] = $location?->country ?: 'US';
+
+        return $address;
+    }
+
+    /**
+     * The ticket link, else the event's primary link, else its own page —
+     * but only a link that is actually an absolute http(s) URL. Older rows
+     * hold values like "Ticketfly.com" or "Admission: Free" from before the
+     * form validated the field, and Search Console flags those as invalid.
+     *
+     * price is only emitted when one is on file. Google renders a price of
+     * 0 as "Free", and most events with no recorded price are ticketed shows
+     * whose price simply was not entered — advertising those as free is
+     * worse than an Offer without a price.
+     *
      * @return array<string, mixed>
      */
     protected static function offers(Event $event, string $eventUrl): array
     {
         $offer = [
-            '@type'         => 'Offer',
-            'url'           => $event->ticket_link ?: ($event->primary_link ?: $eventUrl),
-            'price'         => (string) ($event->door_price ?? $event->presale_price ?? 0),
-            'priceCurrency' => 'USD',
-            'availability'  => self::CONTEXT.'/InStock',
+            '@type'        => 'Offer',
+            'url'          => self::validUrl($event->ticket_link) ?? self::validUrl($event->primary_link) ?? $eventUrl,
+            'availability' => self::CONTEXT.'/InStock',
         ];
+
+        $price = $event->door_price ?? $event->presale_price;
+
+        if (null !== $price && '' !== $price) {
+            $offer['price'] = (string) $price;
+            $offer['priceCurrency'] = 'USD';
+        }
 
         if ($validFrom = EventTime::toInstant($event->created_at)) {
             $offer['validFrom'] = $validFrom->toAtomString();
         }
 
         return $offer;
+    }
+
+    /**
+     * The value if it is an absolute http or https URL, otherwise null.
+     * filter_var rejects non-ASCII hosts, which also catches the homoglyph
+     * domains that Search Console reports as invalid.
+     */
+    public static function validUrl(?string $value): ?string
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        if ('' === $value || false === filter_var($value, FILTER_VALIDATE_URL)) {
+            return null;
+        }
+
+        $scheme = strtolower((string) parse_url($value, PHP_URL_SCHEME));
+
+        return in_array($scheme, ['http', 'https'], true) ? $value : null;
     }
 
     /**
@@ -199,13 +309,7 @@ class EventSchema
         $performers = [];
 
         foreach ($event->performerEntities($limit) as $entity) {
-            $performer = ['@type' => 'PerformingGroup', 'name' => $entity->name];
-
-            if ($link = $entity->primaryLink()) {
-                $performer['url'] = $link->url;
-            }
-
-            $performers[] = $performer;
+            $performers[] = self::performer($entity);
         }
 
         if (!empty($performers)) {
@@ -213,33 +317,71 @@ class EventSchema
         }
 
         $fallback = ['@type' => 'PerformingGroup', 'name' => $event->name];
-        if ($event->primary_link) {
-            $fallback['url'] = $event->primary_link;
+        if ($url = self::validUrl($event->primary_link)) {
+            $fallback['url'] = $url;
         }
 
         return [$fallback];
     }
 
     /**
+     * A performing entity as a PerformingGroup with its own page as the url
+     * when it has no external link.
+     *
+     * @return array<string, string>
+     */
+    public static function performer(Entity $entity): array
+    {
+        return [
+            '@type' => 'PerformingGroup',
+            'name'  => $entity->name,
+            'url'   => self::entityUrl($entity),
+        ];
+    }
+
+    /**
      * The promoter runs the show; absent one, the venue is the closest thing
-     * to an organizer we can name.
+     * to an organizer we can name; absent both, the series the event belongs
+     * to may name either.
      *
      * @return array<string, mixed>|null
      */
     protected static function organizer(Event $event): ?array
     {
-        $entity = $event->promoter ?: $event->venue;
+        $entity = $event->promoter
+            ?: $event->venue
+            ?: $event->series?->promoter
+            ?: $event->series?->venue;
 
         if (null === $entity) {
             return null;
         }
 
-        $organizer = ['@type' => 'Organization', 'name' => $entity->name];
+        return self::organization($entity);
+    }
 
-        if ($link = $entity->primaryLink()) {
-            $organizer['url'] = $link->url;
-        }
+    /**
+     * An entity as an Organization with a url that is always present.
+     *
+     * @return array<string, string>
+     */
+    public static function organization(Entity $entity): array
+    {
+        return [
+            '@type' => 'Organization',
+            'name'  => $entity->name,
+            'url'   => self::entityUrl($entity),
+        ];
+    }
 
-        return $organizer;
+    /**
+     * The entity's own site when it has a valid primary link, else its page
+     * here. Search Console's single largest warning was organizers with a
+     * name and no url: most venues and promoters have no primary link set,
+     * and their arcane.city page is a real, crawlable url for them.
+     */
+    public static function entityUrl(Entity $entity): string
+    {
+        return self::validUrl($entity->primaryLink()?->url) ?? route('entities.show', $entity->slug);
     }
 }

--- a/tests/Unit/Services/EventSchemaTest.php
+++ b/tests/Unit/Services/EventSchemaTest.php
@@ -6,7 +6,9 @@ use App\Models\Entity;
 use App\Models\Event;
 use App\Models\Link;
 use App\Models\Location;
+use App\Models\Photo;
 use App\Models\Role;
+use App\Models\Series;
 use App\Models\Visibility;
 use App\Services\EventSchema;
 use Illuminate\Support\Collection;
@@ -39,6 +41,7 @@ class EventSchemaTest extends TestCase
         $event->setRelation('visibility', null);
         $event->setRelation('venue', null);
         $event->setRelation('promoter', null);
+        $event->setRelation('series', null);
 
         return $event;
     }
@@ -47,9 +50,18 @@ class EventSchemaTest extends TestCase
     {
         $venue = new Entity(['name' => $name, 'slug' => 'squirrel-hill-sports-bar']);
         $venue->setRelation('links', new Collection());
+        $venue->setRelation('photos', new Collection());
         $venue->setRelation('locations', new Collection($location ? [$location] : []));
 
         return $venue;
+    }
+
+    private function photo(string $path): Photo
+    {
+        $photo = new Photo(['path' => $path, 'thumbnail' => $path]);
+        $photo->is_primary = 1;
+
+        return $photo;
     }
 
     private function location(string $visibility, array $attributes = []): Location
@@ -177,6 +189,40 @@ class EventSchemaTest extends TestCase
         $this->assertSame('Pittsburgh', $schema['location']['address']['addressLocality']);
     }
 
+    public function test_a_venue_with_no_location_on_file_gets_a_city_level_address(): void
+    {
+        // Search Console's second-largest warning: a fifth of listed venues
+        // have no Location row, and a Place with no address at all is worth
+        // less than one locatable to the city.
+        $event = $this->event();
+        $event->setRelation('venue', $this->venue());
+
+        $schema = EventSchema::forEvent($event);
+
+        $this->assertSame('Squirrel Hill Sports Bar', $schema['location']['name']);
+        $this->assertSame([
+            '@type'           => 'PostalAddress',
+            'addressLocality' => 'Pittsburgh',
+            'addressRegion'   => 'PA',
+            'addressCountry'  => 'US',
+        ], $schema['location']['address']);
+    }
+
+    public function test_a_location_with_no_street_still_publishes_its_city(): void
+    {
+        $event = $this->event();
+        $event->setRelation('venue', $this->venue(location: $this->location('Public', [
+            'address_one' => null, 'city' => 'Millvale', 'postcode' => null,
+        ])));
+
+        $address = EventSchema::forEvent($event)['location']['address'];
+
+        $this->assertArrayNotHasKey('streetAddress', $address);
+        $this->assertArrayNotHasKey('postalCode', $address);
+        $this->assertSame('Millvale', $address['addressLocality']);
+        $this->assertSame('PA', $address['addressRegion']);
+    }
+
     // -- offers -----------------------------------------------------------
 
     public function test_offer_url_prefers_the_ticket_link(): void
@@ -206,6 +252,39 @@ class EventSchemaTest extends TestCase
         $this->assertSame('USD', $schema['offers']['priceCurrency']);
     }
 
+    public function test_an_unknown_price_is_not_advertised_as_free(): void
+    {
+        // Google renders price 0 as "Free". A null price means nobody entered
+        // one, which is not the same claim.
+        $offer = EventSchema::forEvent($this->event())['offers'];
+
+        $this->assertArrayNotHasKey('price', $offer);
+        $this->assertArrayNotHasKey('priceCurrency', $offer);
+        $this->assertSame('https://schema.org/InStock', $offer['availability']);
+    }
+
+    public function test_an_explicit_zero_price_is_free(): void
+    {
+        // '0.00', not '0': Event::setDoorPriceAttribute() treats a bare '0'
+        // as empty and stores null, so an explicit free price arrives as '0.00'.
+        $this->assertSame('0.00', EventSchema::forEvent($this->event(['door_price' => '0.00']))['offers']['price']);
+    }
+
+    public function test_a_ticket_link_that_is_not_a_url_is_not_used(): void
+    {
+        // Pre-validation rows hold values like these; Search Console reports
+        // them as missing or invalid offer urls.
+        foreach (['Ticketfly.com', 'Admission: Free', 'e', 'ttps://example.test/x', 'mailto:x@example.test', 'https://millvalемusicfestival.com'] as $junk) {
+            $schema = EventSchema::forEvent($this->event(['ticket_link' => $junk, 'primary_link' => 'not a url either']));
+
+            $this->assertSame(route('events.show', 'camp-gloom'), $schema['offers']['url'], "accepted: $junk");
+        }
+
+        // Surrounding whitespace is a data-entry slip, not a bad link.
+        $schema = EventSchema::forEvent($this->event(['ticket_link' => ' https://example.test/x ']));
+        $this->assertSame('https://example.test/x', $schema['offers']['url']);
+    }
+
     // -- performer / organizer --------------------------------------------
 
     public function test_related_performers_are_listed_with_their_links(): void
@@ -221,7 +300,8 @@ class EventSchemaTest extends TestCase
         $this->assertCount(2, $schema['performer']);
         $this->assertSame('DJ Strawberry Bloodbath', $schema['performer'][0]['name']);
         $this->assertSame('https://example.test/strawberry', $schema['performer'][0]['url']);
-        $this->assertArrayNotHasKey('url', $schema['performer'][1]);
+        // No external link: the performer's own page here is still a url.
+        $this->assertSame(route('entities.show', 'zona-morta'), $schema['performer'][1]['url']);
     }
 
     public function test_the_performer_limit_is_respected(): void
@@ -268,9 +348,55 @@ class EventSchemaTest extends TestCase
         $this->assertSame('Squirrel Hill Sports Bar', EventSchema::forEvent($event)['organizer']['name']);
     }
 
-    public function test_an_event_with_neither_promoter_nor_venue_omits_organizer(): void
+    public function test_an_organizer_with_no_external_link_points_at_its_own_page(): void
+    {
+        // The single largest Search Console warning (1,884 items): an
+        // Organization with a name and no url.
+        $event = $this->event();
+        $event->setRelation('venue', $this->venue());
+
+        $this->assertSame(route('entities.show', 'squirrel-hill-sports-bar'), EventSchema::forEvent($event)['organizer']['url']);
+    }
+
+    public function test_organizer_falls_back_to_the_series_promoter_or_venue(): void
+    {
+        $promoter = new Entity(['name' => 'Gloom Collective', 'slug' => 'gloom-collective']);
+        $promoter->setRelation('links', new Collection());
+
+        $series = new Series(['name' => 'Gloom Nights']);
+        $series->setRelation('promoter', $promoter);
+        $series->setRelation('venue', null);
+
+        $event = $this->event();
+        $event->setRelation('series', $series);
+
+        $this->assertSame('Gloom Collective', EventSchema::forEvent($event)['organizer']['name']);
+    }
+
+    public function test_an_event_with_neither_promoter_nor_venue_nor_series_omits_organizer(): void
     {
         $this->assertArrayNotHasKey('organizer', EventSchema::forEvent($this->event()));
+    }
+
+    // -- image ------------------------------------------------------------
+
+    public function test_image_falls_back_through_series_and_venue_to_the_site_promo(): void
+    {
+        $event = $this->event();
+        $this->assertSame([url(EventSchema::DEFAULT_IMAGE_PATH)], EventSchema::forEvent($event)['image']);
+
+        $venue = $this->venue();
+        $venue->setRelation('photos', new Collection([$this->photo('photos/venue.jpg')]));
+        $event->setRelation('venue', $venue);
+        $this->assertStringEndsWith('photos/venue.jpg', EventSchema::forEvent($event)['image'][0]);
+
+        $series = new Series(['name' => 'Gloom Nights']);
+        $series->setRelation('photos', new Collection([$this->photo('photos/series.jpg')]));
+        $event->setRelation('series', $series);
+        $this->assertStringEndsWith('photos/series.jpg', EventSchema::forEvent($event)['image'][0]);
+
+        $event->setRelation('photos', new Collection([$this->photo('photos/flyer.jpg')]));
+        $this->assertStringEndsWith('photos/flyer.jpg', EventSchema::forEvent($event)['image'][0]);
     }
 
     // -- description ------------------------------------------------------
@@ -292,9 +418,17 @@ class EventSchemaTest extends TestCase
         $this->assertSame('The long one.', $schema['description']);
     }
 
-    public function test_an_event_with_no_copy_omits_description(): void
+    public function test_an_event_with_no_copy_describes_itself(): void
     {
-        $this->assertArrayNotHasKey('description', EventSchema::forEvent($this->event()));
+        $event = $this->event(['start_at' => '2026-08-01 21:00:00']);
+        $event->setRelation('venue', $this->venue());
+
+        $this->assertSame(
+            'Camp Gloom at Squirrel Hill Sports Bar on Saturday, August 1, 2026.',
+            EventSchema::forEvent($event)['description']
+        );
+
+        $this->assertSame('Camp Gloom.', EventSchema::forEvent($this->event(['start_at' => null]))['description']);
     }
 
     public function test_an_event_with_no_start_time_omits_the_dates(): void


### PR DESCRIPTION
## Why

The Search Console "Events" export from 2026-09-10 (`context/insights/`) has 0 invalid items but ~3,300 non-critical "missing recommended field" warnings. Nearly all trace to `EventSchema` omitting a key when the underlying data is thin. Plan: `context/plans/gsc-event-structured-data.md`.

| Warning | Items | Cause → fallback |
|---|---|---|
| Missing `organizer.url` | 1884 | url only when the promoter/venue had a primary Link → the entity's own arcane.city page |
| Missing `location.address` | 966 | address only when a Location with a street existed → always a `PostalAddress`, city-level (Pittsburgh, PA, US) when no street |
| Missing `organizer` | 137 | no promoter and no venue → the series' promoter or venue |
| Missing `image` | 99 | no flyer → series photo → venue photo → site promo image |
| Missing/invalid `offers.url` | 8 | `ticket_link` like `Ticketfly.com` / a homoglyph domain → only absolute http(s) URLs are used, else the event page |
| Missing `description` | 1 | no copy → "{name} at {venue} on {date}." |

Guarded venue addresses are still withheld entirely.

## Also: unknown price is no longer "Free"

`offers.price` was `"0"` whenever `door_price` and `presale_price` were both null. Google renders price 0 as **Free**; 2,126 public events have a null price that means "not entered". `price`/`priceCurrency` are now emitted only when a price is on file. An explicit `0.00` still says free.

## Other changes

- Performers without an external link get their own page as `url` (same helper as organizer).
- `venue.photos` and `series.photos` added to the shared eager loads in the events, entities and series controllers so the image fallback stays constant in the number of events. The listing query-count guard in `EventTimeWindowPagesTest` caught the N+1 with photoless factory events.
- `EventSchema::location()`, `organization()`, `performer()`, `entityUrl()`, `validUrl()` are public so the follow-up series schema PR can share them.

## Tests

- `tests/Unit/Services/EventSchemaTest.php`: 34 tests covering each fallback, the trimmed/invalid URL cases, unknown vs explicit-zero price, image chain.
- `tests/Unit` + `tests/Feature/Web` (547 tests) green; PHPStan clean on touched files.

## After deploy

Click **Validate fix** on each issue in Search Console; counts fall as pages are recrawled. The data fixes in the plan (venue Locations, organizer primary links, junk ticket links) improve what actually shows and are separate admin work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vFTGsG3jCVq4ieXd4AxTj



---

### CI note (applies to every open PR in this repo right now)

The `NPM security audit` step fails **before** PHPStan or the tests run, for a pre-existing reason on `main`: js-yaml 4.0.0–4.3.1 carries a high-severity advisory (GHSA-2883-xcg3-v3hh). `package.json` pins `overrides: {"js-yaml": "^4.3.1"}` and swagger-ui@5.32.11 exact-pins `js-yaml: =4.3.0`, so the entire 4.x line is vulnerable and dependabot cannot propose a fix past the override. The last three runs on `main` fail identically. A fix means overriding to js-yaml 5.x against swagger-ui's pin, which risks the `/api/docs` renderer, so it is left as a separate decision.

Verified locally instead, on this branch: `composer run-script phpstan` clean, and the full `./vendor/bin/phpunit tests` suite green (1757 tests).