### PR TITLE
Validate ticket_link and primary_link as absolute http(s) URLs

### DIFF
--- a/app/Http/Requests/EventPatchRequest.php
+++ b/app/Http/Requests/EventPatchRequest.php
@@ -49,8 +49,8 @@ class EventPatchRequest extends Request
             'visibility_id' => ['sometimes', 'required'],
             'presale_price' => ['sometimes', 'nullable', 'numeric', 'between:0,999.99'],
             'door_price' => ['sometimes', 'nullable', 'numeric', 'between:0,999.99'],
-            'primary_link' => ['sometimes', 'nullable', 'regex:/^http:\/\/|https:\/\/|^$/', 'max:255'],
-            'ticket_link' => ['sometimes', 'nullable', 'regex:/^http:\/\/|https:\/\/|^$/', 'max:255'],
+            'primary_link' => ['sometimes', 'nullable', 'url:http,https', 'max:255'],
+            'ticket_link' => ['sometimes', 'nullable', 'url:http,https', 'max:255'],
             // Only validated when present. entity_list must be existing entity
             // IDs so a bad body returns 422 rather than a raw SQL error on the
             // entity_id integer column (EVENTREPO-XV).

--- a/app/Http/Requests/EventRequest.php
+++ b/app/Http/Requests/EventRequest.php
@@ -56,8 +56,8 @@ class EventRequest extends Request
             'visibility_id' => 'required',
             'presale_price' => 'nullable|numeric|between:0,999.99',
             'door_price' => 'nullable|numeric|between:0,999.99',
-            'primary_link' => ['nullable','regex:/^http:\/\/|https:\/\/|^$/','max:255'],
-            'ticket_link' => ['nullable','regex:/^http:\/\/|https:\/\/|^$/','max:255'],
+            'primary_link' => ['nullable','url:http,https','max:255'],
+            'ticket_link' => ['nullable','url:http,https','max:255'],
             // entity_list is a set of existing entity IDs that get synced onto
             // the event. Reject non-integer / unknown values here so a bad body
             // (e.g. entity names instead of IDs) returns 422 rather than tripping
@@ -85,9 +85,9 @@ class EventRequest extends Request
             'door_at.before_or_equal' => 'The door open time must be before or equal to the start time',
             'event_type_id.required' => 'An event type is required',
             'visibility_id.required' => 'A visibility is required',
-            'primary_link.regex' => 'A primary link must be a valid URL starting with http:// or https:// or blank',
+            'primary_link.url' => 'A primary link must be a valid URL starting with http:// or https:// or blank',
             'primary_link.max' => 'A primary link must be less than 255 characters',
-            'ticket_link.regex' => 'A ticket link must be a valid URL starting with http:// or https:// or blank',
+            'ticket_link.url' => 'A ticket link must be a valid URL starting with http:// or https:// or blank',
             'ticket_link.max' => 'A ticket link must be less than 255 characters',
             'entity_list.array' => 'The entity list must be an array of entity IDs',
             'entity_list.*.integer' => 'Each entity in the entity list must be an entity ID',

--- a/app/Http/Requests/SeriesPatchRequest.php
+++ b/app/Http/Requests/SeriesPatchRequest.php
@@ -41,8 +41,8 @@ class SeriesPatchRequest extends Request
             'presale_price' => ['sometimes', 'nullable', 'numeric', 'between:0,999.99'],
             'door_price' => ['sometimes', 'nullable', 'numeric', 'between:0,999.99'],
             'occurrence_type_id' => ['sometimes', 'required'],
-            'primary_link' => ['sometimes', 'nullable', 'regex:/^http:\/\/|https:\/\/|^$/', 'max:255'],
-            'ticket_link' => ['sometimes', 'nullable', 'regex:/^http:\/\/|https:\/\/|^$/', 'max:255'],
+            'primary_link' => ['sometimes', 'nullable', 'url:http,https', 'max:255'],
+            'ticket_link' => ['sometimes', 'nullable', 'url:http,https', 'max:255'],
             'occurrence_week_id' => ['sometimes', 'nullable'],
             'occurrence_day_id' => ['sometimes', 'nullable'],
         ];

--- a/app/Http/Requests/SeriesRequest.php
+++ b/app/Http/Requests/SeriesRequest.php
@@ -48,8 +48,8 @@ class SeriesRequest extends Request
             'presale_price' => 'nullable|numeric|between:0,999.99',
             'door_price' => 'nullable|numeric|between:0,999.99',
             'occurrence_type_id' => 'required',
-            'primary_link' => ['nullable','regex:/^http:\/\/|https:\/\/|^$/','max:255'],
-            'ticket_link' => ['nullable','regex:/^http:\/\/|https:\/\/|^$/','max:255'],
+            'primary_link' => ['nullable','url:http,https','max:255'],
+            'ticket_link' => ['nullable','url:http,https','max:255'],
             'occurrence_week_id' => 'nullable',
             'occurrence_day_id' => 'nullable',
         ];
@@ -93,9 +93,9 @@ class SeriesRequest extends Request
             'occurrence_type_id.required' => 'An occurrence type is required',
             'occurrence_week_id.required' => 'An occurrence week is required for this occurrence type',
             'occurrence_day_id.required' => 'An occurrence day is required for this occurrence type',
