### PR TITLE
Emit complete EventSeries JSON-LD on series pages (Search Console)

### DIFF
--- a/app/Http/Controllers/SeriesController.php
+++ b/app/Http/Controllers/SeriesController.php
@@ -276,7 +276,9 @@ class SeriesController extends Controller
 
         // get the series
         $series = $query
-            ->with('visibility', 'eventStatus', 'eventType', 'promoter', 'venue', 'tags', 'entities', 'photos', 'upcomingEvent','occurrenceType','occurrenceWeek','occurrenceDay')
+            // venue.locations/links/photos, promoter.links and entities.roles/links
+            // feed the per-series JSON-LD built by App\Services\SeriesSchema.
+            ->with('visibility', 'eventStatus', 'eventType', 'promoter.links', 'venue.locations', 'venue.links', 'venue.photos', 'tags', 'entities.roles', 'entities.links', 'photos', 'upcomingEvent','occurrenceType','occurrenceWeek','occurrenceDay')
             ->paginate($listResultSet->getLimit());
 
         // saves the updated session
@@ -657,12 +659,22 @@ class SeriesController extends Controller
         // Series::nextEvent() (used by getSeoTitleFormat()/getFestivalYear() below,
         // for both this request and the view's own title render) reuse the cached
         // relation instead of re-querying.
-        $series->loadMissing(['photos', 'venue.locations', 'upcomingEvent']);
+        // venue.links/photos, promoter.links, entities.roles/links and occurrenceType
+        // feed the EventSeries JSON-LD built by App\Services\SeriesSchema.
+        $series->loadMissing([
+            'photos', 'venue.locations', 'venue.links', 'venue.photos', 'promoter.links',
+            'entities.roles', 'entities.links', 'occurrenceType', 'upcomingEvent',
+        ]);
 
         // Each event renders through events/card-tw, which touches venue, eventType,
         // visibility, tags, photos (getPrimaryPhoto), entities and threads per card —
         // eager-load them so the grid is a fixed number of queries, not N per event.
