### PR TITLE
Fix npm audit CI failure by overriding js-yaml to ^4.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3759,9 +3759,9 @@
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "node_modules/js-yaml": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+            "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
             "funding": [
                 {
                     "type": "github",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "vue": "^3.2"
     },
     "overrides": {
-        "js-yaml": "^4.3.1"
+        "js-yaml": "^4.3.2"
     },
     "dependencies": {
         "alpinejs": "^3.13.5",


### PR DESCRIPTION
## Problem

The `NPM security audit` step (`npm audit --audit-level=high`) has been failing on **every PR and on `main`**, gating PHPStan and the test suite behind it. It surfaces as:

```
js-yaml  4.0.0 - 4.3.1
Severity: high
js-yaml: maxTotalMergeKeys does not limit CPU use for empty merge sources
```

This matches Dependabot alert [#273](https://github.com/geoff-maddock/events-tracker/security/dependabot/273) on the default branch.

## Root cause

The advisory (GHSA-2883-xcg3-v3hh) has a vulnerable range of `>=4.0.0 <4.3.2`, so **js-yaml 4.3.2** (released 2026-08-26) is an in-line patch — **no 5.x jump is required.**

The existing `overrides` entry of `^4.3.1` already *permitted* 4.3.2, but `package-lock.json` was resolved before 4.3.2 shipped and had 4.3.1 pinned. Raising the override floor and refreshing the lockfile is the whole fix.

## Two notes for the reviewer

**The override is required regardless of swagger-ui version.** swagger-ui exact-pins js-yaml at every release — `=4.3.0` at 5.32.11, `=4.3.1` at 5.32.15 — so bumping swagger-ui does not clear the advisory.

**Ignore npm's `fixAvailable`.** It proposes downgrading swagger-ui to 3.51.2, a breaking major. That is not necessary.

`@humanfs/node` (moderate) also appears in older CI logs but needed no action here — it was already resolved to 0.16.8 by #2119, and moderate severity never gated `--audit-level=high`.

## Verification

- `npm audit --audit-level=high` → exits **0** (`found 0 vulnerabilities`)
- `npm run build` → clean
- `npm run lint` → exits 0 (7 warnings, all pre-existing in `swagger.js`)
- js-yaml 4.3.2 parses `public/postman/schemas/api.yml` correctly — all 94 paths

## Follow-up, not addressed here

While verifying the `/api/docs` risk, I found the npm `swagger-ui` package is a **phantom dependency** — nothing bundles it. Vite's inputs are only `resources/css/tailwind.css` and `resources/assets/js/app.js`, and nothing imports `resources/assets/js/swagger.js`. `/api/docs` serves `asset('/js/swagger.js')`, a **committed 11.7MB prebuilt bundle from Dec 2024**.

So this override has zero runtime effect on the docs page (the renderer was never at risk), but that stale bundle still carries an old js-yaml that `npm audit` cannot see — the audit is green while the actually-served code is unpatched. Worth its own PR: either rebuild the bundle from the current dependency or make it a real Vite entry. Left alone here to keep this fix minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XFt6qKxn5ncF5A9dYCQgq