-            'primary_link.regex' => 'A primary link must be a valid URL starting with http:// or https:// or blank',
+            'primary_link.url' => 'A primary link must be a valid URL starting with http:// or https:// or blank',
             'primary_link.max' => 'A primary link must be less than 255 characters',
-            'ticket_link.regex' => 'A ticket link must be a valid URL starting with http:// or https:// or blank',
+            'ticket_link.url' => 'A ticket link must be a valid URL starting with http:// or https:// or blank',
             'ticket_link.max' => 'A ticket link must be less than 255 characters',
             'length.integer' => 'A series length must be an integer',
         ];

--- a/tests/Feature/Web/LinkFieldValidationTest.php
+++ b/tests/Feature/Web/LinkFieldValidationTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature\Web;
+
+use App\Models\User;
+use App\Models\UserStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * ticket_link and primary_link on the event and series forms must be
+ * absolute http(s) URLs.
+ *
+ * The rule used to be regex:/^http:\/\/|https:\/\/|^$/ — the middle branch
+ * is unanchored, so "Doors at 8 https://x" passed and only the leading
+ * "http://" form was actually checked. Search Console reports every
+ * non-URL that reached offers.url as an invalid item.
+ */
+class LinkFieldValidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withExceptionHandling();
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function rejectedLinks(): array
+    {
+        return [
+            'bare domain' => ['Ticketfly.com'],
+            'prose' => ['Admission: Free'],
+            'prose with a url inside' => ['Doors at 8 https://tickets.example/x'],
+            'missing scheme letter' => ['ttps://tickets.example/x'],
+            'mailto' => ['mailto:booking@example.test'],
+        ];
+    }
+
+    /**
+     * @dataProvider rejectedLinks
+     */
+    public function test_event_form_rejects_a_link_that_is_not_an_absolute_url(string $link): void
+    {
+        $this->actingAs(User::factory()->create(['user_status_id' => UserStatus::ACTIVE]))
+            ->post('/events', ['ticket_link' => $link, 'primary_link' => $link])
+            ->assertSessionHasErrors(['ticket_link', 'primary_link']);
+    }
+
+    /**
+     * @dataProvider rejectedLinks
+     */
+    public function test_series_form_rejects_a_link_that_is_not_an_absolute_url(string $link): void
+    {
+        $this->actingAs(User::factory()->create(['user_status_id' => UserStatus::ACTIVE]))
+            ->post('/series', ['ticket_link' => $link, 'primary_link' => $link])
+            ->assertSessionHasErrors(['ticket_link', 'primary_link']);
+    }
+
+    public function test_valid_and_blank_links_pass_the_link_rules(): void
+    {
+        $user = User::factory()->create(['user_status_id' => UserStatus::ACTIVE]);
+
+        $this->actingAs($user)
+            ->post('/events', ['ticket_link' => 'https://tickets.example/x', 'primary_link' => 'http://example.test/x'])
+            ->assertSessionDoesntHaveErrors(['ticket_link', 'primary_link']);
+
+        $this->actingAs($user)
+            ->post('/events', ['ticket_link' => '', 'primary_link' => ''])
+            ->assertSessionDoesntHaveErrors(['ticket_link', 'primary_link']);
+    }
+}


### PR DESCRIPTION
Independent of #2130 / #2131; part of the same Search Console plan (`context/plans/gsc-event-structured-data.md`).

## Why

`EventRequest`, `EventPatchRequest`, `SeriesRequest` and `SeriesPatchRequest` validated both link fields with:

```
regex:/^http:\/\/|https:\/\/|^$/
```

The middle alternative is unanchored, so `Doors at 8 https://tickets.example/x` passes, and only the bare `http://` prefix form was really checked. Anything that slips through becomes `offers.url` in the Event JSON-LD, which Search Console reports as an invalid URL. (The 105 existing junk rows like `Ticketfly.com` predate validation entirely; #2130 stops emitting those, and they're on the data-cleanup list.)

## What

The four rules become `['nullable', 'url:http,https', 'max:255']`. Blank still passes through `nullable`; the custom messages keep their wording under the `.url` key.

Note the `url` rule allows Unicode hostnames, so a homoglyph domain still passes validation. `EventSchema::validUrl()` in #2130 rejects those at output time.

## Tests

`tests/Feature/Web/LinkFieldValidationTest.php` posts each rejected shape (bare domain, prose, prose containing a URL, missing scheme letter, mailto) to both forms and checks a valid pair and a blank pair pass. The test user is pinned to an active status; the factory picks a random status and inactive users are redirected before validation runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vFTGsG3jCVq4ieXd4AxTj



---

### CI note (applies to every open PR in this repo right now)

The `NPM security audit` step fails **before** PHPStan or the tests run, for a pre-existing reason on `main`: js-yaml 4.0.0–4.3.1 carries a high-severity advisory (GHSA-2883-xcg3-v3hh). `package.json` pins `overrides: {"js-yaml": "^4.3.1"}` and swagger-ui@5.32.11 exact-pins `js-yaml: =4.3.0`, so the entire 4.x line is vulnerable and dependabot cannot propose a fix past the override. The last three runs on `main` fail identically. A fix means overriding to js-yaml 5.x against swagger-ui's pin, which risks the `/api/docs` renderer, so it is left as a separate decision.

Verified locally instead, on this branch: `composer run-script phpstan` clean, and the full `./vendor/bin/phpunit tests` suite green (1757 tests).