-        $eventEager = ['venue.photos', 'eventType', 'visibility', 'tags', 'photos', 'entities', 'series.photos', 'threads'];
+        // The upcoming set is also emitted as subEvent JSON-LD through EventSchema,
+        // which reads venue.locations/links, promoter.links and entities.roles/links.
+        $eventEager = [
+            'venue.locations', 'venue.links', 'venue.photos', 'promoter.links', 'eventType', 'visibility',
+            'tags', 'photos', 'entities.roles', 'entities.links', 'series.photos', 'threads',
+        ];
         if ($this->user) {
             // The attend/unattend button reads getEventResponse($user)->responseType per card.
             $eventEager['eventResponses'] = function ($query) {

--- a/app/Services/SeriesSchema.php
+++ b/app/Services/SeriesSchema.php
@@ -1,0 +1,287 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Entity;
+use App\Models\Event;
+use App\Models\Series;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Storage;
+use Throwable;
+
+/**
+ * Maps a Series onto a schema.org EventSeries node.
+ *
+ * EventSeries is a subtype of Event, and Search Console validates it as one:
+ * the series pages were the source of a block of "missing endDate / offers /
+ * eventStatus / performer" warnings because the node carried only a name,
+ * url, description, image and location. This emits the same recommended
+ * property set EventSchema does for a single event, drawing dates from the
+ * next instantiated event (or the recurrence schedule when none exists yet)
+ * and everything else from the series row and its promoter, venue and
+ * lineup. Shared pieces — the Place, Organization and PerformingGroup
+ * shapes, URL validation — come from EventSchema so the two never drift.
+ */
+class SeriesSchema
+{
+    /** Performers emitted per series; lineups on a series are a curated handful. */
+    public const PERFORMER_LIMIT = 10;
+
+    /** Occurrence types whose schedule can be projected to a next date. */
+    private const SCHEDULED_TYPES = ['Weekly', 'Biweekly', 'Monthly', 'Bimonthly', 'Yearly'];
+
+    /**
+     * A standalone EventSeries document for the series page, with its
+     * upcoming instances as subEvents.
+     *
+     * @param  iterable<int, Event>  $upcomingEvents
+     * @return array<string, mixed>
+     */
+    public static function document(Series $series, iterable $upcomingEvents = []): array
+    {
+        $node = ['@context' => EventSchema::CONTEXT] + self::forSeries($series);
+
+        $subEvents = [];
+        foreach ($upcomingEvents as $event) {
+            $subEvents[] = self::subEvent($series, $event);
+        }
+
+        if (!empty($subEvents)) {
+            $node['subEvent'] = $subEvents;
+        }
+
+        return $node;
+    }
+
+    /**
+     * The EventSeries node with no @context, for embedding in an ItemList.
+     *
+     * Relations read: photos, venue.locations, venue.links, venue.photos,
+     * promoter.links, entities.roles, entities.links, upcomingEvent,
+     * occurrenceType. Callers rendering many series should eager load them.
+     *
+     * @return array<string, mixed>
+     */
+    public static function forSeries(Series $series): array
+    {
+        $url = route('series.show', $series->slug);
+
+        $node = [
+            '@type'            => 'EventSeries',
+            '@id'              => $url.'#series',
+            'name'             => $series->name,
+            'url'              => $url,
+            'mainEntityOfPage' => ['@type' => 'WebPage', '@id' => $url],
+        ];
+
+        [$startDate, $endDate] = self::dates($series);
+
+        if ($startDate) {
+            $node['startDate'] = $startDate;
+        }
+
+        if ($endDate) {
+            $node['endDate'] = $endDate;
+        }
+
+        $node['eventAttendanceMode'] = EventSchema::CONTEXT.'/OfflineEventAttendanceMode';
+        $node['eventStatus'] = EventSchema::CONTEXT.($series->cancelled_at ? '/EventCancelled' : '/EventScheduled');
+        $node['image'] = [self::image($series)];
+        $node['description'] = self::description($series);
+        $node['location'] = EventSchema::location($series->venue);
+        $node['offers'] = self::offers($series, $url);
+        $node['performer'] = self::performers($series);
+
+        if ($organizer = $series->promoter ?: $series->venue) {
+            $node['organizer'] = EventSchema::organization($organizer);
+        }
+
+        return $node;
+    }
+
+    /**
+     * An instance of the series as an embedded Event. An instance with no
+     * venue of its own inherits the series venue — with its address — which
+     * is more specific than EventSchema's TBA fallback.
+     *
+     * @return array<string, mixed>
+     */
+    public static function subEvent(Series $series, Event $event): array
+    {
+        $node = EventSchema::forEvent($event, EventSchema::LISTING_PERFORMER_LIMIT);
+
+        if (empty($event->venue_id) && $series->venue) {
+            $node['location'] = EventSchema::location($series->venue);
+        }
+
+        return $node;
+    }
+
+    /**
+     * The next instantiated event's times when there is one; otherwise the
+     * series' own start/end wall-clock times on the next date its recurrence
+     * schedule lands on. A cancelled series, one with no schedule, or one
+     * whose schedule cannot be projected gets no dates rather than wrong ones.
+     *
+     * @return array{0: ?string, 1: ?string}
+     */
+    protected static function dates(Series $series): array
+    {
+        if ($next = $series->nextEvent()) {
+            return [
+                EventTime::startsAt($next)?->toAtomString(),
+                EventTime::endsAt($next)?->toAtomString(),
+            ];
+        }
+
+        if ($series->cancelled_at || !$series->start_at) {
+            return [null, null];
+        }
+
+        if (!in_array($series->occurrenceType?->name, self::SCHEDULED_TYPES, true)) {
+            return [null, null];
+        }
+
+        try {
+            // Series::cycleFromFoundedAt() walks the schedule forward from
+            // founded_at; nthOfMonth() can hand back false for an impossible
+            // week/day pair, which Carbon::parse() then chokes on.
+            $date = $series->nextOccurrenceDate();
+        } catch (Throwable) {
+            return [null, null];
+        }
+
+        if (!$date) {
+            return [null, null];
+        }
+
+        $start = EventTime::toInstant($date->format('Y-m-d').' '.$series->start_at->format('H:i:s'));
+
+        if (!$start) {
+            return [null, null];
+        }
+
+        $minutes = Event::DEFAULT_LENGTH * 60;
+
+        if ($series->end_at) {
+            // Wall-clock difference; an end before the start means it
+            // crosses midnight.
+            $minutes = (int) $series->start_at->diffInMinutes($series->end_at, false);
+            if ($minutes <= 0) {
+                $minutes += 24 * 60;
+            }
+        }
+
+        return [$start->toAtomString(), $start->addMinutes($minutes)->toAtomString()];
+    }
+
+    /**
+     * The series' own image, else its venue's, else the site promo image.
+     */
+    protected static function image(Series $series): string
+    {
+        $photo = $series->getPrimaryPhoto() ?? $series->venue?->getPrimaryPhoto();
+
+        if ($photo) {
+            return Storage::disk('external')->url($photo->getStoragePath());
+        }
+
+        return url(EventSchema::DEFAULT_IMAGE_PATH);
+    }
+
+    /**
+     * Short blurb, else long description, else a sentence built from the
+     * schedule and venue — never absent.
+     */
+    protected static function description(Series $series): string
+    {
+        $text = $series->short ?: $series->description;
+
+        if (null !== $text && '' !== trim($text)) {
+            $clean = trim(preg_replace('/\s+/', ' ', strip_tags($text)) ?? '');
+
+            if ('' !== $clean) {
+                return $clean;
+            }
+        }
+
+        $sentence = $series->name;
+
+        if ($type = $series->occurrenceType?->name) {
+            if (in_array($type, self::SCHEDULED_TYPES, true)) {
+                $sentence .= ', a '.strtolower($type).' series';
+            }
+        }
+
+        if ($series->venue) {
+            $sentence .= ' at '.$series->venue->name;
+        }
+
+        return $sentence.'.';
+    }
+
+    /**
+     * Same rules as EventSchema::offers(): only a real absolute URL, and a
+     * price only when one is on file.
+     *
+     * @return array<string, mixed>
+     */
+    protected static function offers(Series $series, string $seriesUrl): array
+    {
+        $offer = [
+            '@type'        => 'Offer',
+            'url'          => EventSchema::validUrl($series->ticket_link) ?? EventSchema::validUrl($series->primary_link) ?? $seriesUrl,
+            'availability' => EventSchema::CONTEXT.'/InStock',
+        ];
+
+        $price = $series->door_price ?? $series->presale_price;
+
+        if (null !== $price && '' !== $price) {
+            $offer['price'] = (string) $price;
+            $offer['priceCurrency'] = 'USD';
+        }
+
+        if ($validFrom = EventTime::toInstant($series->created_at)) {
+            $offer['validFrom'] = $validFrom->toAtomString();
+        }
+
+        return $offer;
+    }
+
+    /**
+     * The series' dj/band/producer entities, falling back to the series
+     * itself so the property is never empty.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected static function performers(Series $series): array
+    {
+        $performers = self::performerEntities($series)
+            ->take(self::PERFORMER_LIMIT)
+            ->map(fn (Entity $entity) => EventSchema::performer($entity))
+            ->values()
+            ->all();
+
+        if (!empty($performers)) {
+            return $performers;
+        }
+
+        $fallback = ['@type' => 'PerformingGroup', 'name' => $series->name];
+        if ($url = EventSchema::validUrl($series->primary_link)) {
+            $fallback['url'] = $url;
+        }
+
+        return [$fallback];
+    }
+
+    /**
+     * @return Collection<int, Entity>
+     */
+    protected static function performerEntities(Series $series): Collection
+    {
+        return $series->entities
+            ->filter(fn (Entity $entity) => $entity->roles->whereIn('slug', ['dj', 'band', 'producer'])->isNotEmpty())
+            ->sortBy('name')
+            ->values();
+    }
+}

--- a/app/Services/SeriesSchema.php
+++ b/app/Services/SeriesSchema.php
@@ -27,6 +27,14 @@ class SeriesSchema
     /** Performers emitted per series; lineups on a series are a curated handful. */
     public const PERFORMER_LIMIT = 10;
 
+    /**
+     * Upcoming instances emitted as subEvents. The busiest series in the data
+     * runs 18 events in a year, so this never truncates a real schedule — it
+     * bounds the page if a festival ever announces a very long run at once.
+     * The template this replaced was bounded by the archive's pagination.
+     */
+    public const SUB_EVENT_LIMIT = 25;
+
     /** Occurrence types whose schedule can be projected to a next date. */
     private const SCHEDULED_TYPES = ['Weekly', 'Biweekly', 'Monthly', 'Bimonthly', 'Yearly'];
 
@@ -43,6 +51,10 @@ class SeriesSchema
 
         $subEvents = [];
         foreach ($upcomingEvents as $event) {
+            if (count($subEvents) >= self::SUB_EVENT_LIMIT) {
+                break;
+            }
+
             $subEvents[] = self::subEvent($series, $event);
         }
 

--- a/resources/views/series/index-json-ld.blade.php
+++ b/resources/views/series/index-json-ld.blade.php
@@ -1,26 +1,14 @@
 @php
+    use App\Services\SeriesSchema;
+
     $items = [];
     $position = 1;
     foreach ($series as $item) {
-        $listItem = [
+        $items[] = [
             '@type'    => 'ListItem',
             'position' => $position++,
-            'item'     => [
-                '@type' => 'EventSeries',
-                'name'  => $item->name,
-                'url'   => route('series.show', $item),
-            ],
+            'item'     => SeriesSchema::forSeries($item),
         ];
-        if ($item->short) {
-            $listItem['item']['description'] = $item->short;
-        }
-        if ($item->venue) {
-            $listItem['item']['location'] = [
-                '@type' => 'Place',
-                'name'  => $item->venue->name,
-            ];
-        }
-        $items[] = $listItem;
     }
 
     $jsonLd = [

--- a/resources/views/series/json-ld.blade.php
+++ b/resources/views/series/json-ld.blade.php
@@ -1,69 +1,15 @@
 @php
-    use App\Services\EventSchema;
+    use App\Services\SeriesSchema;
 
     $canonicalUrl = route('series.show', $series);
 
-    $seriesJsonLd = [
-        '@context'         => 'https://schema.org',
-        '@type'            => 'EventSeries',
-        '@id'              => $canonicalUrl . '#series',
-        'name'             => $series->name,
-        'url'              => $canonicalUrl,
-        'mainEntityOfPage' => ['@type' => 'WebPage', '@id' => $canonicalUrl],
-    ];
+    // $upcomingEvents comes from SeriesController::show(); older callers of
+    // this partial passed only the paginated archive as $events.
+    $instances = $upcomingEvents ?? collect($events ?? [])->filter(
+        fn ($ev) => $ev->start_at && $ev->start_at->gte(now())
+    );
 
-    if ($series->short) {
-        $seriesJsonLd['description'] = $series->short;
-    }
-
-    if ($photo = $series->getPrimaryPhoto()) {
-        $seriesJsonLd['image'] = Storage::disk('external')->url($photo->getStoragePath());
-    }
-
-    if ($series->venue) {
-        $seriesJsonLd['location'] = [
-            '@type' => 'Place',
-            'name'  => $series->venue->name,
-            'url'   => route('entities.show', $series->venue->slug),
-        ];
-        $venueLocation = $series->venue->getPrimaryLocation();
-        if ($venueLocation && !empty($venueLocation->address_one)) {
-            $seriesJsonLd['location']['address'] = [
-                '@type'           => 'PostalAddress',
-                'streetAddress'   => $venueLocation->address_one,
-                'addressLocality' => $venueLocation->city,
-                'addressRegion'   => $venueLocation->state ?? '',
-                'postalCode'      => $venueLocation->postcode ?? '',
-                'addressCountry'  => $venueLocation->country ?? 'US',
-            ];
-        }
-    }
-
-    // Add upcoming instances as subEvents
-    if (isset($events) && count($events) > 0) {
-        $subEvents = [];
-        foreach ($events as $ev) {
-            if (!$ev->start_at || $ev->start_at->lt(now())) {
-                continue;
-            }
-            $subEvent = EventSchema::forEvent($ev, EventSchema::LISTING_PERFORMER_LIMIT);
-
-            // An instance with no venue of its own inherits the series venue,
-            // which is more specific than EventSchema's TBA fallback.
-            if (empty($ev->venue_id) && $series->venue) {
-                $subEvent['location'] = [
-                    '@type' => 'Place',
-                    'name'  => $series->venue->name,
-                    'url'   => route('entities.show', $series->venue->slug),
-                ];
-            }
-
-            $subEvents[] = $subEvent;
-        }
-        if (!empty($subEvents)) {
-            $seriesJsonLd['subEvent'] = $subEvents;
-        }
-    }
+    $seriesJsonLd = SeriesSchema::document($series, $instances);
 
     $breadcrumbJsonLd = [
         '@context'        => 'https://schema.org',

--- a/tests/Feature/Web/SeriesStructuredDataTest.php
+++ b/tests/Feature/Web/SeriesStructuredDataTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Feature\Web;
+
+use App\Models\Entity;
+use App\Models\Event;
+use App\Models\OccurrenceType;
+use App\Models\Series;
+use App\Models\User;
+use App\Models\Visibility;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * The series page and listing emit EventSeries JSON-LD with the full set of
+ * recommended Event properties, and upcoming instances inherit the series
+ * venue's address.
+ */
+class SeriesStructuredDataTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>> every ld+json block on the page, decoded
+     */
+    private function structuredData(string $html): array
+    {
+        preg_match_all('#<script type="application/ld\+json">(.*?)</script>#s', $html, $matches);
+        $this->assertNotEmpty($matches[1], 'the page emitted no JSON-LD block');
+
+        return array_map(function (string $json) {
+            $decoded = json_decode($json, true);
+            $this->assertSame(JSON_ERROR_NONE, json_last_error(), 'JSON-LD did not parse: '.json_last_error_msg());
+
+            return $decoded;
+        }, $matches[1]);
+    }
+
+    private function venueWithAddress(): Entity
+    {
+        $venue = Entity::factory()->venue()->create(['name' => 'Squirrel Hill Sports Bar']);
+        $venue->locations()->create([
+            'name' => 'Main',
+            'slug' => 'main-'.$venue->id,
+            'address_one' => '4305 Murray Ave',
+            'city' => 'Pittsburgh',
+            'state' => 'PA',
+            'postcode' => '15217',
+            'location_type_id' => 1,
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'created_by' => User::factory()->create()->id,
+        ]);
+
+        return $venue;
+    }
+
+    private function series(array $overrides = []): Series
+    {
+        return Series::factory()->create(array_merge([
+            'name' => 'Gloom Nights',
+            'slug' => 'gloom-nights',
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'occurrence_type_id' => OccurrenceType::where('name', 'Weekly')->value('id'),
+            'venue_id' => $this->venueWithAddress()->id,
+            'ticket_link' => 'https://tickets.example/gloom',
+            'door_price' => '10.00',
+        ], $overrides));
+    }
+
+    public function test_the_series_page_emits_a_complete_event_series_node(): void
+    {
+        $series = $this->series();
+        Event::factory()->create([
+            'series_id' => $series->id,
+            'venue_id' => null,
+            'name' => 'Gloom Nights: Next',
+            'start_at' => Carbon::now()->addDays(3)->setTime(21, 0),
+            'visibility_id' => Visibility::VISIBILITY_PUBLIC,
+            'created_by' => User::factory()->create()->id,
+        ]);
+
+        [$node] = $this->structuredData($this->get('/series/'.$series->slug)->assertOk()->getContent());
+
+        $this->assertSame('EventSeries', $node['@type']);
+        foreach (['startDate', 'endDate', 'eventStatus', 'eventAttendanceMode', 'image', 'description', 'location', 'offers', 'performer', 'organizer'] as $field) {
+            $this->assertArrayHasKey($field, $node, "missing $field");
+        }
+
+        $this->assertSame('https://tickets.example/gloom', $node['offers']['url']);
+        $this->assertSame('10.00', $node['offers']['price']);
+        $this->assertNotEmpty($node['organizer']['url']);
+        $this->assertSame('4305 Murray Ave', $node['location']['address']['streetAddress']);
+
+        // The venueless instance inherits the series venue, address included.
+        $this->assertSame('Gloom Nights: Next', $node['subEvent'][0]['name']);
+        $this->assertSame('Squirrel Hill Sports Bar', $node['subEvent'][0]['location']['name']);
+        $this->assertSame('4305 Murray Ave', $node['subEvent'][0]['location']['address']['streetAddress']);
+        $this->assertSame($node['subEvent'][0]['startDate'], $node['startDate']);
+    }
+
+    public function test_the_series_listing_items_carry_the_same_properties(): void
+    {
+        $this->series();
+
+        $blocks = $this->structuredData($this->get('/series')->assertOk()->getContent());
+        $list = collect($blocks)->firstWhere('@type', 'ItemList');
+        $item = collect($list['itemListElement'])->pluck('item')->firstWhere('name', 'Gloom Nights');
+
+        $this->assertNotNull($item, 'the series was not listed');
+        foreach (['startDate', 'endDate', 'eventStatus', 'offers', 'performer', 'organizer', 'location'] as $field) {
+            $this->assertArrayHasKey($field, $item, "missing $field");
+        }
+    }
+}

--- a/tests/Unit/Services/SeriesSchemaTest.php
+++ b/tests/Unit/Services/SeriesSchemaTest.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Entity;
+use App\Models\Event;
+use App\Models\Link;
+use App\Models\Location;
+use App\Models\OccurrenceType;
+use App\Models\Photo;
+use App\Models\Role;
+use App\Models\Series;
+use App\Models\Visibility;
+use App\Services\EventSchema;
+use App\Services\SeriesSchema;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Collection;
+use Tests\TestCase;
+
+/**
+ * The schema.org EventSeries mapping. Built from unsaved models with their
+ * relations set by hand, as EventSchemaTest does, so nothing here touches
+ * the database.
+ */
+class SeriesSchemaTest extends TestCase
+{
+    private function series(array $attributes = [], ?string $occurrence = 'Weekly'): Series
+    {
+        $series = new Series(array_merge([
+            'name' => 'Gloom Nights',
+            'slug' => 'gloom-nights',
+            'start_at' => '2026-01-05 21:00:00',
+            'end_at' => '2026-01-06 02:00:00',
+            'founded_at' => '2026-01-05 21:00:00',
+        ], $attributes));
+
+        $series->setRelation('photos', new Collection());
+        $series->setRelation('entities', new Collection());
+        $series->setRelation('venue', null);
+        $series->setRelation('promoter', null);
+        $series->setRelation('upcomingEvent', null);
+        $series->setRelation('occurrenceType', $occurrence ? new OccurrenceType(['name' => $occurrence]) : null);
+
+        return $series;
+    }
+
+    private function venue(?Location $location = null): Entity
+    {
+        $venue = new Entity(['name' => 'Squirrel Hill Sports Bar', 'slug' => 'squirrel-hill-sports-bar']);
+        $venue->setRelation('links', new Collection());
+        $venue->setRelation('photos', new Collection());
+        $venue->setRelation('locations', new Collection($location ? [$location] : []));
+
+        return $venue;
+    }
+
+    private function location(): Location
+    {
+        $location = new Location([
+            'address_one' => '4305 Murray Ave',
+            'city' => 'Pittsburgh',
+            'state' => 'PA',
+            'postcode' => '15217',
+            'country' => 'US',
+        ]);
+        $location->setRelation('visibility', new Visibility(['name' => 'Public']));
+
+        return $location;
+    }
+
+    private function event(array $attributes = []): Event
+    {
+        $event = new Event(array_merge([
+            'name' => 'Gloom Nights: March',
+            'slug' => 'gloom-nights-march',
+            'start_at' => '2026-08-03 21:00:00',
+        ], $attributes));
+
+        $event->setRelation('photos', new Collection());
+        $event->setRelation('entities', new Collection());
+        $event->setRelation('visibility', null);
+        $event->setRelation('venue', null);
+        $event->setRelation('promoter', null);
+        $event->setRelation('series', null);
+
+        return $event;
+    }
+
+    private function performer(string $name): Entity
+    {
+        $entity = new Entity(['name' => $name, 'slug' => str($name)->slug()->value()]);
+        $entity->setRelation('roles', new Collection([new Role(['slug' => 'dj', 'name' => 'DJ'])]));
+        $entity->setRelation('links', new Collection());
+
+        return $entity;
+    }
+
+    // -- dates ------------------------------------------------------------
+
+    public function test_dates_come_from_the_next_instantiated_event(): void
+    {
+        $series = $this->series();
+        $series->setRelation('upcomingEvent', $this->event(['start_at' => '2026-08-03 21:00:00', 'end_at' => '2026-08-04 01:00:00']));
+
+        $schema = SeriesSchema::forSeries($series);
+
+        $this->assertSame('2026-08-03T21:00:00-04:00', $schema['startDate']);
+        $this->assertSame('2026-08-04T01:00:00-04:00', $schema['endDate']);
+    }
+
+    public function test_dates_project_from_the_schedule_when_no_event_exists_yet(): void
+    {
+        // Weekly from Monday 2026-01-05 at 9 PM: the next Monday on or after
+        // today, at 9 PM Pittsburgh time, running until 2 AM.
+        $schema = SeriesSchema::forSeries($this->series());
+
+        $expected = CarbonImmutable::parse('2026-01-05 21:00:00', 'America/New_York');
+        $today = CarbonImmutable::now('America/New_York')->startOfDay();
+        while ($expected->lt($today)) {
+            $expected = $expected->addWeek();
+        }
+
+        $this->assertSame($expected->toAtomString(), $schema['startDate']);
+        $this->assertSame($expected->addHours(5)->toAtomString(), $schema['endDate']);
+    }
+
+    public function test_a_series_with_no_schedule_omits_the_dates(): void
+    {
+        $schema = SeriesSchema::forSeries($this->series(occurrence: 'No Schedule'));
+
+        $this->assertArrayNotHasKey('startDate', $schema);
+        $this->assertArrayNotHasKey('endDate', $schema);
+    }
+
+    public function test_a_cancelled_series_is_cancelled_and_has_no_projected_dates(): void
+    {
+        $schema = SeriesSchema::forSeries($this->series(['cancelled_at' => '2026-07-01 12:00:00']));
+
+        $this->assertSame('https://schema.org/EventCancelled', $schema['eventStatus']);
+        $this->assertArrayNotHasKey('startDate', $schema);
+    }
+
+    public function test_a_scheduled_series_is_scheduled(): void
+    {
+        $this->assertSame('https://schema.org/EventScheduled', SeriesSchema::forSeries($this->series())['eventStatus']);
+    }
+
+    // -- the recommended set ----------------------------------------------
+
+    public function test_every_recommended_event_property_is_present(): void
+    {
+        // The Search Console block this class exists to clear: 48 public
+        // series each missing endDate, offers, eventStatus and performer.
+        $schema = SeriesSchema::forSeries($this->series());
+
+        foreach (['startDate', 'endDate', 'eventStatus', 'eventAttendanceMode', 'image', 'description', 'location', 'offers', 'performer'] as $field) {
+            $this->assertArrayHasKey($field, $schema, "missing $field");
+        }
+        $this->assertSame('EventSeries', $schema['@type']);
+    }
+
+    public function test_offers_follow_the_event_rules(): void
+    {
+        $offer = SeriesSchema::forSeries($this->series(['ticket_link' => 'Ticketfly.com']))['offers'];
+        $this->assertSame(route('series.show', 'gloom-nights'), $offer['url']);
+        $this->assertArrayNotHasKey('price', $offer);
+
+        $offer = SeriesSchema::forSeries($this->series(['ticket_link' => 'https://tickets.example/gloom', 'door_price' => '10.00']))['offers'];
+        $this->assertSame('https://tickets.example/gloom', $offer['url']);
+        $this->assertSame('10.00', $offer['price']);
+        $this->assertSame('USD', $offer['priceCurrency']);
+    }
+
+    public function test_performers_are_the_lineup_or_the_series_itself(): void
+    {
+        $series = $this->series();
+        $this->assertSame([['@type' => 'PerformingGroup', 'name' => 'Gloom Nights']], SeriesSchema::forSeries($series)['performer']);
+
+        $series->setRelation('entities', new Collection([$this->performer('Zona Morta'), $this->performer('Cutups')]));
+        $performers = SeriesSchema::forSeries($series)['performer'];
+
+        $this->assertSame(['Cutups', 'Zona Morta'], array_column($performers, 'name'));
+        $this->assertSame(route('entities.show', 'cutups'), $performers[0]['url']);
+    }
+
+    public function test_organizer_prefers_the_promoter_and_always_has_a_url(): void
+    {
+        $promoter = new Entity(['name' => 'Gloom Collective', 'slug' => 'gloom-collective']);
+        $promoter->setRelation('links', new Collection([new Link(['url' => 'https://example.test/gloom', 'is_primary' => 1])]));
+
+        $series = $this->series();
+        $series->setRelation('venue', $this->venue());
+        $this->assertSame([
+            '@type' => 'Organization',
+            'name' => 'Squirrel Hill Sports Bar',
+            'url' => route('entities.show', 'squirrel-hill-sports-bar'),
+        ], SeriesSchema::forSeries($series)['organizer']);
+
+        $series->setRelation('promoter', $promoter);
+        $this->assertSame('https://example.test/gloom', SeriesSchema::forSeries($series)['organizer']['url']);
+    }
+
+    public function test_location_carries_the_venue_address(): void
+    {
+        $series = $this->series();
+        $series->setRelation('venue', $this->venue($this->location()));
+
+        $location = SeriesSchema::forSeries($series)['location'];
+
+        $this->assertSame('Squirrel Hill Sports Bar', $location['name']);
+        $this->assertSame('4305 Murray Ave', $location['address']['streetAddress']);
+    }
+
+    public function test_a_venueless_instance_inherits_the_series_venue_with_its_address(): void
+    {
+        // The old template inherited only the venue name, which is where the
+        // "missing address" count on series pages came from.
+        $series = $this->series();
+        $series->setRelation('venue', $this->venue($this->location()));
+
+        $node = SeriesSchema::subEvent($series, $this->event());
+
+        $this->assertSame('Event', $node['@type']);
+        $this->assertSame('Squirrel Hill Sports Bar', $node['location']['name']);
+        $this->assertSame('4305 Murray Ave', $node['location']['address']['streetAddress']);
+    }
+
+    public function test_image_falls_back_through_the_venue_to_the_site_promo(): void
+    {
+        $series = $this->series();
+        $this->assertSame([url(EventSchema::DEFAULT_IMAGE_PATH)], SeriesSchema::forSeries($series)['image']);
+
+        $photo = new Photo(['path' => 'photos/venue.jpg', 'thumbnail' => 'photos/venue.jpg']);
+        $photo->is_primary = 1;
+        $venue = $this->venue();
+        $venue->setRelation('photos', new Collection([$photo]));
+        $series->setRelation('venue', $venue);
+        $this->assertStringEndsWith('photos/venue.jpg', SeriesSchema::forSeries($series)['image'][0]);
+    }
+
+    public function test_description_falls_back_to_the_schedule_and_venue(): void
+    {
+        $series = $this->series();
+        $series->setRelation('venue', $this->venue());
+
+        $this->assertSame('Gloom Nights, a weekly series at Squirrel Hill Sports Bar.', SeriesSchema::forSeries($series)['description']);
+        $this->assertSame('A goth night.', SeriesSchema::forSeries($this->series(['short' => 'A <b>goth</b> night.']))['description']);
+    }
+
+    // -- shape ------------------------------------------------------------
+
+    public function test_the_document_carries_the_context_and_upcoming_instances(): void
+    {
+        $document = SeriesSchema::document($this->series(), [$this->event()]);
+
+        $this->assertSame('https://schema.org', $document['@context']);
+        $this->assertCount(1, $document['subEvent']);
+        $this->assertSame('Gloom Nights: March', $document['subEvent'][0]['name']);
+        $this->assertArrayNotHasKey('@context', $document['subEvent'][0]);
+        $this->assertArrayNotHasKey('subEvent', SeriesSchema::document($this->series()));
+    }
+
+    public function test_it_encodes_to_valid_json(): void
+    {
+        $schema = SeriesSchema::forSeries($this->series(['short' => "line one\nline two \\ \"quoted\""]));
+        $json = json_encode($schema);
+
+        $this->assertIsString($json);
+        $this->assertSame($schema, json_decode($json, true));
+    }
+}

--- a/tests/Unit/Services/SeriesSchemaTest.php
+++ b/tests/Unit/Services/SeriesSchemaTest.php
@@ -260,6 +260,15 @@ class SeriesSchemaTest extends TestCase
         $this->assertArrayNotHasKey('subEvent', SeriesSchema::document($this->series()));
     }
 
+    public function test_sub_events_are_capped(): void
+    {
+        $events = array_fill(0, SeriesSchema::SUB_EVENT_LIMIT + 5, $this->event());
+
+        $document = SeriesSchema::document($this->series(), $events);
+
+        $this->assertCount(SeriesSchema::SUB_EVENT_LIMIT, $document['subEvent']);
+    }
+
     public function test_it_encodes_to_valid_json(): void
     {
         $schema = SeriesSchema::forSeries($this->series(['short' => "line one\nline two \\ \"quoted\""]));


### PR DESCRIPTION
Stacked on #2130 (merge that first; this PR's base is its branch).

## Why

The Search Console export has a block of 49 items each missing `endDate`, `offers`, `eventStatus` and `performer`. The series pages fit: there are 48 public series, and the `EventSeries` node in `series/json-ld.blade.php` emitted only name, url, description, image, location and subEvent. EventSeries is a subtype of Event and Google validates it against the Event property set.

## What

New `App\Services\SeriesSchema`, used by both the series page and the `/series` listing:

- `startDate` / `endDate` from the next instantiated event; otherwise projected from the recurrence schedule for Weekly, Biweekly, Monthly, Bimonthly and Yearly series. Cancelled or unscheduled series get no dates rather than wrong ones, and the projection is wrapped so a bad week/day pair cannot break the page.
- `eventStatus` from `cancelled_at`, plus `eventAttendanceMode`.
- `image`: series photo → venue photo → site promo image.
- `description` with a "{name}, a weekly series at {venue}." fallback.
- `location` through `EventSchema::location()`, so it carries the full address.
- `offers` with the same URL validation and known-price-only rule as events.
- `performer` from the series lineup (dj/band/producer roles), else the series itself.
- `organizer`: promoter, else venue, always with a url.

Sub-events are capped at 25 (the busiest series in the data runs 18 events in a year, and the template this replaced was bounded by the archive pagination). Sub-events with no venue of their own now inherit the series venue **with its address** (the old override copied only the name, which contributed to the address warnings). The show page passes its already-computed `$upcomingEvents` to the partial instead of filtering the paginated archive, and both controllers eager load what the builder reads.

## Tests

- `tests/Unit/Services/SeriesSchemaTest.php` (15 tests): date sources, schedule projection, cancelled/unscheduled, offers, performers, organizer url, address inheritance, image and description fallbacks, JSON validity.
- `tests/Feature/Web/SeriesStructuredDataTest.php`: series page node has every recommended field and the venueless instance inherits the address; listing items carry the same properties.
- Existing series SEO/controller tests green; PHPStan clean.

## Worth checking in Search Console

If the 49-item issues list example URLs that are *not* series pages, they are stale crawls of listing pages from before #2075 and will clear on recrawl regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vFTGsG3jCVq4ieXd4AxTj



---

### CI note (applies to every open PR in this repo right now)

The `NPM security audit` step fails **before** PHPStan or the tests run, for a pre-existing reason on `main`: js-yaml 4.0.0–4.3.1 carries a high-severity advisory (GHSA-2883-xcg3-v3hh). `package.json` pins `overrides: {"js-yaml": "^4.3.1"}` and swagger-ui@5.32.11 exact-pins `js-yaml: =4.3.0`, so the entire 4.x line is vulnerable and dependabot cannot propose a fix past the override. The last three runs on `main` fail identically. A fix means overriding to js-yaml 5.x against swagger-ui's pin, which risks the `/api/docs` renderer, so it is left as a separate decision.

Verified locally instead, on this branch: `composer run-script phpstan` clean, and the full `./vendor/bin/phpunit tests` suite green (1757 tests).